### PR TITLE
Recherche und Konzept für das MCP-Server-Plugin dokumentieren

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ Das Plugin befindet sich im Aufbau. Installations-, Konfigurations- und Nutzungs
 ## Entwicklung
 
 - [Implementierungsrichtlinien](docs/development/implementation-guidelines.md)
+- [Plugin-Konzept](docs/development/plugin-concept.md)
 - [Änderungsgetriebene Teststrategie](docs/development/test-strategy.md)
+- [Recherche-Ergebnisse](docs/research/research-results.md)
 - [Beitragen und Git-Workflow](CONTRIBUTING.md)
 
 ## Lizenz

--- a/docs/development/implementation-guidelines.md
+++ b/docs/development/implementation-guidelines.md
@@ -98,6 +98,12 @@ Architekturentscheidung festgehalten.
 - Loxone-Zugriffe werden mit dem angemeldeten Loxone-Benutzer ausgeführt und auf
   dessen tatsächlich sicht- und bedienbare Elemente begrenzt.
 - Für jeden Assistenten wird ein eigenes Konto mit minimalen Rechten empfohlen.
+- Der Miniserver-Adapter verwendet ausschließlich Loxone-JWT/Tokenauth. HTTP
+  Basic Authentication und persistente Loxone-Passwörter werden nicht angeboten.
+- Gen. 1 wird mangels TLS ausschließlich lokal über HTTP/WS angebunden;
+  Authentifizierung und Steuerkommandos verwenden zusätzlich die Loxone Command
+  Encryption. Gen. 2 verwendet HTTPS/WSS mit vollständiger Zertifikatsprüfung
+  und ohne stillen Rückfall auf Klartexttransport.
 - LoxBerry-Funktionen haben eine separate Berechtigungsschicht. Zunächst sind sie
   nur lesend; Systemänderungen benötigen eine explizite Freigabe pro Aktionstyp.
 - Schreibende Tools prüfen die Berechtigung unmittelbar vor der Aktion und

--- a/docs/development/plugin-concept.md
+++ b/docs/development/plugin-concept.md
@@ -1,0 +1,619 @@
+# Konzept: LoxBerry MCP-Server-Plugin
+
+- **Status:** Konzeptentwurf zur fachlichen und technischen Prüfung
+- **Stand:** 2026-08-01
+- **Basis:** [Recherche-Ergebnisse](../research/research-results.md) und
+  [Implementierungsrichtlinien](implementation-guidelines.md)
+
+## 1. Produktvision
+
+Das Plugin stellt einen MCP-Server direkt auf dem LoxBerry bereit. Ein
+KI-Assistent kann damit die für seinen Loxone-Benutzer freigegebenen Räume,
+Kategorien, Steuerungen und Zustände verstehen und eng begrenzte Befehle an die
+laufende Loxone-Installation senden. Zusätzlich kann er freigegebene Zustände
+des LoxBerry und des Plugins abfragen.
+
+Der Betrieb benötigt keinen eigenen Cloud-Dienst des Projekts. Lokale Clients
+bleiben im LAN; Cloud-Clients können optional über eine vom Benutzer
+bereitgestellte, standardkonforme HTTPS-Adresse verbunden werden.
+
+Das Plugin programmiert weder den Miniserver neu noch bietet es eine allgemeine
+Fernadministration des LoxBerry. Es ist eine kontrollierte Bedien- und
+Diagnoseschnittstelle für eine bestehende Installation.
+
+## 2. Zielgruppen und Nutzen
+
+- **Loxone-Benutzer:** natürliche Abfragen und Bedienung mit den vorhandenen
+  Raum-, Kategorie- und Steuerungsnamen
+- **Miniserver-Gen.-1-Benutzer:** MCP-Zugang trotz fehlendem nativen
+  Loxone-MCP-Plugin
+- **LoxBerry-Betreiber:** lokale Diagnose von Plugin- und Systemzuständen
+- **Automatisierungs- und Support-Agenten:** strukturierte, begrenzte Tools statt
+  SSH oder einer allgemeinen Shell
+
+## 3. Abgrenzung
+
+Nicht zum Produktumfang gehören:
+
+- Änderung der Loxone-Projektlogik, Benutzer oder Berechtigungen
+- Loxone Config, Expertenmodus oder Automatik-Designer über MCP
+- beliebige Miniserver-Webservicepfade
+- allgemeine Shell-, Datei-, Paket- oder `sudo`-Kommandos auf dem LoxBerry
+- ungeprüfte globale Aktionen auf alle Steuerungen
+- eigener Cloud-Relay-, Konto- oder Telemetriedienst
+- Garantie für Browser, Clients, Miniserver oder Architekturen ohne Testnachweis
+
+## 4. Entscheidungsgrundsätze
+
+1. Loxone und LoxBerry sind zwei getrennte Autorisierungsdomänen.
+2. Der Server startet read-only; Schreibrechte werden bewusst hinzugefügt.
+3. Sichtbarkeit und Bedienbarkeit von Loxone-Objekten werden mit dem jeweiligen
+   Loxone-Benutzer am Miniserver durchgesetzt.
+4. Ein Tool bietet nur semantisch bekannte Aktionen und Wertebereiche an.
+5. UUIDs sind stabile Identitäten; Namen dienen Suche und Darstellung.
+6. Der Dienst läuft ohne Root-Rechte und erhält keine breite `sudo`-Freigabe.
+7. Externer Zugriff ist optional und ausschließlich über HTTPS vorgesehen.
+8. Jede Produktzusage benötigt automatisierte oder dokumentierte reale Evidenz.
+
+## 5. Empfohlener Technologie-Stack
+
+### Kernruntime
+
+Bevorzugt wird ein eigenständiger Python-Dienst, sofern der Runtime-Spike die
+Support-Matrix bestätigt:
+
+- Python 3.10 oder neuer
+- offizielles MCP-Python-SDK (Tier 1), auf eine geprüfte Hauptversion fixiert
+- `asyncio`/ASGI mit Streamable HTTP auf einem Loopback-Port
+- typisierte Ein- und Ausgabemodelle
+- kleiner eigener Loxone-Adapter für den tatsächlich benötigten API-Umfang
+- keine Datenbank im MVP; atomare JSON-Konfiguration und begrenzter RAM-Cache
+
+Python passt gut, weil MCP-, HTTP- und WebSocket-Verarbeitung überwiegend auf
+Netzwerk-I/O wartet. Es ist nicht mit den Perl-/PHP-Komponenten von LoxBerry
+gekoppelt und läuft als eigener unprivilegierter Prozess. Die höhere
+Runtime- und Speicherlast gegenüber einem Go-Binary ist zu messen, wird für den
+kleinen Toolumfang aber nicht als grundsätzlicher Engpass erwartet.
+
+Das Plugin installiert niemals Abhängigkeiten in das System-Python. Es erhält
+ein eigenes virtuelles Environment und einen vollständig fixierten,
+reproduzierbaren Abhängigkeitssatz. Auf Debian 12 verhindert dies zugleich
+Konflikte mit PEP 668. Für jede unterstützte Architektur müssen vorgebaute
+Wheels vorhanden oder im Paket mitgeliefert sein; die normale Installation
+darf weder Compiler noch Rust-Toolchain benötigen.
+
+Diese Empfehlung bedeutet zunächst auch: LoxBerry-/Debian-Kombinationen mit
+Python 3.9 sind nicht automatisch unterstützt. Soll insbesondere Debian 11 zur
+ersten Support-Matrix gehören, werden drei Optionen im Spike verglichen:
+
+1. Support-Basis auf Systeme mit Python 3.10 oder neuer begrenzen,
+2. eine plugin-eigene Python-Runtime sicher und wartbar mitliefern oder
+3. den Kerndienst als statisches Go-Binary bauen.
+
+Go ist damit die dokumentierte Rückfalloption. Das offizielle Go-SDK ist
+ebenfalls Tier 1; ein einzelnes Binary reduziert Installations- und
+Abhängigkeitsrisiken, kostet aber mehr Implementierungsaufwand.
+
+Vor der Festlegung beweist ein Spike:
+
+- Python-Version und venv-Erstellung auf allen ausgewählten LoxBerry-Basen
+- Installation aller fixierten Abhängigkeiten ausschließlich aus verfügbaren
+  oder mitgelieferten Wheels
+- Paketgröße, Start sowie RAM- und CPU-Bedarf im Idle und bei Zustandsupdates
+  auf den ausgewählten Architekturen
+- Streamable HTTP/Origin-Prüfung hinter dem LoxBerry-Apache
+- OAuth-Interoperabilität mit mindestens zwei relevanten Clients
+- Loxone-Anmeldung, Rechtefilterung und WebSocket-Zustände auf Gen. 1 und Gen. 2
+
+Falls Python an einer erforderlichen Altplattform, fehlenden ARM-Wheels oder dem
+Ressourcenbudget scheitert, wird Go verwendet. TypeScript bleibt eine weitere,
+aber nicht bevorzugte Alternative. Das zusätzliche Express-Server-Plugin soll
+nicht zur Pflicht des MCP-Kerndienstes werden.
+
+### Protokollversion
+
+Der erste Release zielt auf die stabile MCP-Version `2025-11-25` und nutzt die
+Versionsaushandlung des SDK. Eine noch nicht finale Protokollrevision darf
+zusätzlich unterstützt werden, aber niemals die einzige kompatible Version
+sein.
+
+## 6. Zielarchitektur
+
+```text
+MCP-Client
+   │ HTTPS + OAuth 2.1
+   ▼
+LoxBerry Apache / Reverse Proxy
+   │ Loopback, Streamable HTTP
+   ▼
+mcpserver-Dienst (Benutzer loxberry)
+   ├── MCP-Transport und Tool-Registry
+   ├── OAuth Resource-/Authorization-Server
+   ├── Policy und Audit
+   ├── Loxone-Adapter ── HTTP/WebSocket ── Miniserver
+   ├── LoxBerry-Read-Adapter ── sichere lokale APIs/Dateien
+   └── Konfiguration, Sessions und begrenzte Caches
+
+LoxBerry Admin-UI (htmlauth)
+   └── Konfiguration, Scopes, Sessions, Status und Logs
+```
+
+### Komponenten
+
+| Komponente | Verantwortung |
+| --- | --- |
+| MCP-Transport | Versionierung, Streamable HTTP, Sessions, Limits, Origin-Prüfung |
+| Tool-Registry | stabile Namen, Schemas, Annotationen und Handlerzuordnung |
+| OAuth-Schicht | Discovery, PKCE, Tokens, Scopes, Widerruf und Clientbindung |
+| Policy Engine | Benutzer-, Scope-, Tool- und Zielprüfung vor jedem Aufruf |
+| Loxone-Adapter | Authentifizierung, Struktur, Zustand, Statistik und Befehle |
+| Control Registry | erlaubte Aktionen und Wertebereiche pro Loxone-Control-Typ |
+| LoxBerry-Adapter | ausschließlich freigegebene, semantische Diagnoseoperationen |
+| Audit | sicherheitsrelevante Ereignisse ohne Secrets oder unnötige Zustandswerte |
+| Admin-UI | lokale Konfiguration und Betriebsdiagnose über LoxBerry `htmlauth` |
+
+## 7. Netzwerk und Veröffentlichung
+
+Der Dienst lauscht ausschließlich auf `127.0.0.1` an einem konfigurierten,
+konfliktgeprüften Port. Apache veröffentlicht den MCP-Endpunkt unter einem
+Pluginpfad, beispielsweise:
+
+```text
+https://<loxberry>/plugins/mcpserver/mcp
+```
+
+Der genaue Pfad wird im Transport-Spike festgelegt. Er muss GET und POST sowie
+die zugehörige OAuth-Discovery unterstützen. Reverse-Proxy-Header werden nur von
+einem explizit vertrauten lokalen Proxy akzeptiert.
+
+Für externe Nutzung gilt:
+
+- ausschließlich HTTPS mit öffentlich vertrauenswürdigem Zertifikat
+- explizit konfigurierte externe Basis-URL
+- kein automatisches Öffnen von Routerports
+- vollständige Weiterleitung von MCP- und `/.well-known`-Pfaden
+- Host-/Origin-Allowlist und Schutz vor DNS Rebinding
+- dokumentierter Verbindungscheck vor Freigabe
+
+LAN-Clients können direkt über die lokale HTTPS-Adresse arbeiten. stdio wird
+nicht als zweiter Servermodus benötigt; ein lokaler Client kann bei Bedarf eine
+generische Streamable-HTTP-zu-stdio-Bridge verwenden.
+
+## 8. Authentifizierung und Autorisierung
+
+### MCP-Client zum Plugin
+
+Der HTTP-Endpunkt implementiert die MCP-Autorisierung mit OAuth 2.1:
+
+- Protected Resource Metadata
+- Authorization Server Metadata
+- Authorization Code Flow mit PKCE
+- Resource Indicator/Audience-Bindung
+- kurzlebige Access Tokens
+- rotierende, widerrufbare Refresh Tokens
+- sichere Registrierung unterstützter öffentlicher Clients
+
+MCP-Tokens sind ausschließlich für das Plugin gültig. Sie werden nie an Loxone
+oder andere Dienste weitergereicht.
+
+### Plugin zum Miniserver
+
+Im Autorisierungsablauf meldet sich der Benutzer mit einem dedizierten
+Loxone-Konto am ausgewählten Miniserver an. Das Passwort wird nur zur Anmeldung
+verwendet und nicht gespeichert. Nach erfolgreicher Anmeldung verwendet das
+Plugin, soweit vom Miniserver unterstützt, ein erneuerbares Loxone-Token.
+
+Zu prüfen ist, wie das Token auf den unterstützten Generationen sicher erneuert
+und widerrufen wird. Bis dieser Nachweis vorliegt, ist eine erneute Anmeldung
+nach Dienstneustart akzeptabler als persistente Passwortspeicherung.
+
+Jede Server-Session bindet mindestens:
+
+- MCP-Client-ID
+- Loxone-Miniserver
+- Loxone-Benutzeridentität
+- erteilte Scopes
+- Token-Audience
+- Ausgabe- und Ratenlimits
+
+Struktur- und Zustandscaches werden nicht zwischen Benutzern mit möglicherweise
+unterschiedlichen Rechten geteilt.
+
+### Scopes
+
+Vorgesehene Scopes:
+
+| Scope | Bedeutung | Default |
+| --- | --- | --- |
+| `loxone:read` | freigegebene Struktur und Zustände lesen | an |
+| `loxone:history` | freigegebene Historie/Statistik lesen | später/optional |
+| `loxone:control` | einzelne freigegebene Steuerungen bedienen | aus |
+| `loxberry:read` | freigegebene LoxBerry-/Plugin-Diagnose lesen | aus |
+| `loxberry:operate` | eng begrenzte LoxBerry-Aktionen | nicht im MVP |
+
+Ein Loxone-Benutzer allein kann `loxberry:*` nicht erteilen. Diese Scopes
+benötigen eine zusätzliche lokale Freigabe durch den LoxBerry-Administrator und
+eine Allowlist für Loxone-Benutzer beziehungsweise MCP-Clients.
+
+### Mehrschichtige Begrenzung
+
+Ein Aufruf wird nur ausgeführt, wenn alle Ebenen zustimmen:
+
+1. gültiges, audience-gebundenes MCP-Token
+2. erforderlicher Scope
+3. Tool im Plugin aktiviert
+4. Benutzer/Client in der lokalen Policy erlaubt
+5. Ziel im vom Miniserver gelieferten Benutzermodell sichtbar
+6. Aktion für den erkannten Control-Typ zulässig
+7. Eingabewerte im erlaubten Bereich
+8. Rate Limit und Parallelitätsgrenze nicht überschritten
+
+Clientseitige Toolfilter und MCP-Annotationen sind zusätzliche Hinweise, keine
+Autorisierung.
+
+## 9. Loxone-Datenmodell
+
+### Struktur
+
+Der Adapter lädt die benutzerspezifische Loxone-Struktur und normalisiert:
+
+- Räume
+- Kategorien
+- Controls und Subcontrols
+- Control-Typ
+- Action-UUID und State-UUIDs
+- lesbare Namen
+- vom Typ unterstützte Fähigkeiten
+
+Die rohe Strukturdatei wird nicht vollständig an das Modell ausgegeben.
+Benutzer-, Programm-, Verdrahtungs- und andere für die Bedienung unnötige Daten
+werden nicht exponiert.
+
+### Zustände
+
+Aktuelle Zustände werden bevorzugt über eine authentifizierte
+WebSocket-Verbindung bezogen. Der Cache ist:
+
+- pro Loxone-Benutzer getrennt
+- im RAM
+- mit Zeitstempel und Frischekennzeichnung versehen
+- größenbegrenzt
+- nach Reconnect zunächst unvollständig, bis Snapshot oder Events vorliegen
+
+Antworten unterscheiden `current`, `stale`, `unknown` und `unavailable`, statt
+fehlende Werte als `0` oder `false` zu interpretieren.
+
+### Namen und Identitäten
+
+Suchtools akzeptieren Namen, Räume und Kategorien. Schreibtools verwenden die
+zuvor aufgelöste UUID. Bei mehreren Treffern wird eine Kandidatenliste
+zurückgegeben; der Server wählt nie willkürlich den ersten Treffer.
+
+### Control Registry
+
+Jeder unterstützte Control-Typ definiert:
+
+- lesbare Zustände und Einheiten
+- erlaubte Actions
+- erforderliche Parameter und Wertebereiche
+- Zuordnung zum konkreten Loxone-Kommando
+- Read-/Write-, Destructive- und Idempotenz-Metadaten
+- Tests und bestätigte Miniserver-Versionen
+
+Nicht bekannte Typen bleiben lesbar, sofern ihre Zustände sicher darstellbar
+sind. Sie erhalten keine generische Schreibmöglichkeit.
+
+## 10. MCP-Tool-Inventar
+
+### MVP: Loxone lesen
+
+| Tool | Zweck |
+| --- | --- |
+| `loxone_get_system_status` | Erreichbarkeit, Version, Verbindung und Cachefrische |
+| `loxone_list_rooms` | sichtbare Räume, paginiert |
+| `loxone_list_categories` | sichtbare Kategorien, paginiert |
+| `loxone_find_controls` | Suche/Filter nach Name, Raum, Kategorie und Typ |
+| `loxone_describe_control` | Fähigkeiten, erlaubte Actions und State-Metadaten |
+| `loxone_get_states` | aktuelle Zustände einer begrenzten UUID-Liste |
+
+Diese Tools erhalten `readOnlyHint: true`, `destructiveHint: false` und passende
+Ausgabeschemas.
+
+### MVP: Loxone bedienen
+
+Nach erfolgreicher Read-only-Phase folgt genau ein semantisch begrenztes Tool:
+
+`loxone_operate_control`
+
+- Ziel ausschließlich per UUID
+- Action als Enum aus der Control Registry
+- typisierte Parameter statt freiem String
+- optionaler erwarteter Vorzustand gegen verlorene Updates
+- strukturierte Rückgabe von angenommenem Befehl und beobachtetem Nachzustand
+- kein automatischer Retry, wenn Idempotenz nicht sicher ist
+
+Bulk-Aktionen nach Raum, Kategorie oder „alle“ bleiben außerhalb des MVP. Eine
+spätere Erweiterung benötigt Vorschau, maximale Zielanzahl und explizite
+Bestätigung.
+
+### Loxone-Historie
+
+`loxone_get_statistics` folgt nach einem eigenen Spike zu API-Versionen,
+Zeitzonen, Aggregation und Antwortgrößen. Rohhistorien werden zeitlich und
+mengenmäßig begrenzt; serverseitige Aggregation wird bevorzugt.
+
+### MVP: LoxBerry lesen
+
+| Tool | Zweck |
+| --- | --- |
+| `loxberry_get_system_status` | Version, Uptime, CPU-/Speicher-/Datenträgerstatus in sicherem Umfang |
+| `loxberry_get_plugin_status` | Zustand und Version dieses MCP-Plugins |
+| `loxberry_get_service_health` | nur explizit freigegebene plugin-eigene Dienste |
+
+Keine vollständigen Prozesslisten, Netzwerkdetails, Umgebungsvariablen,
+Konfigurationsdateien oder Logs werden ungefiltert ausgegeben.
+
+### Später: LoxBerry bedienen
+
+Erste mögliche Aktion ist der Neustart ausschließlich des plugin-eigenen
+MCP-Dienstes. Reboot, Shutdown, Paketverwaltung, fremde Dienste und beliebige
+Kommandos bleiben gesperrt, bis ein eigener Sicherheits- und
+Wiederherstellungsentwurf akzeptiert wurde.
+
+## 11. Tool-Ergebnisse und Fehler
+
+Jedes Ergebnis enthält, soweit sinnvoll:
+
+- `ok`
+- `data`
+- `warnings`
+- `observed_at` in UTC/ISO 8601
+- `stale`
+- `trace_id`
+
+Fehler unterscheiden mindestens:
+
+- `invalid_input`
+- `unauthenticated`
+- `permission_denied`
+- `not_found`
+- `ambiguous_target`
+- `unsupported_control`
+- `conflict`
+- `rate_limited`
+- `loxone_unreachable`
+- `timeout`
+- `temporarily_unavailable`
+- `internal_error`
+
+Interne Pfade, Stacktraces, Tokens und Passwörter erscheinen nicht im
+MCP-Ergebnis.
+
+## 12. Konfiguration und Dateien
+
+### Normale Konfiguration
+
+Vorgesehene Bereiche:
+
+```text
+schema_version
+server.listen_port
+server.local_base_url
+server.external_base_url
+server.allowed_origins
+loxone.host_or_serial
+loxone.connection_timeout
+tools.loxone_read_enabled
+tools.loxone_control_enabled
+tools.loxberry_read_enabled
+policy.allowed_loxberry_users
+limits.requests_per_minute
+limits.max_parallel_calls
+audit.retention_days
+```
+
+### Secrets und Sessions
+
+- getrennt von normaler Konfiguration
+- Eigentümer `loxberry`, Modus höchstens `0600`
+- atomare Schreibvorgänge
+- Signing-/Encryption-Key bei Installation kryptografisch erzeugt
+- Refresh Tokens serverseitig nur gehasht, soweit das Verfahren dies erlaubt
+- keine Secrets in Backups/Diagnosen ohne ausdrückliche, dokumentierte Regel
+- Widerruf einzelner Clients und aller Sessions über die Admin-UI
+
+Konfigurationsänderungen werden vollständig validiert und atomar aktiviert. Ein
+Fehler erhält die letzte gültige Laufzeitkonfiguration.
+
+## 13. LoxBerry-Integration
+
+### Paketstruktur
+
+Das Plugin folgt dem V4-Layout mit mindestens:
+
+```text
+plugin.cfg
+release.cfg
+prerelease.cfg
+bin/
+config/
+templates/
+templates/lang/
+webfrontend/htmlauth/
+install-/upgrade-/uninstall-hooks
+```
+
+Architekturabhängige Binaries werden reproduzierbar gebaut und eindeutig
+ausgewählt. Plugin-Identität und Ordnername werden vor dem ersten Paket
+festgelegt und danach nicht geändert.
+
+### Dienst
+
+- eigener systemd-Dienst oder nachweislich gleichwertiger nativer
+  LoxBerry-Dienstmechanismus
+- läuft als `loxberry`, nicht als Root
+- restriktive `UMask`
+- Loopback-Bindung
+- automatischer Start nur bei gültiger, aktivierter Konfiguration
+- Health-Check und begrenztes Restart-Verhalten
+- Root-Hooks installieren nur Unit, Proxy-Regel und erforderliche Rechte
+
+Für privilegierte spätere Aktionen wird kein breites `sudo systemctl *` oder
+Shellrecht vergeben. Falls nötig, erhält jede erlaubte Operation einen eigenen,
+argumentlosen oder streng validierenden Helper.
+
+### Weboberfläche
+
+Die LoxBerry-authentifizierte Admin-UI bietet:
+
+- Einrichtungsassistent und Miniserver-Verbindungstest
+- lokalen und externen MCP-Endpunkt mit Erreichbarkeitsstatus
+- Read-/Write-Toolsets und LoxBerry-Scope-Policy
+- registrierte Clients/Sessions und Widerruf
+- Dienststatus, Version und letzte Fehler
+- Audit-Ansicht ohne Geheimnisse
+- Links zu deutscher und englischer Anleitung
+
+Desktop und Mobile besitzen denselben Funktionsumfang gemäß
+[Implementierungsrichtlinien](implementation-guidelines.md).
+
+## 14. Logging und Audit
+
+Technische Logs nutzen die LoxBerry-Logverwaltung und enthalten Komponente,
+Schweregrad und Trace-ID. Wiederholte Verbindungsfehler werden gedrosselt.
+
+Das getrennte Audit erfasst für schreibende oder abgewiesene Aufrufe:
+
+- UTC-Zeit
+- MCP-Client-ID
+- pseudonymisierte oder angemessen dargestellte Benutzeridentität
+- Tool und Ziel-UUID
+- Action, nicht-sensitive Parameter und Ergebnis
+- Trace-ID
+
+Aktuelle Raumzustände, Passwörter, Tokens und vollständige Tool-Payloads werden
+nicht pauschal protokolliert. Aufbewahrung und Löschung sind konfigurierbar und
+begrenzt.
+
+## 15. Robustheit und Limits
+
+- feste Maximalgröße für HTTP- und JSON-RPC-Nachrichten
+- Pagination und Ergebnislimits
+- Timeouts pro Loxone-Aufruf
+- begrenzte Parallelität pro Benutzer und global
+- Backoff mit Jitter bei Verbindungsfehlern
+- Circuit Breaker bei wiederholtem Miniserver-Ausfall
+- kein automatischer Retry nicht-idempotenter Schreibaktionen
+- Graceful Shutdown und Abbruch laufender lesender Aufrufe
+- atomare Konfiguration und Sessionpersistenz
+- Statusantworten bleiben auch bei Miniserver-Ausfall verfügbar
+
+## 16. Testkonzept
+
+Zusätzlich zur allgemeinen [Teststrategie](test-strategy.md) sind folgende
+Nachweise erforderlich:
+
+### Automatisiert
+
+- MCP-Conformance für unterstützte Protokollversionen
+- JSON-Schemas und Tool-Annotationen
+- OAuth-Discovery, PKCE, Audience, Ablauf, Refresh und Widerruf
+- Scope- und Policy-Matrix einschließlich negativer Fälle
+- Strukturparser mit anonymisierten Gen.-1-/Gen.-2-Fixtures
+- Control Registry und Wertebereiche
+- Namensmehrdeutigkeit und UUID-Validierung
+- Redirect-, Origin-, Path- und Injection-Angriffe
+- Secret-Maskierung und Auditfelder
+- Reconnect, Timeout, Backoff und nicht-idempotente Fehlerpfade
+- Konfigurationsmigrationen und atomare Aktivierung
+
+### Reale Systeme
+
+- mindestens ein bestätigter Miniserver Gen. 1 und Gen. 2
+- eingeschränkter Loxone-Testbenutzer: unsichtbare Controls bleiben unsichtbar
+- erlaubte und verbotene Schreibaktionen
+- WebSocket-Zustand und Reconnect
+- LoxBerry-Installation, Upgrade, Deinstallation und Dienstrechte
+- Apache-Proxy mit Streamable HTTP und OAuth-Discovery
+- ausgewählte lokale und cloudbasierte MCP-Clients
+- Desktop-/Mobile-Admin-UI nach der risikobasierten Viewport-Matrix
+
+Reale Zugangsdaten und Strukturdateien werden nicht in Fixtures oder CI
+übernommen.
+
+## 17. Umsetzungsphasen
+
+### Phase 0: Architektur-Spikes
+
+- Python-Version, venv und Wheels auf allen Zielarchitekturen
+- kleiner Go-Vergleichsbuild, falls Altplattform oder Ressourcenbudget kritisch
+  sind
+- MCP Streamable HTTP hinter Apache
+- OAuth-End-to-End mit zwei Clients
+- Loxone-Tokenauth und Rechtefilterung Gen. 1/2
+- WebSocket-Snapshot-/Delta-Verhalten
+- Ressourcenverbrauch
+
+**Ergebnis:** bestätigte oder korrigierte Technologieentscheidung und
+Support-Matrix.
+
+### Phase 1: Read-only Alpha
+
+- Pluginlayout, Dienst und Admin-UI-Grundgerüst
+- OAuth und Sessionwiderruf
+- Struktur, Suche, Beschreibung und Zustände
+- nur `loxone:read`
+- lokale/LAN-Nutzung
+- deterministische Tests und CI
+
+### Phase 2: Kontrollierte Loxone-Schreibaktionen
+
+- erste getestete Control-Typen
+- `loxone_operate_control`
+- Audit und Rate Limits
+- explizite Aktivierung von `loxone:control`
+- optionaler externer HTTPS-Betrieb nach Sicherheitstest
+
+### Phase 3: LoxBerry Read-only
+
+- separater `loxberry:read`-Freigabefluss
+- sichere System- und Plugin-Diagnose
+- keine fremden Logs oder Konfigurationsinhalte
+
+### Phase 4: Erweiterungen
+
+- Historie/Statistik
+- weitere bestätigte Control-Typen
+- eng begrenzte plugin-eigene LoxBerry-Aktion
+- mehrere Miniserver nur bei nachgewiesenem Bedarf
+
+## 18. Abnahmekriterien für den ersten öffentlichen Test
+
+- Installation und Upgrade über den normalen LoxBerry Plugin Manager
+- Dienst läuft ohne Root und ausschließlich auf Loopback
+- MCP-Conformance und CI erfolgreich
+- OAuth funktioniert mit mindestens zwei dokumentierten Clients
+- Loxone-Rechtefilterung ist mit eingeschränktem Benutzer real bestätigt
+- keine Write-Tools ohne Scope und explizite Aktivierung
+- keine freien Kommandopfade oder LoxBerry-Shell
+- Secrets fehlen in Logs, HTML, Prozessargumenten und Diagnoseexport
+- lokaler Endpunkt und Sessionwiderruf sind verständlich dokumentiert
+- Admin-UI funktioniert auf Desktop und Mobile
+- Support-Matrix nennt nur tatsächlich geprüfte Kombinationen
+
+## 19. Noch zu entscheidende Punkte
+
+Vor der Implementierung benötigt das Review Entscheidungen zu:
+
+1. endgültiger Plugin-ID und Installationsordner
+2. erste LoxBerry-Versionen und CPU-Architekturen
+3. verbindliche Python-/Go-Entscheidung nach dem Runtime- und Paketierungsspike
+4. exakter öffentlicher Pluginpfad und Apache-Integration
+5. OAuth-Clientregistrierung und Sessionpersistenz
+6. Mindestfirmware für Miniserver Gen. 1 und Gen. 2
+7. erste unterstützte Control-Typen
+8. Zeitpunkt und konkreter Umfang von `loxberry:read`
+9. ob externer HTTPS-Zugriff bereits im ersten öffentlichen Test enthalten ist
+
+Diese Punkte sind absichtlich sichtbar offen. Sie werden nicht durch zufällige
+Implementierungsdetails vorweggenommen.

--- a/docs/development/plugin-concept.md
+++ b/docs/development/plugin-concept.md
@@ -191,6 +191,10 @@ Für externe Nutzung gilt:
 - Host-/Origin-Allowlist und Schutz vor DNS Rebinding
 - dokumentierter Verbindungscheck vor Freigabe
 
+Der erste öffentliche Test bietet noch keinen externen MCP-Zugriff. Er ist auf
+lokale beziehungsweise LAN-Clients begrenzt. Die externe Veröffentlichung wird
+erst nach einem eigenen Reverse-Proxy-, OAuth- und Sicherheitstest aktiviert.
+
 LAN-Clients können direkt über die lokale HTTPS-Adresse arbeiten. stdio wird
 nicht als zweiter Servermodus benötigt; ein lokaler Client kann bei Bedarf eine
 generische Streamable-HTTP-zu-stdio-Bridge verwenden.
@@ -214,14 +218,42 @@ oder andere Dienste weitergereicht.
 
 ### Plugin zum Miniserver
 
-Im Autorisierungsablauf meldet sich der Benutzer mit einem dedizierten
-Loxone-Konto am ausgewählten Miniserver an. Das Passwort wird nur zur Anmeldung
-verwendet und nicht gespeichert. Nach erfolgreicher Anmeldung verwendet das
-Plugin, soweit vom Miniserver unterstützt, ein erneuerbares Loxone-Token.
+Beide Miniserver-Generationen werden direkt über die normale Loxone-Webservice-
+und WebSocket-API angebunden. Das Plugin verwendet Loxone JSON Web Tokens; es
+verwendet weder HTTP Basic Authentication noch die OAuth-Schnittstelle des
+nativen Gen.-2-MCP-Servers. MCP-OAuth und Loxone-JWT bleiben getrennte
+Sicherheitsdomänen.
 
-Zu prüfen ist, wie das Token auf den unterstützten Generationen sicher erneuert
-und widerrufen wird. Bis dieser Nachweis vorliegt, ist eine erneute Anmeldung
-nach Dienstneustart akzeptabler als persistente Passwortspeicherung.
+| Merkmal | Miniserver Gen. 1 | Miniserver Gen. 2/Compact |
+| --- | --- | --- |
+| Transport | ausschließlich HTTP und WS | ausschließlich HTTPS und WSS für das Plugin |
+| Serverauthentizität | keine TLS-Serveridentität; nur lokales, vertrauenswürdiges Netz | Zertifikats- und Hostnamenprüfung zwingend |
+| Loxone-Anmeldung | JWT mit `getkey2`, HMAC und Loxone Command Encryption | JWT über die TLS-geschützte API |
+| Anwendungskryptografie | RSA-Schlüsselaustausch und AES-256-CBC für Auth-/Steuerkommandos | ab Firmware 11.2 bei geprüftem TLS nicht erforderlich |
+| HTTP Basic Auth | nicht unterstützt | nicht unterstützt |
+| Reale Ausgangsbasis | verfügbares Testgerät mit Firmware `17.1.7.27`; Prüfung noch ausstehend | Firmwarestände erst durch öffentliche Beta bestätigt |
+
+Der Verbindungsaufbau beginnt lokal mit dem nicht sensitiven
+`jdev/cfg/apiKey`-Probe. Der Adapter wertet Firmware und `httpsStatus` aus:
+
+1. Meldet der Miniserver TLS-Unterstützung, sind HTTPS/WSS, ein zum Zertifikat
+   passender Hostname und vollständige Zertifikatsprüfung Pflicht. Nach einem
+   TLS-Fehler erfolgt kein stiller Rückfall auf HTTP/WS.
+2. Fehlt TLS-Unterstützung, wird die Verbindung nur für Gen. 1 und nur zu einem
+   lokalen Ziel zugelassen. Tokenanforderung, Tokenauthentifizierung und
+   Steuerkommandos verwenden die Loxone Command Encryption.
+3. Der Adapter verwendet den von `getkey2` gemeldeten Hashalgorithmus und darf
+   SHA1 oder SHA256 nicht anhand der Generation fest annehmen.
+4. Das Passwort lebt nur für die erstmalige Tokenanforderung im Speicher und
+   wird weder gespeichert noch protokolliert. Das erneuerbare Loxone-JWT wird
+   im geschützten Secret-Speicher abgelegt, erneuert und bei Widerruf mit
+   `killtoken` invalidiert.
+
+Command Encryption ersetzt auf Gen. 1 kein TLS. Insbesondere Strukturdateien,
+Statusereignisse und Teile der Antworten besitzen keine garantierte
+Ende-zu-Ende-Vertraulichkeit. Deshalb sind Gen.-1-Verbindungen auf das lokale
+Netz beschränkt, verwenden einen dedizierten Benutzer mit Minimalrechten und
+werden in der UI als transportseitig unverschlüsselt gekennzeichnet.
 
 Jede Server-Session bindet mindestens:
 
@@ -463,6 +495,18 @@ Architekturabhängige Binaries werden reproduzierbar gebaut und eindeutig
 ausgewählt. Plugin-Identität und Ordnername werden vor dem ersten Paket
 festgelegt und danach nicht geändert.
 
+Die dauerhafte Plugin-Identität lautet:
+
+```ini
+[PLUGIN]
+NAME=mcpserver
+FOLDER=mcpserver
+TITLE=LoxBerry MCP Server
+```
+
+Code ermittelt weiterhin den tatsächlich von LoxBerry vergebenen Ordner, da
+bei einer Namenskollision ein numerischer Suffix ergänzt werden kann.
+
 ### Dienst
 
 - eigener systemd-Dienst oder nachweislich gleichwertiger nativer
@@ -660,21 +704,23 @@ Support-Matrix.
 - Support-Matrix nennt nur tatsächlich geprüfte Kombinationen
 - Gen. 2 ist bis zu einem vollständigen unabhängigen Betanachweis ausdrücklich
   als `experimental` gekennzeichnet
+- erster Test auf LoxBerry 4, Debian 13 und `arm64`
+- Gen. 1 mindestens Firmware `17.1.7.27`; ältere Versionen sind unbestätigt
+- externer MCP-Zugriff ist nicht konfigurierbar
 
-## 19. Noch zu entscheidende Punkte
+## 19. Entscheidungen vor dem ersten ausführbaren Commit
 
-Vor der Implementierung benötigt das Review Entscheidungen zu:
+| Nr. | Thema | Entscheidung/Status |
+| --- | --- | --- |
+| 1 | Plugin-ID und Ordner | festgelegt: `NAME=mcpserver`, `FOLDER=mcpserver`, `TITLE=LoxBerry MCP Server` |
+| 2 | erste CPU-Architektur | festgelegt: LoxBerry 4 auf Debian 13, `arm64` |
+| 3 | Runtime | offen: Python durch Runtime- und Paketierungsspike bestätigen |
+| 4 | öffentlicher Pluginpfad/Apache | offen; `/plugins/mcpserver/mcp` bleibt ein Beispiel |
+| 5 | MCP-OAuth-Clientregistrierung und Sessionpersistenz | offen |
+| 6 | Miniserver-Firmware | Gen. 1 mindestens `17.1.7.27`; Gen.-2-Stände werden durch die öffentliche Beta bestätigt |
+| 7 | erste unterstützte Control-Typen | offen |
+| 8 | Zeitpunkt und Umfang von `loxberry:read` | offen |
+| 9 | externer HTTPS-Zugriff im ersten Test | festgelegt: nicht enthalten, erster Test nur lokal/LAN |
 
-1. endgültiger Plugin-ID und Installationsordner
-2. erste CPU-Architekturen für LoxBerry 4 unter Debian 13
-3. Bestätigung von Python durch den Runtime- und Paketierungsspike
-4. exakter öffentlicher Pluginpfad und Apache-Integration
-5. OAuth-Clientregistrierung und Sessionpersistenz
-6. lokal bestätigte Mindestfirmware für Gen. 1 und durch die öffentliche Beta
-   bestätigte Firmwarestände für Gen. 2
-7. erste unterstützte Control-Typen
-8. Zeitpunkt und konkreter Umfang von `loxberry:read`
-9. ob externer HTTPS-Zugriff bereits im ersten öffentlichen Test enthalten ist
-
-Diese Punkte sind absichtlich sichtbar offen. Sie werden nicht durch zufällige
+Offene Punkte bleiben bewusst sichtbar und werden nicht durch zufällige
 Implementierungsdetails vorweggenommen.

--- a/docs/development/plugin-concept.md
+++ b/docs/development/plugin-concept.md
@@ -59,10 +59,10 @@ Nicht zum Produktumfang gehören:
 
 ### Kernruntime
 
-Bevorzugt wird ein eigenständiger Python-Dienst, sofern der Runtime-Spike die
-Support-Matrix bestätigt:
+Für den MVP wird ein eigenständiger Python-Dienst auf LoxBerry 4 unter Debian 13
+(Trixie) bevorzugt:
 
-- Python 3.10 oder neuer
+- systemseitiges Python 3.13; das MCP-SDK selbst verlangt mindestens Python 3.10
 - offizielles MCP-Python-SDK (Tier 1), auf eine geprüfte Hauptversion fixiert
 - `asyncio`/ASGI mit Streamable HTTP auf einem Loopback-Port
 - typisierte Ein- und Ausgabemodelle
@@ -77,26 +77,25 @@ kleinen Toolumfang aber nicht als grundsätzlicher Engpass erwartet.
 
 Das Plugin installiert niemals Abhängigkeiten in das System-Python. Es erhält
 ein eigenes virtuelles Environment und einen vollständig fixierten,
-reproduzierbaren Abhängigkeitssatz. Auf Debian 12 verhindert dies zugleich
-Konflikte mit PEP 668. Für jede unterstützte Architektur müssen vorgebaute
-Wheels vorhanden oder im Paket mitgeliefert sein; die normale Installation
-darf weder Compiler noch Rust-Toolchain benötigen.
+reproduzierbaren Abhängigkeitssatz. Dies respektiert das von Debian verwaltete
+System-Python und PEP 668. Für jede unterstützte Architektur müssen vorgebaute
+Wheels vorhanden oder im Paket mitgeliefert sein; die normale Installation darf
+weder Compiler noch Rust-Toolchain benötigen.
 
-Diese Empfehlung bedeutet zunächst auch: LoxBerry-/Debian-Kombinationen mit
-Python 3.9 sind nicht automatisch unterstützt. Soll insbesondere Debian 11 zur
-ersten Support-Matrix gehören, werden drei Optionen im Spike verglichen:
+LoxBerry 3 und ältere Debian-Basen gehören nicht zur anfänglichen Support-Matrix.
+Sie können später ergänzt werden, wenn Python-Version und Abhängigkeiten dafür
+reproduzierbar bereitgestellt werden können. Diese optionale
+Rückwärtskompatibilität blockiert den MVP nicht.
 
-1. Support-Basis auf Systeme mit Python 3.10 oder neuer begrenzen,
-2. eine plugin-eigene Python-Runtime sicher und wartbar mitliefern oder
-3. den Kerndienst als statisches Go-Binary bauen.
-
-Go ist damit die dokumentierte Rückfalloption. Das offizielle Go-SDK ist
-ebenfalls Tier 1; ein einzelnes Binary reduziert Installations- und
-Abhängigkeitsrisiken, kostet aber mehr Implementierungsaufwand.
+Go bleibt die dokumentierte Rückfalloption, falls Python-Wheels oder das
+Ressourcenbudget auf einer erforderlichen LoxBerry-4-Architektur scheitern. Das
+offizielle Go-SDK ist ebenfalls Tier 1; ein einzelnes Binary reduziert
+Installations- und Abhängigkeitsrisiken, kostet aber mehr Implementierungsaufwand.
 
 Vor der Festlegung beweist ein Spike:
 
-- Python-Version und venv-Erstellung auf allen ausgewählten LoxBerry-Basen
+- Python 3.13 und venv-Erstellung auf allen ausgewählten
+  LoxBerry-4-/Debian-13-Architekturen
 - Installation aller fixierten Abhängigkeiten ausschließlich aus verfügbaren
   oder mitgelieferten Wheels
 - Paketgröße, Start sowie RAM- und CPU-Bedarf im Idle und bei Zustandsupdates
@@ -546,7 +545,7 @@ Reale Zugangsdaten und Strukturdateien werden nicht in Fixtures oder CI
 ### Phase 0: Architektur-Spikes
 
 - Python-Version, venv und Wheels auf allen Zielarchitekturen
-- kleiner Go-Vergleichsbuild, falls Altplattform oder Ressourcenbudget kritisch
+- kleiner Go-Vergleichsbuild nur, falls Wheels oder Ressourcenbudget kritisch
   sind
 - MCP Streamable HTTP hinter Apache
 - OAuth-End-to-End mit zwei Clients
@@ -606,8 +605,8 @@ Support-Matrix.
 Vor der Implementierung benötigt das Review Entscheidungen zu:
 
 1. endgültiger Plugin-ID und Installationsordner
-2. erste LoxBerry-Versionen und CPU-Architekturen
-3. verbindliche Python-/Go-Entscheidung nach dem Runtime- und Paketierungsspike
+2. erste CPU-Architekturen für LoxBerry 4 unter Debian 13
+3. Bestätigung von Python durch den Runtime- und Paketierungsspike
 4. exakter öffentlicher Pluginpfad und Apache-Integration
 5. OAuth-Clientregistrierung und Sessionpersistenz
 6. Mindestfirmware für Miniserver Gen. 1 und Gen. 2

--- a/docs/development/plugin-concept.md
+++ b/docs/development/plugin-concept.md
@@ -111,10 +111,26 @@ nicht zur Pflicht des MCP-Kerndienstes werden.
 
 ### Protokollversion
 
-Der erste Release zielt auf die stabile MCP-Version `2025-11-25` und nutzt die
-Versionsaushandlung des SDK. Eine noch nicht finale Protokollrevision darf
-zusätzlich unterstützt werden, aber niemals die einzige kompatible Version
-sein.
+Der erste öffentliche Release implementiert die finale MCP-Version
+`2025-11-25` über die stabile v1-Linie des offiziellen Python-SDKs. Die konkrete
+SDK-Version und ihre transitiven Abhängigkeiten werden im Build exakt fixiert;
+die Protokollversion wird nicht durch eigene Konstanten am SDK vorbei erzwungen.
+
+Die Revision `2026-07-28` bleibt solange außerhalb des produktiven Umfangs, bis
+alle folgenden Bedingungen erfüllt sind:
+
+1. die MCP-Spezifikation ist final veröffentlicht,
+2. ein stabiles offizielles Python-SDK unterstützt sie vollständig,
+3. die offizielle Conformance-Suite ist erfolgreich,
+4. mindestens zwei relevante Clients sind real interoperabel getestet und
+5. `2025-11-25` bleibt während einer dokumentierten Übergangsphase per
+   Versionsaushandlung nutzbar.
+
+Die interne Architektur wird dennoch auf den stateless Ansatz vorbereitet:
+Tool-Handler sind wiedereintrittsfähig, fachlicher Zustand liegt nicht nur in
+einer MCP-Transportsession, und der MVP hängt nicht von Roots, Sampling oder
+MCP-Logging ab. Damit wird das spätere Upgrade kleiner, ohne einen Release
+Candidate zum Produktionsvertrag zu machen.
 
 ## 6. Zielarchitektur
 

--- a/docs/development/plugin-concept.md
+++ b/docs/development/plugin-concept.md
@@ -102,7 +102,8 @@ Vor der Festlegung beweist ein Spike:
   auf den ausgewählten Architekturen
 - Streamable HTTP/Origin-Prüfung hinter dem LoxBerry-Apache
 - OAuth-Interoperabilität mit mindestens zwei relevanten Clients
-- Loxone-Anmeldung, Rechtefilterung und WebSocket-Zustände auf Gen. 1 und Gen. 2
+- Loxone-Anmeldung, Rechtefilterung und WebSocket-Zustände auf dem verfügbaren
+  Miniserver Gen. 1
 
 Falls Python an einer erforderlichen Altplattform, fehlenden ARM-Wheels oder dem
 Ressourcenbudget scheitert, wird Go verwendet. TypeScript bleibt eine weitere,
@@ -544,7 +545,9 @@ Nachweise erforderlich:
 
 ### Reale Systeme
 
-- mindestens ein bestätigter Miniserver Gen. 1 und Gen. 2
+- Miniserver Gen. 1 wird auf dem verfügbaren eigenen Zielsystem geprüft
+- Miniserver Gen. 2 wird mangels eigener Hardware ausschließlich durch
+  freiwillige Dritte in einer öffentlichen Beta geprüft
 - eingeschränkter Loxone-Testbenutzer: unsichtbare Controls bleiben unsichtbar
 - erlaubte und verbotene Schreibaktionen
 - WebSocket-Zustand und Reconnect
@@ -556,6 +559,44 @@ Nachweise erforderlich:
 Reale Zugangsdaten und Strukturdateien werden nicht in Fixtures oder CI
 übernommen.
 
+### Öffentliche Gen.-2-Beta
+
+Die öffentliche Beta ist ein eigener, reproduzierbarer Testkanal und kein
+Ersatz für automatisierte Tests. Sie beginnt read-only. Betatester erhalten:
+
+- ein eindeutig versioniertes Pre-Release-Paket mit Prüfsumme
+- eine kurze Installations-, Rücksetz- und Deinstallationsanleitung
+- einen Testplan für Anmeldung, Rechtefilterung, Struktur, Zustände und Reconnect
+- eine Liste der für die Beta vorgesehenen MCP-Clients; über alle Berichte
+  sollen mindestens zwei unterschiedliche Clients abgedeckt werden
+- die Vorgabe, einen dedizierten Loxone-Benutzer mit Minimalrechten zu verwenden
+- einen lokalen Diagnoseexport, der Secrets, interne Adressen, Namen und
+  Strukturinhalte standardmäßig maskiert
+- ein öffentliches GitHub-Issue-Formular für strukturierte Ergebnisse
+
+Ein Beta-Bericht nennt mindestens LoxBerry-Version, CPU-Architektur,
+Miniserver-Generation und -Firmware, Pluginversion, MCP-Client/-Version,
+ausgeführte Testfälle und Ergebnis. Passwörter, Tokens, komplette
+Strukturdateien und unmaskierte Logs werden weder angefordert noch veröffentlicht.
+
+Gen.-2-Schreibtests folgen erst nach erfolgreicher Read-only-Beta. Sie sind
+separat opt-in, verwenden unkritische Teststeuerungen und dokumentieren
+Ausgangszustand, erwartete Aktion, Ergebnis und Wiederherstellung. Das Projekt
+greift nicht ohne separate ausdrückliche Zustimmung remote auf Systeme von
+Betatestern zu.
+
+Die Support-Matrix unterscheidet:
+
+- `maintainer-tested`: selbst auf vorhandener Hardware geprüft
+- `community-confirmed`: mindestens ein vollständiger, nachvollziehbarer
+  Beta-Bericht eines unabhängigen Dritten
+- `experimental`: implementiert, aber ohne ausreichenden realen Nachweis
+- `unsupported`: nicht angeboten oder bekanntermaßen inkompatibel
+
+Ohne erfolgreichen Gen.-2-Betabericht wird Gen. 2 nicht als bestätigt
+unterstützt bezeichnet. Ein Release kann dann Gen. 1 unterstützen und Gen. 2
+weiterhin als experimentell ausweisen.
+
 ## 17. Umsetzungsphasen
 
 ### Phase 0: Architektur-Spikes
@@ -565,7 +606,7 @@ Reale Zugangsdaten und Strukturdateien werden nicht in Fixtures oder CI
   sind
 - MCP Streamable HTTP hinter Apache
 - OAuth-End-to-End mit zwei Clients
-- Loxone-Tokenauth und Rechtefilterung Gen. 1/2
+- Loxone-Tokenauth und Rechtefilterung auf Gen. 1
 - WebSocket-Snapshot-/Delta-Verhalten
 - Ressourcenverbrauch
 
@@ -580,6 +621,8 @@ Support-Matrix.
 - nur `loxone:read`
 - lokale/LAN-Nutzung
 - deterministische Tests und CI
+- versioniertes öffentliches Gen.-2-Betapaket samt Testplan und maskiertem
+  Diagnoseexport
 
 ### Phase 2: Kontrollierte Loxone-Schreibaktionen
 
@@ -615,6 +658,8 @@ Support-Matrix.
 - lokaler Endpunkt und Sessionwiderruf sind verständlich dokumentiert
 - Admin-UI funktioniert auf Desktop und Mobile
 - Support-Matrix nennt nur tatsächlich geprüfte Kombinationen
+- Gen. 2 ist bis zu einem vollständigen unabhängigen Betanachweis ausdrücklich
+  als `experimental` gekennzeichnet
 
 ## 19. Noch zu entscheidende Punkte
 
@@ -625,7 +670,8 @@ Vor der Implementierung benötigt das Review Entscheidungen zu:
 3. Bestätigung von Python durch den Runtime- und Paketierungsspike
 4. exakter öffentlicher Pluginpfad und Apache-Integration
 5. OAuth-Clientregistrierung und Sessionpersistenz
-6. Mindestfirmware für Miniserver Gen. 1 und Gen. 2
+6. lokal bestätigte Mindestfirmware für Gen. 1 und durch die öffentliche Beta
+   bestätigte Firmwarestände für Gen. 2
 7. erste unterstützte Control-Typen
 8. Zeitpunkt und konkreter Umfang von `loxberry:read`
 9. ob externer HTTPS-Zugriff bereits im ersten öffentlichen Test enthalten ist

--- a/docs/development/test-strategy.md
+++ b/docs/development/test-strategy.md
@@ -80,6 +80,38 @@ wiederhergestellt. Eine Änderung am Installer benötigt den normalen
 Plugin-Manager-Weg; ein Merge allein benötigt keine vollständige
 Installationsabnahme.
 
+## Öffentliche Betatests für nicht vorhandene Hardware
+
+Steht eine zugesagte Hardwaregeneration den Maintainern nicht zur Verfügung,
+wird die fehlende reale Prüfung ausdrücklich als `unverified` beziehungsweise
+`experimental` ausgewiesen. Sie wird nicht durch Mocks als bestanden erklärt.
+
+Tests auf einem Miniserver Gen. 2 werden durch freiwillige Dritte über eine
+öffentliche Beta erbracht. Dafür stellt das Projekt ein versioniertes
+Pre-Release-Paket, Prüfsumme, Testplan, Rücksetzweg, maskierten Diagnoseexport
+und ein strukturiertes GitHub-Issue-Formular bereit. Der Test startet read-only
+und verwendet einen dedizierten Loxone-Benutzer mit Minimalrechten.
+
+Ein verwertbarer Bericht enthält:
+
+- Plugin-, LoxBerry- und Miniserver-Version
+- CPU-Architektur sowie MCP-Client und dessen Version
+- ausgeführte Testfälle mit erwartetem und beobachtetem Ergebnis
+- ausschließlich maskierte relevante Logauszüge
+- Kennzeichnung, ob nur gelesen oder ausdrücklich eine Teststeuerung bedient
+  wurde
+
+Passwörter, Tokens, vollständige Strukturdateien, interne Adressen und
+unmaskierte Zustandsdaten werden nicht angefordert. Schreibtests sind ein
+separater Opt-in-Schritt an unkritischen Steuerungen mit dokumentierter
+Wiederherstellung. Maintainer und KI-Agenten greifen nicht ohne eine separate,
+ausdrückliche Zustimmung remote auf Geräte der Betatester zu.
+
+Die Support-Matrix unterscheidet selbst getestete, durch mindestens einen
+vollständigen unabhängigen Bericht bestätigte, experimentelle und nicht
+unterstützte Kombinationen. Ein fehlender Betatester ist kein fehlgeschlagener
+Test, aber die betreffende Kombination bleibt unbestätigt.
+
 ## Mindestanforderungen an Tests
 
 - Tests sind deterministisch, wiederholbar und enthalten keine echten Secrets,

--- a/docs/development/test-strategy.md
+++ b/docs/development/test-strategy.md
@@ -71,6 +71,10 @@ Grenze nicht beweisen können:
 - Benutzer, Gruppen, Dateirechte oder `sudo`
 - systemd und Prozess-Lifecycle
 - Netzwerkbindung und Verbindung zum Miniserver
+- Gen.-1-JWT-Anforderung und -Authentifizierung mit Command Encryption auf
+  Firmware `17.1.7.27`
+- Prüfung, dass Basic Auth, Zugangsdaten in URLs und Klartextpasswörter abgelehnt
+  beziehungsweise niemals erzeugt werden
 - Installation, Upgrade oder Deinstallation
 - reale Berechtigungsfilter des Loxone-Benutzers
 
@@ -91,6 +95,11 @@ Tests auf einem Miniserver Gen. 2 werden durch freiwillige Dritte über eine
 Pre-Release-Paket, Prüfsumme, Testplan, Rücksetzweg, maskierten Diagnoseexport
 und ein strukturiertes GitHub-Issue-Formular bereit. Der Test startet read-only
 und verwendet einen dedizierten Loxone-Benutzer mit Minimalrechten.
+
+Die Gen.-2-Beta prüft zusätzlich HTTPS/WSS mit gültiger Hostnamen- und
+Zertifikatsprüfung, JWT-Anforderung/-Erneuerung und den fehlenden Klartext-
+Fallback nach einem TLS-Fehler. Der jeweilige Firmwarestand wird im Bericht
+festgehalten und erst danach in die Support-Matrix aufgenommen.
 
 Ein verwertbarer Bericht enthält:
 

--- a/docs/research/research-results.md
+++ b/docs/research/research-results.md
@@ -1,0 +1,393 @@
+# Recherche-Ergebnisse: Loxone und LoxBerry MCP-Server
+
+- **Stand:** 2026-08-01
+- **Zweck:** Technische und konzeptionelle Grundlage für das LoxBerry MCP-Server-Plugin
+- **Methode:** bereitgestellte Notizen, aktuelle Original-Repositories sowie offizielle Loxone-, LoxBerry- und MCP-Dokumentation
+
+## 1. Kurzfazit
+
+Ein MCP-Server auf dem LoxBerry ist technisch sinnvoll und unterscheidet sich
+klar vom nativen Loxone-MCP-Server:
+
+- Er kann auch Installationen adressieren, in denen der native MCP-Server nicht
+  verfügbar ist, insbesondere Miniserver Gen. 1.
+- Er kann Loxone- und LoxBerry-Informationen in einem bewusst begrenzten Server
+  zusammenführen.
+- Er kann unabhängig vom rotierenden Loxone-Cloud-Relay eine stabile lokale oder
+  eigene HTTPS-Adresse anbieten.
+- Er muss dafür Authentifizierung, Autorisierung und Tool-Grenzen selbst
+  wesentlich sorgfältiger gestalten als ein reiner lokaler CLI-Wrapper.
+
+Die beste Ausgangsarchitektur ist ein eigenständiger, unprivilegierter Dienst
+mit Streamable HTTP, einem typsicheren Loxone-Adapter, einer pro Benutzer
+getrennten Struktur-/Zustandssicht und einem kleinen, standardmäßig lesenden
+Tool-Inventar. Beliebige Miniserver-Kommandos, globale Raumaktionen und
+allgemeiner Shellzugriff gehören nicht in die erste Version.
+
+Als technische Basis ist Python besonders prüfenswert: Der Dienst ist vor allem
+I/O-lastig, das offizielle MCP-Python-SDK ist Tier 1 und bringt Streamable HTTP,
+Schemas sowie die Resource-Server-Seite der OAuth-Integration mit. Python ist
+jedoch nur dann die einfachere Lösung, wenn die festgelegte LoxBerry-Basis
+mindestens Python 3.10 und installierbare ARM-Pakete für alle fixierten
+Abhängigkeiten bietet. Andernfalls bleibt ein statisches Go-Binary die robustere
+Paketierungsoption. Diese Entscheidung muss vor der Implementierung durch einen
+kleinen Zielsystem-, Transport-, Abhängigkeits- und OAuth-Spike bestätigt
+werden.
+
+## 2. Quellenlage und Grenzen
+
+Die bereitgestellten Dateien wurden vollständig ausgewertet:
+
+- `Loxone eigener MCP-Server.md`
+- `Projekte mit Loxone MCP-Server.md`
+- `Loxberry Plugin Konzept.md`
+
+Die Notizen zum nativen Loxone-MCP-Server beschreiben Funktionen und
+Einrichtung detaillierter als die derzeit öffentlich auffindbaren Loxone-
+Webseiten. Die öffentliche Einführung und der Changelog bestätigen den
+MCP-Server ab Loxone Config/Miniserver 17.1, enthalten aber nicht alle in der
+Notiz beschriebenen Tool- und OAuth-Details. Diese Details sind deshalb als
+bereitgestellte Produktdokumentation, nicht als unabhängig reproduzierte
+Implementierungserkenntnis gekennzeichnet.
+
+Vergleichsprojekte entwickeln sich schnell. Aussagen in dieser Recherche
+beziehen sich auf den am 2026-08-01 sichtbaren Default-Branch. README, ältere
+Architekturdokumente und aktueller Quellbaum widersprechen sich teilweise; in
+diesen Fällen wurde der aktuelle Quellbaum höher gewichtet.
+
+## 3. Nativer Loxone-MCP-Server
+
+Loxone führte den nativen MCP-Server mit Config/Miniserver 17.1 für den
+Miniserver Gen. 2 ein. Der öffentliche Changelog nennt KI-Integration,
+Wetterprognosen, Systemstatusaktionen und UTC-Zeitstempel. Für Gen. 1 steht
+dieser Pluginpfad nach den bereitgestellten Unterlagen nicht zur Verfügung.
+
+### Konzept
+
+- Der MCP-Server läuft direkt auf dem Miniserver.
+- Er übernimmt Räume, Kategorien, Steuerungen und deren Namen aus der laufenden
+  Installation.
+- Lesen und Bedienen erfolgt mit den Berechtigungen des angemeldeten
+  Loxone-Benutzers.
+- Lesende und schreibende Tools sind für Clients unterscheidbar.
+- Struktur, aktuelle Zustände, Historie und Statistiken werden angeboten.
+- Programmierung, Benutzerverwaltung, Expertenmodus und Automatik-Designer
+  bleiben außerhalb des MCP-Servers.
+- Lokale und externe MCP-Adressen sind möglich; Cloud-Clients benötigen eine
+  öffentlich erreichbare HTTPS-Adresse auf Port 443.
+- Die Anmeldung verwendet einen browserbasierten OAuth-Ablauf. Bei Reverse-
+  Proxys müssen sowohl der MCP-Pfad als auch die zugehörigen `/.well-known`-
+  Pfade erreichbar sein.
+
+### Übertragbare Erkenntnisse
+
+1. **Berechtigungen aus dem Zielsystem:** Der Miniserver sollte die tatsächlich
+   sichtbaren und bedienbaren Elemente bestimmen. Eine zweite, selbst gepflegte
+   Rechtekopie würde leicht auseinanderlaufen.
+2. **Dedizierter Assistentenbenutzer:** Ein eigenes Loxone-Konto begrenzt die
+   Folgen falsch verstandener Befehle und kann zentral deaktiviert werden.
+3. **Read/Write-Trennung:** Tool-Metadaten und Scopes sollten lesende und
+   schreibende Funktionen sichtbar trennen.
+4. **Keine Neukonfiguration:** Der MCP-Server bedient die laufende Installation,
+   ersetzt aber weder Loxone Config noch die Benutzerverwaltung.
+5. **Standardkonforme Veröffentlichung:** OAuth-Discovery und MCP-Endpunkt
+   müssen gemeinsam durch einen Reverse-Proxy geleitet werden.
+
+### Unterschied zu unserem Plugin
+
+Ein Loxone-Login kann nur Loxone-Rechte belegen. Er erteilt keine
+administrativen Rechte auf dem LoxBerry. LoxBerry-Funktionen benötigen daher
+eine eigene, explizite Autorisierung. Diese Grenze ist die wichtigste
+zusätzliche Sicherheitsanforderung unseres Projekts.
+
+## 4. Vergleichsprojekte
+
+### 4.1 `reijosirila/loxone-mcp-server`
+
+- **Technik:** TypeScript/Node.js, offizielles MCP-TypeScript-SDK, Express,
+  `loxone-ts-api`
+- **Transport:** stdio und Streamable HTTP
+- **Loxone-Zugriff:** WebSocket für Ereignisse, `LoxApp3.json`/Strukturdatei,
+  HTTP-Kommandos
+- **MCP-Modell:** wenige generische Tools für Räume, Kategorien, Steuerungen,
+  Einzelsteuerung und Statistik
+- **HTTP-Schutz:** optionaler statischer API-Key; ohne Key ist der HTTP-Endpunkt
+  offen
+- **Lizenz:** AGPL-3.0
+
+Positiv sind die klare Trennung in Connection-, State-, Control- und
+Statistics-Services sowie eine Factory mit typspezifischen Steuerungsadaptern.
+Die Struktur wird einmal geladen, Zustandsänderungen werden über WebSocket
+eingepflegt und Reconnects verwenden begrenztes Backoff.
+
+Für unser Plugin nicht ausreichend sind optionale Authentifizierung, fehlendes
+HTTPS/WSS im verwendeten Loxone-Client und ein freies `command`-Feld im
+Schreibtool. Außerdem ist AGPL-Code mit unserem Apache-2.0-Projekt nicht einfach
+übernehmbar. Architekturideen dürfen untersucht werden; Quellcode wird nicht
+kopiert.
+
+Quelle: [Repository](https://github.com/reijosirila/loxone-mcp-server),
+[Tool-Definitionen](https://github.com/reijosirila/loxone-mcp-server/blob/main/src/tools/loxone.ts),
+[Connection Manager](https://github.com/reijosirila/loxone-mcp-server/blob/main/src/tools/loxone-system/services/ConnectionManager.ts)
+
+### 4.2 `avrabe/mcp-loxone`
+
+- **Technik:** asynchrones Rust, PulseEngine-MCP-Framework, optional zahlreiche
+  Speicher-, Monitoring-, Discovery- und Sicherheitsmodule
+- **Transport:** stdio, HTTP/SSE und Streamable HTTP
+- **Modell:** schreibende Tools und zahlreiche lesende MCP-Ressourcen
+- **Sicherheit:** Validierung, Rate Limits, TLS, Credential Registry und
+  verschiedene Authentifizierungswege
+- **Tests:** umfangreiche Unit-, Integrations-, Protokoll- und optionale
+  Live-Miniserver-Tests
+- **Lizenz:** wahlweise MIT oder Apache-2.0
+
+Wertvoll sind die Trennung lesender Ressourcen von schreibenden Tools, strikte
+UUID-/Eingabevalidierung, Request-Kontext, Rate Limiting, Circuit Breaker und
+Mock-basierte Tests. Ein statisches Binary passt grundsätzlich gut zu einem
+LoxBerry-Plugin.
+
+Das Projekt ist für unseren Start deutlich zu groß. Default-Features ziehen
+unter anderem Discovery, InfluxDB und Datenbanken ein. Einige
+Architekturdokumente nennen Module oder Toolzahlen, die im aktuellen Quellbaum
+nicht in dieser Form vorhanden sind. Deshalb eignet es sich als Ideensammlung,
+nicht als Vorlage für einen Komplettimport.
+
+Quelle: [Repository](https://github.com/avrabe/mcp-loxone),
+[README](https://github.com/avrabe/mcp-loxone/blob/main/README.md),
+[Cargo-Konfiguration](https://github.com/avrabe/mcp-loxone/blob/main/Cargo.toml)
+
+### 4.3 `Smarteon/lox-mcp`
+
+- **Technik:** Kotlin Multiplatform, Java 21/JAR sowie Linux-Builds,
+  offizielles Kotlin-MCP-SDK und `loxone-client-kotlin`
+- **Transport:** stdio und HTTP/SSE
+- **Datenmodell:** semantisches Modell aus der Loxone-Strukturdatei plus
+  WebSocket-Zustand
+- **MCP-Modell:** wenige Schreibtools und viele hierarchische Ressourcen;
+  Ressourcen können für Clients mit eingeschränktem Support als Tools
+  gespiegelt werden
+- **Konfiguration:** deklarative YAML-Definition der Tools und Ressourcen
+- **Lizenz:** AGPL-3.0 oder separate kommerzielle Lizenz
+
+Die deklarative Tool-Registry, hierarchische Ressourcen und die Option
+„Resources as Tools“ sind gute Interoperabilitätsideen. Ebenso sinnvoll ist die
+Trennung des Loxone-Adapters vom MCP-Server.
+
+Nicht übernommen werden sollten `send_miniserver_command`, frei templatisierte
+Kommandopfade, der vollständige Projekt-XML-Export oder globale Aktionen über
+Räume/Kategorien in einer ersten Version. Diese Funktionen vergrößern
+Angriffsfläche, Kontextmenge und mögliche Schadenswirkung erheblich. Java 21 ist
+zudem für ein kleines LoxBerry-System eine unnötig schwere Mindestlaufzeit.
+
+Quelle: [Repository](https://github.com/Smarteon/lox-mcp),
+[Tool-Konfiguration](https://github.com/Smarteon/lox-mcp/blob/main/src/commonMain/resources/mcp-config.yaml),
+[Loxone-Adapter](https://github.com/Smarteon/lox-mcp/blob/main/src/commonMain/kotlin/LoxoneAdapter.kt)
+
+### 4.4 `discostu105/lox`
+
+- **Technik:** statisches Rust-CLI ohne Laufzeitabhängigkeit
+- **Ziel:** skript- und agentenfreundliche Loxone-Kommandozeile, kein MCP-Server
+- **Datenzugriff:** Strukturcache, HTTP-Kommandos, WebSocket-Streaming,
+  Tokenauthentifizierung und teilweise System-/Konfigurationszugriffe
+- **Agentenfunktionen:** JSON-Ausgabe, Exitcodes, Dry-run, Trace-ID,
+  nichtinteraktiver Modus, Schemas und verständliche Vorschläge bei mehrdeutigen
+  Namen
+- **Lizenz:** GPL-3.0-or-later und kommerzielle Lizenz; README-Badges waren zum
+  Recherchezeitpunkt nicht vollständig konsistent mit Paketmetadaten/Lizenz
+
+Für unser Tool-Design sind insbesondere strukturierte Fehler, Dry-run,
+Korrelations-IDs, strikte UUID-Prüfung und die explizite Auflösung gleicher Namen
+über Raum oder UUID wertvoll. Das Projekt blockiert außerdem Cross-Origin-
+Redirects und maskiert Secrets in URLs.
+
+Ein universelles Shell-Tool um das CLI herum wäre für unser Produkt trotzdem
+ungeeignet: Es würde MCP-Schemas, Tool-Risiken und serverseitige Autorisierung
+umgehen. Auch Konfigurationsdownload, Restore, FTP und allgemeine Systembefehle
+gehören nicht in den MVP.
+
+Quelle: [Repository](https://github.com/discostu105/lox),
+[Agentenleitfaden](https://github.com/discostu105/lox/blob/main/docs/guides/ai-agents.md),
+[Architektur](https://github.com/discostu105/lox/blob/main/docs/architecture.md)
+
+### 4.5 `ivantichy/loxone-mcp-proxy`
+
+- **Technik:** JavaScript auf Node.js 20, ohne externe Runtime-Abhängigkeiten
+- **Ziel:** stabile stdio-Brücke zum nativen Loxone-MCP-Server
+- **Aufgaben:** rotierendes Loxone-Relay auflösen, OAuth 2.1 mit PKCE
+  nichtinteraktiv durchführen, Tokens erneuern und Sitzungen wiederherstellen
+- **Sicherheit:** nur HTTPS-Redirects, dedizierter Benutzer, Token-Cache mit
+  restriktiven Rechten, Logs auf stderr
+- **Lizenz:** MIT
+
+Das Projekt erklärt wichtige Eigenheiten des nativen Loxone-MCP-Pfads:
+Relay-Adressen können wechseln, das OAuth-`resource` ist eine Audience und nicht
+zwingend die tatsächlich erreichbare Adresse, und Verbindungs-/Tokenfehler
+benötigen getrennte Wiederherstellung.
+
+Unser LoxBerry-Dienst hat selbst eine stabile Adresse und benötigt den Proxy
+nicht. Übertragbar sind jedoch HTTPS-only-Redirectvalidierung, rotierende
+Refresh-Tokens, gecachte Discovery, begrenzte Wiederholungen und die strikte
+Trennung von Protokollausgabe und Logs. Das automatisierte Absenden eines
+HTML-Loginformulars ist empfindlich gegenüber Änderungen und sollte nicht die
+primäre Architektur unseres Servers werden.
+
+Quelle: [Repository](https://github.com/ivantichy/loxone-mcp-proxy),
+[OAuth-Implementierung](https://github.com/ivantichy/loxone-mcp-proxy/blob/main/src/loxoneAuth.js),
+[Resolver](https://github.com/ivantichy/loxone-mcp-proxy/blob/main/src/resolver.js)
+
+## 5. LoxBerry-Plattform
+
+Das aktuelle V4-Sample-Plugin bestätigt die maßgeblichen Paket- und
+Lifecycle-Konventionen:
+
+- `plugin.cfg`, `release.cfg` und `prerelease.cfg` liegen im Paket-Root.
+- `AUTHOR.NAME`, `AUTHOR.EMAIL`, `PLUGIN.NAME` und `PLUGIN.FOLDER` werden nach
+  dem ersten Release zu stabilen Update-Identitäten.
+- `FOLDER` kann bei der Installation einen numerischen Suffix erhalten; Code
+  darf den tatsächlichen Ordner nicht hardcodieren.
+- Konfiguration, Daten, Logs, Binärdateien, Templates und Webfrontend verwenden
+  die von LoxBerry bereitgestellten Pfade.
+- Installationsschritte laufen teils als `loxberry`, Root-Hooks nur für eng
+  begrenzte Systemarbeiten.
+- Ein Boot-Daemon muss schnell zurückkehren und lang laufende Prozesse im
+  Hintergrund beziehungsweise über einen Dienst starten.
+- Die Weboberfläche soll das LoxBerry Design System, native Übersetzungen und
+  LoxBerry-Logging nutzen.
+- Plugin-Logs liegen in der LoxBerry-Logverwaltung; temporäre Logpfade können
+  RAM-basiert und nach einem Neustart leer sein.
+
+Die ältere Node.js-Anleitung setzt das zusätzliche Express-Server-Plugin voraus
+und routet Pluginpfade über Port 3300. Diese Abhängigkeit ist für einen
+sicherheitskritischen MCP-Kerndienst nicht ideal. Ein eigener, auf Loopback
+gebundener Dienst hinter einem gezielten Apache-Reverse-Proxy ist konzeptionell
+robuster; die konkrete Integration muss auf einem LoxBerry geprüft werden.
+
+Quelle: [LoxBerry V4 Sample Plugin](https://github.com/mschlenstedt/LoxBerry-Plugin-SamplePlugin-V4),
+[LoxBerry Entwicklerübersicht](https://wiki.loxberry.de/entwickler/start),
+[Node.js Pluginentwicklung](https://wiki.loxberry.de/entwickler/node_js_plugin_entwicklung)
+
+## 6. MCP-Anforderungen
+
+Für HTTP-Server ist Streamable HTTP der aktuelle Standardtransport. Der Server
+muss einen gemeinsamen GET-/POST-Endpunkt anbieten, den `Origin`-Header gegen
+DNS-Rebinding prüfen und jede Verbindung authentifizieren. Die stabile
+MCP-Spezifikation ist zum Recherchestand `2025-11-25`; die Revision
+`2026-07-28` ist noch Release Candidate und darf nicht die einzige unterstützte
+Version sein.
+
+Die Autorisierungsspezifikation verlangt für geschützte HTTP-Ressourcen OAuth-
+Discovery über Protected Resource Metadata, OAuth 2.1, PKCE, Resource Indicators
+und an die Server-Audience gebundene Tokens. Tokens für den MCP-Server dürfen
+nicht als Token-Passthrough an den Miniserver weitergereicht werden.
+
+Tool-Annotationen (`readOnlyHint`, `destructiveHint`, `idempotentHint`,
+`openWorldHint`) helfen Clients bei der Risikodarstellung, sind aber keine
+Sicherheitsgrenze. Autorisierung und Validierung müssen serverseitig erfolgen.
+
+Das offizielle Python-SDK ist Tier 1, unterstützt Streamable HTTP, typisierte
+Ausgabeschemas und die Einbindung eines OAuth-Token-Verifiers. Es setzt Python
+3.10 oder neuer voraus. Seine stabile v1-Linie befindet sich zum
+Recherchestand im Wartungsmodus, während v2 noch als Vorabversion geführt wird;
+eine Implementierung muss deshalb die gewählte Hauptversion und alle
+Abhängigkeiten explizit fixieren.
+
+Python passt fachlich gut: MCP-, HTTP- und WebSocket-Verarbeitung sind in diesem
+Plugin überwiegend I/O-lastig, nicht rechenintensiv. Es gibt auch keinen
+technischen Konflikt mit den Perl-/PHP-Bestandteilen von LoxBerry, wenn der
+Python-Dienst als eigener unprivilegierter Prozess läuft. Die Risiken liegen in
+der Auslieferung: LoxBerry 3 kann auf Debian 11 oder Debian 12 betrieben werden;
+Debian 11 liefert standardmäßig Python 3.9 und erfüllt damit die SDK-Anforderung
+nicht. Debian 12 erzwingt für das System-Python PEP 668, weshalb
+Plugin-Abhängigkeiten in ein eigenes virtuelles Environment gehören. Zusätzlich
+müssen Wheels für alle unterstützten Architekturen verfügbar sein; ein
+Compiler- oder Rust-Build auf dem Zielgerät ist kein akzeptabler normaler
+Installationsweg.
+
+Das offizielle Go-SDK ist ebenfalls Tier 1, unterstützt Streamable HTTP und
+mehrere Protokollversionen. Ein statisches Go-Binary vereinfacht Installation,
+Start und Architekturpaketierung, erhöht aber den Implementierungsaufwand und
+bietet weniger dynamische Schema-Ergonomie. Das Rust-SDK ist Tier 2.
+
+Quelle: [MCP-Transporte](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports),
+[MCP-Autorisierung](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization),
+[MCP-SDKs](https://modelcontextprotocol.io/docs/sdk),
+[MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk),
+[MCP Go SDK](https://github.com/modelcontextprotocol/go-sdk)
+
+## 7. Lizenzbewertung
+
+| Projekt/Quelle | Lizenzlage | Konsequenz für dieses Apache-2.0-Projekt |
+| --- | --- | --- |
+| `reijosirila/loxone-mcp-server` | AGPL-3.0 | Konzepte analysieren, keinen Code übernehmen |
+| `avrabe/mcp-loxone` | MIT oder Apache-2.0 | Codeübernahme prinzipiell möglich, aber nur gezielt mit Attribution und Herkunftsnachweis |
+| `Smarteon/lox-mcp` | AGPL-3.0 oder kommerziell | Konzepte analysieren, keinen Code ohne passende Lizenz übernehmen |
+| `discostu105/lox` | GPL-3.0-or-later und kommerziell | Konzepte analysieren, keinen Code übernehmen |
+| `ivantichy/loxone-mcp-proxy` | MIT | gezielte Übernahme prinzipiell möglich, Attribution erforderlich |
+| LoxBerry V4 Sample Plugin | keine erkannte Repository-Lizenz | Struktur als Dokumentation verwenden; Code nicht ungeprüft kopieren |
+| LoxBerry Wiki | Seite nennt Public Domain, sofern nicht anders bezeichnet | Fakten und Konventionen nutzbar; Quelle weiterhin nennen |
+| Loxone-Dokumentation | proprietäre Produktdokumentation | zusammenfassen und verlinken, keine umfangreiche Vervielfältigung |
+
+Für später tatsächlich übernommenen Fremdcode werden Datei, Commit, Lizenz,
+Änderungen und erforderliche Notices im Repository dokumentiert. Diese
+Recherche selbst übernimmt keinen Fremdcode.
+
+## 8. Empfohlene Muster
+
+- ein kleiner, stabiler Tool-Katalog statt vieler überlappender Tools
+- lesende Entdeckung vor jeder schreibenden Aktion
+- UUID als Identität, Name/Raum/Kategorie nur zur Suche und Darstellung
+- Fehler bei mehrdeutigen Namen statt willkürlicher Auswahl
+- typspezifische Actions und Wertebereiche statt freier Befehlsstrings
+- pro Benutzer getrennte Struktur-, Zustands- und Berechtigungscaches
+- WebSocket für aktuelle Zustände, HTTP für Struktur und Befehle
+- strukturierte Ergebnisse, Tool-Ausgabeschemas und Korrelations-ID
+- optionale Vorschau für größere oder riskantere Aktionen
+- kurze Timeouts, begrenzte Retries, Backoff und Circuit Breaker
+- standardmäßig read-only, schreibende Tools separat aktivierbar
+- MCP-Annotationen zusätzlich zu echter serverseitiger Autorisierung
+- Mock-/Fixture-Tests plus wenige gezielte Tests am echten Miniserver
+- isolierter, vollständig fixierter Python-Runtime-Stack oder statisches Binary
+
+## 9. Nicht empfohlene Muster
+
+- optional ungeschützter HTTP-Endpunkt
+- ein allgemeines Shell-, URL-, Pfad- oder Raw-Command-Tool
+- vollständiger Projekt-XML- oder Benutzerexport an das Sprachmodell
+- globale Aktionen auf alle Geräte oder ganze Räume im MVP
+- ein gemeinsamer Cache für Benutzer mit unterschiedlichen Loxone-Rechten
+- Basic-Auth-Zugangsdaten in MCP-Client-Konfiguration oder Prozessargumenten
+- Vertrauen auf Tool-Annotationen oder clientseitige Toolfilter als
+  Sicherheitsgrenze
+- ungeprüftes Folgen von Redirects oder fremden OAuth-Metadaten-URLs
+- persistente Speicherung des Loxone-Passworts, wenn ein erneuerbares Token
+  ausreicht
+- Datenbank, Telemetrie, Dashboards oder Discovery ohne konkreten MVP-Bedarf
+- Übernahme eines Gesamtprojekts mit inkompatibler Lizenz oder veralteten
+  Dokumentationsannahmen
+
+## 10. Offene Forschungsfragen
+
+Folgende Punkte benötigen vor der Implementierung einen reproduzierbaren Spike
+auf echten Zielsystemen:
+
+1. Welche LoxBerry-4-Architekturen sollen das erste Release tatsächlich tragen?
+2. Ist auf allen Zielsystemen Python 3.10 oder neuer vorhanden und lassen sich
+   alle fixierten Abhängigkeiten ohne Kompilierung in ein plugin-eigenes venv
+   installieren?
+3. Wie wird Streamable HTTP einschließlich SSE durch den LoxBerry-Apache ohne
+   Buffering- oder Timeoutprobleme weitergeleitet?
+4. Filtert `LoxApp3.json` bei jeder unterstützten Miniserver-Generation exakt
+   nach dem angemeldeten Benutzer?
+5. Welche Tokenauthentifizierung ist für Gen. 1 und Gen. 2 bei den festgelegten
+   Mindestfirmwares zuverlässig und dokumentiert?
+6. Welche OAuth-Clients müssen für den ersten Release interoperabel sein?
+7. Wie werden LoxBerry-Scopes durch einen LoxBerry-Administrator erteilt und
+   widerrufen, ohne Loxone- und LoxBerry-Rechte zu vermischen?
+8. Wie unterscheiden sich Python- und Go-Prototyp bei Paketgröße, Installation,
+   Startzeit und Speicherbedarf auf der ältesten Zielhardware?
+8. Welche externen HTTPS-/Reverse-Proxy-Varianten können sicher unterstützt und
+   real getestet werden?
+
+Die vorgeschlagene Antwort auf diese Fragen und ein gestufter MVP stehen im
+[Plugin-Konzept](../development/plugin-concept.md).

--- a/docs/research/research-results.md
+++ b/docs/research/research-results.md
@@ -100,6 +100,36 @@ administrativen Rechte auf dem LoxBerry. LoxBerry-Funktionen benötigen daher
 eine eigene, explizite Autorisierung. Diese Grenze ist die wichtigste
 zusätzliche Sicherheitsanforderung unseres Projekts.
 
+### Authentifizierung der allgemeinen Miniserver-API
+
+Transportverschlüsselung und Authentifizierung sind getrennt zu betrachten:
+
+| Verfahren | Gen. 1 | Gen. 2/Compact | Bewertung für das Plugin |
+| --- | --- | --- | --- |
+| HTTP/WS | ja | weiterhin möglich | nur für Gen. 1 und nur lokal verwenden |
+| HTTPS/WSS | nein | ja | für Gen. 2 zwingend verwenden und Zertifikat prüfen |
+| HTTP Basic Auth | für Debug/Test weiterhin vorhanden | für Debug/Test weiterhin vorhanden | vollständig ausschließen |
+| Loxone Legacy-Token | vorhanden, seit 10.2 deprecated | vorhanden, seit 10.2 deprecated | nicht neu implementieren |
+| Loxone JWT | seit Firmware 10.2 | seit Firmware 10.2 | gemeinsames primäres Authverfahren |
+| HMAC SHA1/SHA256 | ja, Algorithmus wird von `getkey2` gemeldet | ja | dynamisch nach Serverantwort verwenden |
+| RSA/AES Command Encryption | ja; Ersatz für fehlendes vollständiges TLS | möglich, bei TLS ab 11.2 nicht zwingend | Gen. 1 für Auth- und Steuerkommandos; Gen. 2 verlässt sich auf geprüftes TLS |
+| OAuth des nativen MCP-Servers | nein | ab nativem MCP-Plugin vorhanden | nicht für den direkten API-Adapter verwenden |
+
+Die Aussage „Gen. 1 unterstützt keine Kryptografie“ trifft damit nicht zu.
+Richtig ist: Gen. 1 unterstützt keine vollständige TLS-Transportverschlüsselung.
+Loxone stellt stattdessen Hashing sowie RSA-/AES-basierte Command Encryption
+bereit. Diese schützt jedoch nicht automatisch Strukturdateien, Statusereignisse
+und sämtliche Antworten. Gen.-1-Zugriff bleibt deshalb auf das lokale Netz
+beschränkt.
+
+Die offizielle API-Dokumentation nennt Tokenauthentifizierung seit Version 9.0,
+JWT seit 10.2 und die Abschaffung der regulären passwortbasierten Anmeldung seit
+9.3. HTTP Basic Auth bleibt nur für Debugging und Tests verfügbar und wird für
+das Produkt nicht berücksichtigt.
+
+Quelle: [Loxone: Communicating with the Miniserver](https://www.loxone.com/wp-content/uploads/datasheets/CommunicatingWithMiniserver.pdf),
+[Loxone Web Services](https://www.loxone.com/enen/kb/web-services/)
+
 ## 4. Vergleichsprojekte
 
 ### 4.1 `reijosirila/loxone-mcp-server`

--- a/docs/research/research-results.md
+++ b/docs/research/research-results.md
@@ -394,10 +394,10 @@ auf echten Zielsystemen:
    ein plugin-eigenes venv installieren?
 3. Wie wird Streamable HTTP einschließlich SSE durch den LoxBerry-Apache ohne
    Buffering- oder Timeoutprobleme weitergeleitet?
-4. Filtert `LoxApp3.json` bei jeder unterstützten Miniserver-Generation exakt
-   nach dem angemeldeten Benutzer?
-5. Welche Tokenauthentifizierung ist für Gen. 1 und Gen. 2 bei den festgelegten
-   Mindestfirmwares zuverlässig und dokumentiert?
+4. Filtert `LoxApp3.json` bei Gen. 1 und in unabhängigen öffentlichen
+   Gen.-2-Betatests exakt nach dem angemeldeten Benutzer?
+5. Welche Tokenauthentifizierung ist für Gen. 1 lokal und für Gen. 2 durch
+   reproduzierbare Beta-Berichte bei den jeweiligen Firmwareständen bestätigt?
 6. Welche OAuth-Clients müssen für den ersten Release interoperabel sein?
 7. Wie werden LoxBerry-Scopes durch einen LoxBerry-Administrator erteilt und
    widerrufen, ohne Loxone- und LoxBerry-Rechte zu vermischen?

--- a/docs/research/research-results.md
+++ b/docs/research/research-results.md
@@ -272,9 +272,19 @@ Quelle: [LoxBerry V4 Sample Plugin](https://github.com/mschlenstedt/LoxBerry-Plu
 Für HTTP-Server ist Streamable HTTP der aktuelle Standardtransport. Der Server
 muss einen gemeinsamen GET-/POST-Endpunkt anbieten, den `Origin`-Header gegen
 DNS-Rebinding prüfen und jede Verbindung authentifizieren. Die stabile
-MCP-Spezifikation ist zum Recherchestand `2025-11-25`; die Revision
-`2026-07-28` ist noch Release Candidate und darf nicht die einzige unterstützte
-Version sein.
+MCP-Spezifikation ist zum Recherchestand `2025-11-25`. Die Revision
+`2026-07-28` wird im offiziellen Repository weiterhin als Release Candidate
+geführt, obwohl ihre Finalisierung ursprünglich für den 28. Juli 2026 geplant
+war. Sie verändert den Protokollkern grundlegend: stateless Requests ersetzen
+den bisherigen Initialisierungs-/Session-Lifecycle, `server/discover` übernimmt
+die Erkennung und Extensions werden stärker vom Kern getrennt.
+
+Für das Plugin ist deshalb `2025-11-25` das richtige Produktionsziel. Der
+stabile Python-SDK-Zweig v1 unterstützt diese Version; Python-SDK v2 ist zum
+Recherchestand noch Alpha. `2026-07-28` sollte erst nach finaler Spezifikation,
+stabilem Python-SDK, erfolgreicher Conformance-Suite und realen Clienttests
+hinzukommen. Versionsaushandlung muss `2025-11-25` während einer dokumentierten
+Übergangsphase erhalten.
 
 Die Autorisierungsspezifikation verlangt für geschützte HTTP-Ressourcen OAuth-
 Discovery über Protected Resource Metadata, OAuth 2.1, PKCE, Resource Indicators
@@ -316,6 +326,7 @@ bietet weniger dynamische Schema-Ergonomie. Das Rust-SDK ist Tier 2.
 Quelle: [MCP-Transporte](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports),
 [MCP-Autorisierung](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization),
 [MCP-SDKs](https://modelcontextprotocol.io/docs/sdk),
+[MCP-Spezifikations-Releases](https://github.com/modelcontextprotocol/modelcontextprotocol/releases),
 [MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk),
 [MCP Go SDK](https://github.com/modelcontextprotocol/go-sdk),
 [LoxBerry-Installation](https://wiki.loxberry.de/installation_von_loxberry/die_installation_von_loxberry/start),

--- a/docs/research/research-results.md
+++ b/docs/research/research-results.md
@@ -24,15 +24,15 @@ getrennten Struktur-/Zustandssicht und einem kleinen, standardmäßig lesenden
 Tool-Inventar. Beliebige Miniserver-Kommandos, globale Raumaktionen und
 allgemeiner Shellzugriff gehören nicht in die erste Version.
 
-Als technische Basis ist Python besonders prüfenswert: Der Dienst ist vor allem
-I/O-lastig, das offizielle MCP-Python-SDK ist Tier 1 und bringt Streamable HTTP,
-Schemas sowie die Resource-Server-Seite der OAuth-Integration mit. Python ist
-jedoch nur dann die einfachere Lösung, wenn die festgelegte LoxBerry-Basis
-mindestens Python 3.10 und installierbare ARM-Pakete für alle fixierten
-Abhängigkeiten bietet. Andernfalls bleibt ein statisches Go-Binary die robustere
-Paketierungsoption. Diese Entscheidung muss vor der Implementierung durch einen
-kleinen Zielsystem-, Transport-, Abhängigkeits- und OAuth-Spike bestätigt
-werden.
+Als technische Basis wird für die erste Referenzplattform Python bevorzugt: Das
+Projekt zielt zunächst auf LoxBerry 4 unter Debian 13 (Trixie) mit Python 3.13.
+Der Dienst ist vor allem I/O-lastig, das offizielle MCP-Python-SDK ist Tier 1
+und bringt Streamable HTTP, Schemas sowie die Resource-Server-Seite der
+OAuth-Integration mit. Ein Zielsystem-, Transport-, Abhängigkeits- und
+OAuth-Spike muss noch die verfügbaren Wheels und den Ressourcenbedarf auf den
+konkret unterstützten Architekturen bestätigen. Go bleibt eine
+Paketierungsalternative, ist aber für den MVP keine gleichrangige
+Vorentscheidung mehr.
 
 ## 2. Quellenlage und Grenzen
 
@@ -295,14 +295,18 @@ Abhängigkeiten explizit fixieren.
 Python passt fachlich gut: MCP-, HTTP- und WebSocket-Verarbeitung sind in diesem
 Plugin überwiegend I/O-lastig, nicht rechenintensiv. Es gibt auch keinen
 technischen Konflikt mit den Perl-/PHP-Bestandteilen von LoxBerry, wenn der
-Python-Dienst als eigener unprivilegierter Prozess läuft. Die Risiken liegen in
-der Auslieferung: LoxBerry 3 kann auf Debian 11 oder Debian 12 betrieben werden;
-Debian 11 liefert standardmäßig Python 3.9 und erfüllt damit die SDK-Anforderung
-nicht. Debian 12 erzwingt für das System-Python PEP 668, weshalb
-Plugin-Abhängigkeiten in ein eigenes virtuelles Environment gehören. Zusätzlich
-müssen Wheels für alle unterstützten Architekturen verfügbar sein; ein
-Compiler- oder Rust-Build auf dem Zielgerät ist kein akzeptabler normaler
-Installationsweg.
+Python-Dienst als eigener unprivilegierter Prozess läuft.
+
+Als erste Referenzbasis wird LoxBerry 4 unter Debian 13 (Trixie) festgelegt.
+Debian 13 liefert Python 3.13 und erfüllt damit die Anforderung des MCP-SDKs.
+Plugin-Abhängigkeiten gehören wegen der Trennung vom verwalteten System-Python
+trotzdem in ein eigenes virtuelles Environment. Zusätzlich müssen Wheels für
+alle unterstützten Architekturen verfügbar sein; ein Compiler- oder Rust-Build
+auf dem Zielgerät ist kein akzeptabler normaler Installationsweg.
+
+Ältere LoxBerry-3-/Debian-11-Systeme liefern möglicherweise nur Python 3.9.
+Ihre Unterstützung ist daher eine spätere, eigene Kompatibilitätsentscheidung
+und blockiert den Python-basierten MVP auf LoxBerry 4 nicht.
 
 Das offizielle Go-SDK ist ebenfalls Tier 1, unterstützt Streamable HTTP und
 mehrere Protokollversionen. Ein statisches Go-Binary vereinfacht Installation,
@@ -313,7 +317,9 @@ Quelle: [MCP-Transporte](https://modelcontextprotocol.io/specification/2025-11-2
 [MCP-Autorisierung](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization),
 [MCP-SDKs](https://modelcontextprotocol.io/docs/sdk),
 [MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk),
-[MCP Go SDK](https://github.com/modelcontextprotocol/go-sdk)
+[MCP Go SDK](https://github.com/modelcontextprotocol/go-sdk),
+[LoxBerry-Installation](https://wiki.loxberry.de/installation_von_loxberry/die_installation_von_loxberry/start),
+[Debian-13-Versionshinweise](https://www.debian.org/releases/trixie/release-notes/whats-new.de.html)
 
 ## 7. Lizenzbewertung
 
@@ -371,10 +377,10 @@ Recherche selbst übernimmt keinen Fremdcode.
 Folgende Punkte benötigen vor der Implementierung einen reproduzierbaren Spike
 auf echten Zielsystemen:
 
-1. Welche LoxBerry-4-Architekturen sollen das erste Release tatsächlich tragen?
-2. Ist auf allen Zielsystemen Python 3.10 oder neuer vorhanden und lassen sich
-   alle fixierten Abhängigkeiten ohne Kompilierung in ein plugin-eigenes venv
-   installieren?
+1. Welche LoxBerry-4-/Debian-13-Architekturen soll das erste Release tatsächlich
+   tragen?
+2. Lassen sich alle fixierten Python-3.13-Abhängigkeiten ohne Kompilierung in
+   ein plugin-eigenes venv installieren?
 3. Wie wird Streamable HTTP einschließlich SSE durch den LoxBerry-Apache ohne
    Buffering- oder Timeoutprobleme weitergeleitet?
 4. Filtert `LoxApp3.json` bei jeder unterstützten Miniserver-Generation exakt
@@ -384,9 +390,9 @@ auf echten Zielsystemen:
 6. Welche OAuth-Clients müssen für den ersten Release interoperabel sein?
 7. Wie werden LoxBerry-Scopes durch einen LoxBerry-Administrator erteilt und
    widerrufen, ohne Loxone- und LoxBerry-Rechte zu vermischen?
-8. Wie unterscheiden sich Python- und Go-Prototyp bei Paketgröße, Installation,
-   Startzeit und Speicherbedarf auf der ältesten Zielhardware?
-8. Welche externen HTTPS-/Reverse-Proxy-Varianten können sicher unterstützt und
+8. Bleiben Paketgröße, Startzeit und Speicherbedarf des Python-Prototyps auf der
+   ältesten unterstützten LoxBerry-4-Hardware im festgelegten Budget?
+9. Welche externen HTTPS-/Reverse-Proxy-Varianten können sicher unterstützt und
    real getestet werden?
 
 Die vorgeschlagene Antwort auf diese Fragen und ein gestufter MVP stehen im


### PR DESCRIPTION
## Änderungen

- Recherche zum nativen Loxone-MCP-Server und fünf Vergleichsprojekten zusammengefasst
- LoxBerry-Plugin- und aktuelle MCP-Vorgaben einschließlich Lizenzgrenzen dokumentiert
- Sicherheits-, Autorisierungs-, Tool-, Betriebs- und Testkonzept für das Plugin erstellt
- Python als bevorzugten Kandidaten dokumentiert, sofern Runtime-, Wheel- und Zielsystem-Spike erfolgreich sind; Go bleibt die Paketierungsalternative
- neue Dokumente im README verlinkt

## Motivation

Das Projekt benötigt vor dem ersten ausführbaren Commit eine überprüfbare Architektur- und Sicherheitsbasis. Besonders Loxone- und LoxBerry-Rechte müssen getrennt bleiben, und allgemeine Raw-/Shell-Kommandos sollen nicht Teil des MVP werden.

## Prüfung

- lokale Markdown-Verweise: PASS
- `git diff --check`: PASS
- Quellen und aktuelle Default-Branches am 2026-08-01 geprüft
- keine Code-, Browser- oder Zielgerätetests erforderlich (reine Dokumentation)

## Nicht enthalten

Die drei bereitgestellten Ausgangsdokumente unter `docs/research` bleiben unverändert und sind nicht Bestandteil dieses PRs.