### PR TITLE
Add phase-zero MCP runtime foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   deterministic:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  deterministic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+      - name: Install
+        run: |
+          python -m pip install --disable-pip-version-check \
+            -r requirements/runtime-arm64.lock -r requirements/dev.lock
+          python -m pip install --disable-pip-version-check --no-deps -e .
+      - name: Test
+        run: python tools/test.py

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 Thumbs.db
 .idea/
 .vscode/
+.venv/
 *.swp
 *~
 
@@ -18,3 +19,8 @@ temp/
 
 # Logs
 *.log
+__pycache__/
+.mypy_cache/
+.pytest_cache/
+.ruff_cache/
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -22,6 +22,19 @@ Das Plugin befindet sich im Aufbau. Installations-, Konfigurations- und Nutzungs
 - [Recherche-Ergebnisse](docs/research/research-results.md)
 - [Beitragen und Git-Workflow](CONTRIBUTING.md)
 
+Die Referenzentwicklung verwendet Python 3.13. Nach dem Anlegen eines lokalen
+virtuellen Environments werden die fixierten Laufzeit- und Testabhängigkeiten
+installiert und das Projekt ohne erneute Abhängigkeitsauflösung eingebunden:
+
+```text
+python -m pip install -r requirements/runtime-arm64.lock -r requirements/dev.lock
+python -m pip install --no-deps -e .
+python tools/test.py
+```
+
+`python tools/test.py` ist der einheitliche lokale und CI-Testbefehl. Er führt
+Formatprüfung, Lint, strikte Typprüfung und die deterministischen Tests aus.
+
 ## Lizenz
 
 Dieses Projekt steht unter der [Apache License 2.0](LICENSE).

--- a/docs/development/adr/0001-phase-0-foundation.md
+++ b/docs/development/adr/0001-phase-0-foundation.md
@@ -130,8 +130,11 @@ Der erste Runtime-Spike wurde am 2026-08-01 auf einem LoxBerry 4 mit Debian 13,
 `aarch64` und Python 3.13.5 ausgeführt. MCP `1.28.1` und alle transitiven
 Abhängigkeiten ließen sich als 29 Binär-Wheels laden und anschließend offline
 installieren. Das Wheelhouse belegte 9 MiB, das vollständige `venv` 51 MiB.
-Startzeit und Idle-RSS werden mit dem Minimaldienst im nächsten ausführbaren
-Arbeitspaket ergänzt.
+
+Der Minimaldienst wurde aus demselben Abhängigkeitssatz fünfmal gestartet. Der
+Health-Endpunkt war nach 4,088 bis 4,386 Sekunden erreichbar. Der RSS lag direkt
+danach zwischen 53.428 und 53.452 KiB und nach zehn Minuten Idle bei 53.448 KiB.
+Damit sind Paket-, Startzeit- und Speichergrenze erfüllt.
 
 ## Folgen
 

--- a/docs/development/adr/0001-phase-0-foundation.md
+++ b/docs/development/adr/0001-phase-0-foundation.md
@@ -1,6 +1,6 @@
 # ADR 0001: Phase-0-Grundarchitektur
 
-- **Status:** Angenommen; Runtime bis zum vollständigen Ressourcen-Spike vorläufig
+- **Status:** Angenommen
 - **Datum:** 2026-08-01
 - **Geltung:** Runtime, Transport, Authentifizierung, Persistenz und erster
   ausführbarer Stand
@@ -138,8 +138,7 @@ Damit sind Paket-, Startzeit- und Speichergrenze erfüllt.
 
 ## Folgen
 
-Python ist nach dem erfolgreichen Wheel-Spike die vorläufige Ausgangsruntime.
-Die Bestätigung und der Verzicht auf einen Go-Vergleich erfolgen erst, wenn auch
-Startzeit und Idle-RSS die festgelegten Grenzen erfüllen. Apache-, Loxone-,
-WebSocket- und OAuth-Aussagen bleiben bis zu den jeweiligen reproduzierbaren
-Spikes als noch nicht real bestätigt gekennzeichnet.
+Python ist nach den erfolgreichen Wheel-, Startzeit- und Idle-RSS-Spikes für die
+Referenzplattform bestätigt; ein vorsorglicher paralleler Go-Build entfällt.
+Apache-, Loxone-, WebSocket- und OAuth-Aussagen bleiben bis zu den jeweiligen
+reproduzierbaren Spikes als noch nicht real bestätigt gekennzeichnet.

--- a/docs/development/plugin-concept.md
+++ b/docs/development/plugin-concept.md
@@ -714,7 +714,7 @@ Support-Matrix.
 | --- | --- | --- |
 | 1 | Plugin-ID und Ordner | festgelegt: `NAME=mcpserver`, `FOLDER=mcpserver`, `TITLE=LoxBerry MCP Server` |
 | 2 | erste CPU-Architektur | festgelegt: LoxBerry 4 auf Debian 13, `arm64` |
-| 3 | Runtime | vorläufig: Python 3.13 und MCP-SDK 1.28.1; Wheel-Spike erfolgreich, Start-/RAM-Gates ausstehend |
+| 3 | Runtime | festgelegt: Python 3.13 und MCP-SDK 1.28.1; Wheel-, Start- und RAM-Gates erfolgreich |
 | 4 | öffentlicher Pluginpfad/Apache | Spike-Kandidat: `/plugins/mcpserver/mcp` plus Root-Discovery; Festlegung erst nach realer Apache-Prüfung |
 | 5 | MCP-OAuth-Clientregistrierung und Sessionpersistenz | festgelegt: öffentliche Registrierung, PKCE S256, opaque Tokens und atomare dateibasierte Persistenz; Clientprüfung ausstehend |
 | 6 | Miniserver-Firmware | Gen. 1 mindestens `17.1.7.27`; Gen.-2-Stände werden durch die öffentliche Beta bestätigt |

--- a/docs/development/plugin-concept.md
+++ b/docs/development/plugin-concept.md
@@ -460,6 +460,34 @@ limits.max_parallel_calls
 audit.retention_days
 ```
 
+### Phase-0-Dienstvariablen
+
+Der ausführbare Phase-0-Dienst liest die folgenden internen Variablen. Sie werden
+später aus der validierten Plugin-Konfiguration in die systemd-Umgebung erzeugt
+und sind kein Ersatz für die Admin-UI:
+
+| Variable | Default | Vertrag |
+| --- | --- | --- |
+| `MCPSERVER_HOST` | `127.0.0.1` | ausschließlich exakt dieser Loopback-Host |
+| `MCPSERVER_PORT` | `8765` | ganzzahlig von `1024` bis `65535`; Apache und Dienst müssen denselben Wert erhalten |
+| `MCPSERVER_ALLOWED_HOSTS` | `127.0.0.1:<Port>,localhost:<Port>` | kommaseparierte exakte Host-/Port-Werte oder ein Host mit `:*`; mindestens ein Eintrag |
+| `MCPSERVER_ALLOWED_ORIGINS` | leer | kommaseparierte kanonische `http`-/`https`-Origins ohne Pfad, Zugangsdaten, Query oder Fragment; Standardports und Unicode-Hostnamen werden nicht als alternative Schreibweise akzeptiert |
+
+Für einen später erzeugten lokalen Apache-Vertrag lautet ein schematisches
+Beispiel:
+
+```text
+MCPSERVER_HOST=127.0.0.1
+MCPSERVER_PORT=8765
+MCPSERVER_ALLOWED_HOSTS=127.0.0.1:8765,loxberry.local
+MCPSERVER_ALLOWED_ORIGINS=https://assistant.example
+```
+
+Origins mit internationalisierten Domains werden in der vom Browser gesendeten
+IDNA-ASCII-Schreibweise eingetragen, beispielsweise
+`https://xn--bcher-kva.example`. Zugangsdaten, Tokens oder Sessionwerte gehören
+in keine dieser Variablen.
+
 ### Secrets und Sessions
 
 - getrennt von normaler Konfiguration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ description = "Local MCP server for LoxBerry and Loxone"
 requires-python = ">=3.13,<3.14"
 license = "Apache-2.0"
 dependencies = [
+    "idna==3.18",
     "mcp==1.28.1",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,47 @@
+[build-system]
+requires = ["setuptools==80.9.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "loxberry-mcpserver"
+version = "0.0.1"
+description = "Local MCP server for LoxBerry and Loxone"
+requires-python = ">=3.13,<3.14"
+license = "Apache-2.0"
+dependencies = [
+    "mcp==1.28.1",
+]
+
+[project.optional-dependencies]
+dev = [
+    "mypy==1.17.1",
+    "pytest==8.4.2",
+    "pytest-asyncio==1.2.0",
+    "ruff==0.12.12",
+]
+
+[project.scripts]
+mcpserver = "mcpserver.server:main"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+addopts = "-ra"
+testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py313"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "SIM", "RUF"]
+
+[tool.mypy]
+python_version = "3.13"
+strict = true
+packages = ["mcpserver"]
+mypy_path = "src"

--- a/requirements/dev.lock
+++ b/requirements/dev.lock
@@ -1,6 +1,7 @@
 # Exact additions for the deterministic development and CI environment.
 colorama==0.4.6
 iniconfig==2.3.0
+librt==0.13.0; python_version >= "3.13"
 mypy==1.17.1
 mypy-extensions==1.1.0
 packaging==26.2

--- a/requirements/dev.lock
+++ b/requirements/dev.lock
@@ -1,0 +1,12 @@
+# Exact additions for the deterministic development and CI environment.
+colorama==0.4.6
+iniconfig==2.3.0
+mypy==1.17.1
+mypy-extensions==1.1.0
+packaging==26.2
+pathspec==1.1.1
+pluggy==1.6.0
+pygments==2.20.0
+pytest==8.4.2
+pytest-asyncio==1.2.0
+ruff==0.12.12

--- a/requirements/runtime-arm64.lock
+++ b/requirements/runtime-arm64.lock
@@ -1,0 +1,33 @@
+# Generated from the successful Debian 13 / Python 3.13 arm64 wheel spike.
+# Keep every transitive runtime dependency exact. Release packaging installs
+# these packages from an offline wheelhouse with --no-index and --no-deps.
+annotated-types==0.8.0
+anyio==4.14.2
+attrs==26.1.0
+certifi==2026.7.22
+cffi==2.1.0
+click==8.4.2
+cryptography==50.0.0
+h11==0.16.0
+httpcore==1.0.9
+httpx==0.28.1
+httpx-sse==0.4.3
+idna==3.18
+jsonschema==4.26.0
+jsonschema-specifications==2025.9.1
+mcp==1.28.1
+pycparser==3.0
+pydantic==2.13.4
+pydantic-core==2.46.4
+pydantic-settings==2.14.2
+pyjwt==2.13.0
+python-dotenv==1.2.2
+python-multipart==0.0.32
+pywin32==312; sys_platform == "win32"
+referencing==0.37.0
+rpds-py==2026.6.3
+sse-starlette==3.4.6
+starlette==1.3.1
+typing-extensions==4.16.0
+typing-inspection==0.4.2
+uvicorn==0.52.0

--- a/src/mcpserver/__init__.py
+++ b/src/mcpserver/__init__.py
@@ -1,0 +1,10 @@
+"""LoxBerry MCP Server package."""
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("loxberry-mcpserver")
+except PackageNotFoundError:  # pragma: no cover - source tree without installation
+    __version__ = "0.0.0"
+
+__all__ = ["__version__"]

--- a/src/mcpserver/server.py
+++ b/src/mcpserver/server.py
@@ -1,0 +1,57 @@
+"""Minimal Phase-0 MCP transport with no released domain tools."""
+
+from __future__ import annotations
+
+from typing import Final
+
+from mcp.server.fastmcp import FastMCP
+from mcp.server.transport_security import TransportSecuritySettings
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+from mcpserver import __version__
+from mcpserver.settings import ServerSettings
+
+SERVER_NAME: Final = "LoxBerry MCP Server"
+
+
+def create_server(settings: ServerSettings) -> FastMCP:
+    """Create the MCP server from already validated settings."""
+    transport_security = TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=list(settings.allowed_hosts),
+        allowed_origins=list(settings.allowed_origins),
+    )
+    server = FastMCP(
+        SERVER_NAME,
+        host=settings.host,
+        port=settings.port,
+        streamable_http_path="/mcp",
+        json_response=True,
+        stateless_http=True,
+        transport_security=transport_security,
+    )
+
+    @server.custom_route(  # type: ignore[misc]
+        "/healthz", methods=["GET"], include_in_schema=False
+    )
+    async def health(_: Request) -> Response:
+        return JSONResponse(
+            {
+                "ok": True,
+                "service": "mcpserver",
+                "version": __version__,
+            }
+        )
+
+    return server
+
+
+def main() -> None:
+    """Run Streamable HTTP on the configured loopback port."""
+    settings = ServerSettings.from_environment()
+    create_server(settings).run(transport="streamable-http")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/mcpserver/server.py
+++ b/src/mcpserver/server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Final
 
 from mcp.server.fastmcp import FastMCP
@@ -13,6 +14,30 @@ from mcpserver import __version__
 from mcpserver.settings import ServerSettings
 
 SERVER_NAME: Final = "LoxBerry MCP Server"
+_TRANSPORT_LOGGER_NAME: Final = "mcp.server.transport_security"
+_SENSITIVE_REJECTION_PREFIXES: Final = (
+    "Invalid Host header:",
+    "Invalid Origin header:",
+    "Invalid Content-Type header:",
+)
+
+
+class _RedactRejectedTransportHeader(logging.Filter):
+    """Prevent rejected attacker-controlled headers from reaching service logs."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        message = record.getMessage()
+        for prefix in _SENSITIVE_REJECTION_PREFIXES:
+            if message.startswith(prefix):
+                record.msg = f"{prefix} [redacted]"
+                record.args = ()
+                break
+        return True
+
+
+_transport_logger = logging.getLogger(_TRANSPORT_LOGGER_NAME)
+if not any(isinstance(item, _RedactRejectedTransportHeader) for item in _transport_logger.filters):
+    _transport_logger.addFilter(_RedactRejectedTransportHeader())
 
 
 def create_server(settings: ServerSettings) -> FastMCP:

--- a/src/mcpserver/server.py
+++ b/src/mcpserver/server.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Final
 
 from mcp.server.fastmcp import FastMCP
-from mcp.server.transport_security import TransportSecuritySettings
+from mcp.server.transport_security import TransportSecurityMiddleware, TransportSecuritySettings
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 
@@ -22,6 +22,7 @@ def create_server(settings: ServerSettings) -> FastMCP:
         allowed_hosts=list(settings.allowed_hosts),
         allowed_origins=list(settings.allowed_origins),
     )
+    transport_guard = TransportSecurityMiddleware(transport_security)
     server = FastMCP(
         SERVER_NAME,
         host=settings.host,
@@ -35,7 +36,10 @@ def create_server(settings: ServerSettings) -> FastMCP:
     @server.custom_route(  # type: ignore[misc]
         "/healthz", methods=["GET"], include_in_schema=False
     )
-    async def health(_: Request) -> Response:
+    async def health(request: Request) -> Response:
+        rejection = await transport_guard.validate_request(request)
+        if rejection is not None:
+            return rejection
         return JSONResponse(
             {
                 "ok": True,

--- a/src/mcpserver/settings.py
+++ b/src/mcpserver/settings.py
@@ -29,7 +29,13 @@ def _validate_origins(origins: tuple[str, ...]) -> tuple[str, ...]:
         parsed = urlsplit(origin)
         if parsed.scheme not in {"http", "https"} or not parsed.netloc:
             raise ValueError("MCPSERVER_ALLOWED_ORIGINS must contain HTTP(S) origins")
-        if parsed.path not in {"", "/"} or parsed.query or parsed.fragment or parsed.username:
+        if (
+            parsed.path not in {"", "/"}
+            or parsed.query
+            or parsed.fragment
+            or parsed.username is not None
+            or parsed.password is not None
+        ):
             raise ValueError(
                 "MCPSERVER_ALLOWED_ORIGINS entries must not contain paths or credentials"
             )

--- a/src/mcpserver/settings.py
+++ b/src/mcpserver/settings.py
@@ -30,7 +30,7 @@ def _validate_origins(origins: tuple[str, ...]) -> tuple[str, ...]:
         if parsed.scheme not in {"http", "https"} or not parsed.netloc:
             raise ValueError("MCPSERVER_ALLOWED_ORIGINS must contain HTTP(S) origins")
         if (
-            parsed.path not in {"", "/"}
+            parsed.path != ""
             or parsed.query
             or parsed.fragment
             or parsed.username is not None

--- a/src/mcpserver/settings.py
+++ b/src/mcpserver/settings.py
@@ -1,0 +1,74 @@
+"""Validated process settings with secure local defaults."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from urllib.parse import urlsplit
+
+
+def _parse_port(value: str) -> int:
+    try:
+        port = int(value, 10)
+    except ValueError as exc:
+        raise ValueError("MCPSERVER_PORT must be an integer") from exc
+    if not 1024 <= port <= 65535:
+        raise ValueError("MCPSERVER_PORT must be between 1024 and 65535")
+    return port
+
+
+def _parse_csv(value: str, *, setting: str) -> tuple[str, ...]:
+    entries = tuple(item.strip() for item in value.split(",") if item.strip())
+    if any(any(ord(character) < 32 for character in item) for item in entries):
+        raise ValueError(f"{setting} contains a control character")
+    return entries
+
+
+def _validate_origins(origins: tuple[str, ...]) -> tuple[str, ...]:
+    for origin in origins:
+        parsed = urlsplit(origin)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError("MCPSERVER_ALLOWED_ORIGINS must contain HTTP(S) origins")
+        if parsed.path not in {"", "/"} or parsed.query or parsed.fragment or parsed.username:
+            raise ValueError(
+                "MCPSERVER_ALLOWED_ORIGINS entries must not contain paths or credentials"
+            )
+    return origins
+
+
+@dataclass(frozen=True, slots=True)
+class ServerSettings:
+    """Runtime settings for the local MCP process."""
+
+    host: str
+    port: int
+    allowed_hosts: tuple[str, ...]
+    allowed_origins: tuple[str, ...]
+
+    @classmethod
+    def from_environment(cls) -> ServerSettings:
+        port = _parse_port(os.getenv("MCPSERVER_PORT", "8765"))
+        host = os.getenv("MCPSERVER_HOST", "127.0.0.1").strip()
+        if host != "127.0.0.1":
+            raise ValueError("MCPSERVER_HOST must remain 127.0.0.1")
+
+        default_hosts = f"127.0.0.1:{port},localhost:{port}"
+        allowed_hosts = _parse_csv(
+            os.getenv("MCPSERVER_ALLOWED_HOSTS", default_hosts),
+            setting="MCPSERVER_ALLOWED_HOSTS",
+        )
+        if not allowed_hosts:
+            raise ValueError("MCPSERVER_ALLOWED_HOSTS must not be empty")
+
+        allowed_origins = _validate_origins(
+            _parse_csv(
+                os.getenv("MCPSERVER_ALLOWED_ORIGINS", ""),
+                setting="MCPSERVER_ALLOWED_ORIGINS",
+            )
+        )
+        return cls(
+            host=host,
+            port=port,
+            allowed_hosts=allowed_hosts,
+            allowed_origins=allowed_origins,
+        )

--- a/src/mcpserver/settings.py
+++ b/src/mcpserver/settings.py
@@ -68,8 +68,17 @@ def _canonical_hostname(host: str, *, setting: str) -> str:
             raise ValueError(f"{setting} contains an invalid hostname") from exc
 
         labels = canonical.split(".")
+        try:
+            valid_alabels = all(
+                not label.lower().startswith("xn--")
+                or label.encode("ascii").decode("idna").encode("idna").decode("ascii") == label
+                for label in labels
+            )
+        except UnicodeError:
+            valid_alabels = False
         if (
             len(canonical) > 253
+            or not valid_alabels
             or any(not label or len(label) > 63 for label in labels)
             or any(label.startswith("-") or label.endswith("-") for label in labels)
             or any(

--- a/src/mcpserver/settings.py
+++ b/src/mcpserver/settings.py
@@ -27,7 +27,7 @@ def _parse_csv(value: str, *, setting: str) -> tuple[str, ...]:
 def _validate_origins(origins: tuple[str, ...]) -> tuple[str, ...]:
     for origin in origins:
         parsed = urlsplit(origin)
-        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc or parsed.hostname is None:
             raise ValueError("MCPSERVER_ALLOWED_ORIGINS must contain HTTP(S) origins")
         if (
             parsed.path != ""
@@ -39,6 +39,19 @@ def _validate_origins(origins: tuple[str, ...]) -> tuple[str, ...]:
             raise ValueError(
                 "MCPSERVER_ALLOWED_ORIGINS entries must not contain paths or credentials"
             )
+        try:
+            port = parsed.port
+        except ValueError as exc:
+            raise ValueError("MCPSERVER_ALLOWED_ORIGINS contains an invalid port") from exc
+
+        host = parsed.hostname
+        if ":" in host:
+            host = f"[{host}]"
+        default_port = 80 if parsed.scheme == "http" else 443
+        authority = host if port in {None, default_port} else f"{host}:{port}"
+        canonical = f"{parsed.scheme}://{authority}"
+        if origin != canonical:
+            raise ValueError("MCPSERVER_ALLOWED_ORIGINS entries must use canonical origins")
     return origins
 
 

--- a/src/mcpserver/settings.py
+++ b/src/mcpserver/settings.py
@@ -7,6 +7,8 @@ import os
 from dataclasses import dataclass
 from urllib.parse import urlsplit
 
+import idna
+
 
 def _parse_port(value: str) -> int:
     try:
@@ -63,22 +65,13 @@ def _canonical_hostname(host: str, *, setting: str) -> str:
         if looks_numeric or host.endswith("."):
             raise ValueError(f"{setting} contains a noncanonical numeric hostname") from None
         try:
-            canonical = host.encode("idna").decode("ascii")
-        except UnicodeError as exc:
+            canonical = idna.encode(host, uts46=True, std3_rules=True).decode("ascii")
+        except idna.IDNAError as exc:
             raise ValueError(f"{setting} contains an invalid hostname") from exc
 
         labels = canonical.split(".")
-        try:
-            valid_alabels = all(
-                not label.lower().startswith("xn--")
-                or label.encode("ascii").decode("idna").encode("idna").decode("ascii") == label
-                for label in labels
-            )
-        except UnicodeError:
-            valid_alabels = False
         if (
             len(canonical) > 253
-            or not valid_alabels
             or any(not label or len(label) > 63 for label in labels)
             or any(label.startswith("-") or label.endswith("-") for label in labels)
             or any(

--- a/src/mcpserver/settings.py
+++ b/src/mcpserver/settings.py
@@ -25,6 +25,75 @@ def _parse_csv(value: str, *, setting: str) -> tuple[str, ...]:
     return entries
 
 
+def _canonical_hostname(host: str, *, setting: str) -> str:
+    try:
+        return str(ipaddress.ip_address(host))
+    except ValueError:
+        numeric_label = host.rstrip(".").rsplit(".", 1)[-1].lower()
+        looks_numeric = numeric_label.isdigit() or (
+            numeric_label.startswith("0x")
+            and len(numeric_label) > 2
+            and all(character in "0123456789abcdef" for character in numeric_label[2:])
+        )
+        if looks_numeric or host.endswith("."):
+            raise ValueError(f"{setting} contains a noncanonical numeric hostname") from None
+        try:
+            canonical = host.encode("idna").decode("ascii")
+        except UnicodeError as exc:
+            raise ValueError(f"{setting} contains an invalid hostname") from exc
+
+        labels = canonical.split(".")
+        if (
+            len(canonical) > 253
+            or any(not label or len(label) > 63 for label in labels)
+            or any(label.startswith("-") or label.endswith("-") for label in labels)
+            or any(
+                not (character.isascii() and (character.isalnum() or character == "-"))
+                for label in labels
+                for character in label
+            )
+        ):
+            raise ValueError(f"{setting} contains an invalid hostname") from None
+        return canonical
+
+
+def _validate_hosts(hosts: tuple[str, ...]) -> tuple[str, ...]:
+    for entry in hosts:
+        wildcard_port = entry.endswith(":*")
+        value = entry[:-2] if wildcard_port else entry
+        if not value or "%" in value or "\\" in value:
+            raise ValueError("MCPSERVER_ALLOWED_HOSTS contains an invalid Host value")
+
+        parsed = urlsplit(f"//{value}")
+        if (
+            parsed.hostname is None
+            or parsed.path
+            or parsed.query
+            or parsed.fragment
+            or parsed.username is not None
+            or parsed.password is not None
+        ):
+            raise ValueError("MCPSERVER_ALLOWED_HOSTS contains an invalid Host value")
+        try:
+            port = parsed.port
+        except ValueError as exc:
+            raise ValueError("MCPSERVER_ALLOWED_HOSTS contains an invalid port") from exc
+        if port is not None and not 1 <= port <= 65535:
+            raise ValueError("MCPSERVER_ALLOWED_HOSTS contains an invalid port")
+        if wildcard_port and port is not None:
+            raise ValueError("MCPSERVER_ALLOWED_HOSTS contains an invalid wildcard port")
+
+        host = _canonical_hostname(parsed.hostname, setting="MCPSERVER_ALLOWED_HOSTS")
+        if ":" in host:
+            host = f"[{host}]"
+        canonical = f"{host}:*" if wildcard_port else host
+        if port is not None:
+            canonical = f"{canonical}:{port}"
+        if entry != canonical:
+            raise ValueError("MCPSERVER_ALLOWED_HOSTS entries must use canonical Host values")
+    return hosts
+
+
 def _validate_origins(origins: tuple[str, ...]) -> tuple[str, ...]:
     for origin in origins:
         parsed = urlsplit(origin)
@@ -49,24 +118,7 @@ def _validate_origins(origins: tuple[str, ...]) -> tuple[str, ...]:
         except ValueError as exc:
             raise ValueError("MCPSERVER_ALLOWED_ORIGINS contains an invalid port") from exc
 
-        host = parsed.hostname
-        try:
-            host = str(ipaddress.ip_address(host))
-        except ValueError:
-            numeric_label = host.rstrip(".").rsplit(".", 1)[-1].lower()
-            looks_numeric = numeric_label.isdigit() or (
-                numeric_label.startswith("0x")
-                and len(numeric_label) > 2
-                and all(character in "0123456789abcdef" for character in numeric_label[2:])
-            )
-            if looks_numeric or host.endswith("."):
-                raise ValueError(
-                    "MCPSERVER_ALLOWED_ORIGINS contains a noncanonical numeric hostname"
-                ) from None
-            try:
-                host = host.encode("idna").decode("ascii")
-            except UnicodeError as exc:
-                raise ValueError("MCPSERVER_ALLOWED_ORIGINS contains an invalid hostname") from exc
+        host = _canonical_hostname(parsed.hostname, setting="MCPSERVER_ALLOWED_ORIGINS")
         if ":" in host:
             host = f"[{host}]"
         default_port = 80 if parsed.scheme == "http" else 443
@@ -94,9 +146,11 @@ class ServerSettings:
             raise ValueError("MCPSERVER_HOST must remain 127.0.0.1")
 
         default_hosts = f"127.0.0.1:{port},localhost:{port}"
-        allowed_hosts = _parse_csv(
-            os.getenv("MCPSERVER_ALLOWED_HOSTS", default_hosts),
-            setting="MCPSERVER_ALLOWED_HOSTS",
+        allowed_hosts = _validate_hosts(
+            _parse_csv(
+                os.getenv("MCPSERVER_ALLOWED_HOSTS", default_hosts),
+                setting="MCPSERVER_ALLOWED_HOSTS",
+            )
         )
         if not allowed_hosts:
             raise ValueError("MCPSERVER_ALLOWED_HOSTS must not be empty")

--- a/src/mcpserver/settings.py
+++ b/src/mcpserver/settings.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ipaddress
 import os
 from dataclasses import dataclass
 from urllib.parse import urlsplit
@@ -45,6 +46,13 @@ def _validate_origins(origins: tuple[str, ...]) -> tuple[str, ...]:
             raise ValueError("MCPSERVER_ALLOWED_ORIGINS contains an invalid port") from exc
 
         host = parsed.hostname
+        try:
+            ipaddress.ip_address(host)
+        except ValueError:
+            try:
+                host = host.encode("idna").decode("ascii")
+            except UnicodeError as exc:
+                raise ValueError("MCPSERVER_ALLOWED_ORIGINS contains an invalid hostname") from exc
         if ":" in host:
             host = f"[{host}]"
         default_port = 80 if parsed.scheme == "http" else 443

--- a/src/mcpserver/settings.py
+++ b/src/mcpserver/settings.py
@@ -27,7 +27,32 @@ def _parse_csv(value: str, *, setting: str) -> tuple[str, ...]:
 
 def _canonical_hostname(host: str, *, setting: str) -> str:
     try:
-        return str(ipaddress.ip_address(host))
+        address = ipaddress.ip_address(host)
+        if isinstance(address, ipaddress.IPv6Address) and address.ipv4_mapped is not None:
+            # URL hosts serialize IPv4-mapped IPv6 addresses as hexadecimal
+            # hextets, while ipaddress uses a dotted-decimal suffix.
+            pieces = [
+                int.from_bytes(address.packed[index : index + 2]) for index in range(0, 16, 2)
+            ]
+            best_start = 0
+            best_length = 0
+            start = 0
+            while start < len(pieces):
+                if pieces[start] != 0:
+                    start += 1
+                    continue
+                end = start
+                while end < len(pieces) and pieces[end] == 0:
+                    end += 1
+                if end - start > best_length:
+                    best_start = start
+                    best_length = end - start
+                start = end
+
+            before = ":".join(f"{piece:x}" for piece in pieces[:best_start])
+            after = ":".join(f"{piece:x}" for piece in pieces[best_start + best_length :])
+            return f"{before}::{after}"
+        return str(address)
     except ValueError:
         numeric_label = host.rstrip(".").rsplit(".", 1)[-1].lower()
         looks_numeric = numeric_label.isdigit() or (

--- a/src/mcpserver/settings.py
+++ b/src/mcpserver/settings.py
@@ -30,6 +30,10 @@ def _validate_origins(origins: tuple[str, ...]) -> tuple[str, ...]:
         parsed = urlsplit(origin)
         if parsed.scheme not in {"http", "https"} or not parsed.netloc or parsed.hostname is None:
             raise ValueError("MCPSERVER_ALLOWED_ORIGINS must contain HTTP(S) origins")
+        if "%" in parsed.netloc or "\\" in parsed.netloc:
+            raise ValueError(
+                "MCPSERVER_ALLOWED_ORIGINS entries must not contain encoded or backslash delimiters"
+            )
         if (
             parsed.path != ""
             or parsed.query

--- a/src/mcpserver/settings.py
+++ b/src/mcpserver/settings.py
@@ -53,6 +53,16 @@ def _validate_origins(origins: tuple[str, ...]) -> tuple[str, ...]:
         try:
             host = str(ipaddress.ip_address(host))
         except ValueError:
+            numeric_label = host.rstrip(".").rsplit(".", 1)[-1].lower()
+            looks_numeric = numeric_label.isdigit() or (
+                numeric_label.startswith("0x")
+                and len(numeric_label) > 2
+                and all(character in "0123456789abcdef" for character in numeric_label[2:])
+            )
+            if looks_numeric or host.endswith("."):
+                raise ValueError(
+                    "MCPSERVER_ALLOWED_ORIGINS contains a noncanonical numeric hostname"
+                ) from None
             try:
                 host = host.encode("idna").decode("ascii")
             except UnicodeError as exc:

--- a/src/mcpserver/settings.py
+++ b/src/mcpserver/settings.py
@@ -47,7 +47,7 @@ def _validate_origins(origins: tuple[str, ...]) -> tuple[str, ...]:
 
         host = parsed.hostname
         try:
-            ipaddress.ip_address(host)
+            host = str(ipaddress.ip_address(host))
         except ValueError:
             try:
                 host = host.encode("idna").decode("ascii")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import logging
+
+import pytest
 from starlette.testclient import TestClient
 
 from mcpserver.server import create_server
@@ -58,6 +61,21 @@ def test_unknown_origin_is_rejected() -> None:
         response = client.get("/mcp", headers=headers)
 
     assert response.status_code == 403
+
+
+@pytest.mark.parametrize("path", ["/healthz", "/mcp"])
+def test_rejected_origin_is_redacted_from_logs(caplog: pytest.LogCaptureFixture, path: str) -> None:
+    app = create_server(_settings()).streamable_http_app()
+    secret = "token-that-must-not-be-logged"
+    headers = {"Origin": f"https://user:{secret}@untrusted.example"}
+    caplog.set_level(logging.WARNING, logger="mcp.server.transport_security")
+
+    with TestClient(app, base_url="http://testserver") as client:
+        response = client.get(path, headers=headers)
+
+    assert response.status_code == 403
+    assert secret not in caplog.text
+    assert "Invalid Origin header: [redacted]" in caplog.text
 
 
 def test_mcp_initialize_uses_expected_protocol() -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from starlette.testclient import TestClient
+
+from mcpserver.server import create_server
+from mcpserver.settings import ServerSettings
+
+
+def _settings() -> ServerSettings:
+    return ServerSettings(
+        host="127.0.0.1",
+        port=8765,
+        allowed_hosts=("testserver",),
+        allowed_origins=("https://client.example",),
+    )
+
+
+def test_health_is_small_and_contains_no_configuration() -> None:
+    app = create_server(_settings()).streamable_http_app()
+    with TestClient(app, base_url="http://testserver") as client:
+        response = client.get("/healthz")
+
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+    assert response.json()["service"] == "mcpserver"
+    assert set(response.json()) == {"ok", "service", "version"}
+
+
+def test_unknown_host_is_rejected() -> None:
+    app = create_server(_settings()).streamable_http_app()
+    with TestClient(app, base_url="http://untrusted.example") as client:
+        response = client.get("/mcp")
+
+    assert response.status_code == 421
+
+
+def test_unknown_origin_is_rejected() -> None:
+    app = create_server(_settings()).streamable_http_app()
+    headers = {"Origin": "https://untrusted.example"}
+    with TestClient(app, base_url="http://testserver") as client:
+        response = client.get("/mcp", headers=headers)
+
+    assert response.status_code == 403
+
+
+def test_mcp_initialize_uses_expected_protocol() -> None:
+    app = create_server(_settings()).streamable_http_app()
+    request = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-11-25",
+            "capabilities": {},
+            "clientInfo": {"name": "phase-zero-test", "version": "1"},
+        },
+    }
+    headers = {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "Origin": "https://client.example",
+    }
+    with TestClient(app, base_url="http://testserver") as client:
+        response = client.post("/mcp", json=request, headers=headers)
+
+    assert response.status_code == 200
+    assert response.json()["result"]["protocolVersion"] == "2025-11-25"
+    assert response.json()["result"]["serverInfo"]["name"] == "LoxBerry MCP Server"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -26,6 +26,23 @@ def test_health_is_small_and_contains_no_configuration() -> None:
     assert set(response.json()) == {"ok", "service", "version"}
 
 
+def test_health_rejects_unknown_host() -> None:
+    app = create_server(_settings()).streamable_http_app()
+    with TestClient(app, base_url="http://untrusted.example") as client:
+        response = client.get("/healthz")
+
+    assert response.status_code == 421
+
+
+def test_health_rejects_unknown_origin() -> None:
+    app = create_server(_settings()).streamable_http_app()
+    headers = {"Origin": "https://untrusted.example"}
+    with TestClient(app, base_url="http://testserver") as client:
+        response = client.get("/healthz", headers=headers)
+
+    assert response.status_code == 403
+
+
 def test_unknown_host_is_rejected() -> None:
     app = create_server(_settings()).streamable_http_app()
     with TestClient(app, base_url="http://untrusted.example") as client:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -25,7 +25,7 @@ def test_secure_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.mark.parametrize("host", ["0.0.0.0", "::", "192.0.2.10"])
 def test_non_loopback_bind_is_rejected(monkeypatch: pytest.MonkeyPatch, host: str) -> None:
     monkeypatch.setenv("MCPSERVER_HOST", host)
-    with pytest.raises(ValueError, match="must remain 127.0.0.1"):
+    with pytest.raises(ValueError, match=r"must remain 127\.0\.0\.1"):
         ServerSettings.from_environment()
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -108,11 +108,18 @@ def test_canonical_non_default_origin_port_is_retained(
 
 
 def test_canonical_idna_origin_is_retained(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("MCPSERVER_ALLOWED_ORIGINS", "https://xn--bcher-kva.example")
+    monkeypatch.setenv(
+        "MCPSERVER_ALLOWED_ORIGINS",
+        "https://xn--bcher-kva.example,https://xn--fa-hia.de,https://xn--3xa.gr",
+    )
 
     settings = ServerSettings.from_environment()
 
-    assert settings.allowed_origins == ("https://xn--bcher-kva.example",)
+    assert settings.allowed_origins == (
+        "https://xn--bcher-kva.example",
+        "https://xn--fa-hia.de",
+        "https://xn--3xa.gr",
+    )
 
 
 def test_canonical_ipv6_origin_is_retained(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -51,6 +51,9 @@ def test_invalid_port_is_rejected(monkeypatch: pytest.MonkeyPatch, port: str) ->
         "https://[2001:0db8:0:0:0:0:0:1]",
         "https://example%2ecom",
         "https://example.com\\evil",
+        "https://127.1",
+        "https://0177.0.0.1",
+        "https://0x7f000001",
     ],
 )
 def test_invalid_origin_is_rejected(monkeypatch: pytest.MonkeyPatch, origin: str) -> None:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -44,9 +44,22 @@ def test_invalid_port_is_rejected(monkeypatch: pytest.MonkeyPatch, port: str) ->
         "https://:secret@example.test",
         "https://example.test/",
         "https://example.test/path",
+        "https://client.example:443",
+        "http://client.example:80",
+        "HTTPS://client.example",
     ],
 )
 def test_invalid_origin_is_rejected(monkeypatch: pytest.MonkeyPatch, origin: str) -> None:
     monkeypatch.setenv("MCPSERVER_ALLOWED_ORIGINS", origin)
     with pytest.raises(ValueError, match="MCPSERVER_ALLOWED_ORIGINS"):
         ServerSettings.from_environment()
+
+
+def test_canonical_non_default_origin_port_is_retained(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MCPSERVER_ALLOWED_ORIGINS", "https://client.example:8443")
+
+    settings = ServerSettings.from_environment()
+
+    assert settings.allowed_origins == ("https://client.example:8443",)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -48,6 +48,7 @@ def test_invalid_port_is_rejected(monkeypatch: pytest.MonkeyPatch, port: str) ->
         "http://client.example:80",
         "HTTPS://client.example",
         "https://bücher.example",
+        "https://[2001:0db8:0:0:0:0:0:1]",
     ],
 )
 def test_invalid_origin_is_rejected(monkeypatch: pytest.MonkeyPatch, origin: str) -> None:
@@ -72,3 +73,11 @@ def test_canonical_idna_origin_is_retained(monkeypatch: pytest.MonkeyPatch) -> N
     settings = ServerSettings.from_environment()
 
     assert settings.allowed_origins == ("https://xn--bcher-kva.example",)
+
+
+def test_canonical_ipv6_origin_is_retained(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MCPSERVER_ALLOWED_ORIGINS", "https://[2001:db8::1]")
+
+    settings = ServerSettings.from_environment()
+
+    assert settings.allowed_origins == ("https://[2001:db8::1]",)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -42,6 +42,7 @@ def test_invalid_port_is_rejected(monkeypatch: pytest.MonkeyPatch, port: str) ->
         "ftp://example.test",
         "https://user@example.test",
         "https://:secret@example.test",
+        "https://example.test/",
         "https://example.test/path",
     ],
 )

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -37,6 +37,39 @@ def test_invalid_port_is_rejected(monkeypatch: pytest.MonkeyPatch, port: str) ->
 
 
 @pytest.mark.parametrize(
+    "hosts",
+    [
+        "https://loxberry.local",
+        "loxberry.local:*:443",
+        "user@loxberry.local",
+        "loxberry.local/path",
+        "EXAMPLE.local:8765",
+    ],
+)
+def test_invalid_allowed_host_is_rejected(monkeypatch: pytest.MonkeyPatch, hosts: str) -> None:
+    monkeypatch.setenv("MCPSERVER_ALLOWED_HOSTS", hosts)
+
+    with pytest.raises(ValueError, match="MCPSERVER_ALLOWED_HOSTS"):
+        ServerSettings.from_environment()
+
+
+def test_canonical_allowed_hosts_are_retained(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(
+        "MCPSERVER_ALLOWED_HOSTS",
+        "loxberry.local,loxberry.local:8765,loxberry.local:*,[2001:db8::1]:8765",
+    )
+
+    settings = ServerSettings.from_environment()
+
+    assert settings.allowed_hosts == (
+        "loxberry.local",
+        "loxberry.local:8765",
+        "loxberry.local:*",
+        "[2001:db8::1]:8765",
+    )
+
+
+@pytest.mark.parametrize(
     "origin",
     [
         "ftp://example.test",

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -82,6 +82,7 @@ def test_canonical_allowed_hosts_are_retained(monkeypatch: pytest.MonkeyPatch) -
         "HTTPS://client.example",
         "https://bücher.example",
         "https://[2001:0db8:0:0:0:0:0:1]",
+        "https://[::ffff:192.168.1.1]",
         "https://example%2ecom",
         "https://example.com\\evil",
         "https://127.1",
@@ -119,3 +120,13 @@ def test_canonical_ipv6_origin_is_retained(monkeypatch: pytest.MonkeyPatch) -> N
     settings = ServerSettings.from_environment()
 
     assert settings.allowed_origins == ("https://[2001:db8::1]",)
+
+
+def test_browser_canonical_ipv4_mapped_ipv6_origin_is_retained(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MCPSERVER_ALLOWED_ORIGINS", "https://[::ffff:c0a8:101]")
+
+    settings = ServerSettings.from_environment()
+
+    assert settings.allowed_origins == ("https://[::ffff:c0a8:101]",)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -49,6 +49,8 @@ def test_invalid_port_is_rejected(monkeypatch: pytest.MonkeyPatch, port: str) ->
         "HTTPS://client.example",
         "https://bücher.example",
         "https://[2001:0db8:0:0:0:0:0:1]",
+        "https://example%2ecom",
+        "https://example.com\\evil",
     ],
 )
 def test_invalid_origin_is_rejected(monkeypatch: pytest.MonkeyPatch, origin: str) -> None:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -88,6 +88,7 @@ def test_canonical_allowed_hosts_are_retained(monkeypatch: pytest.MonkeyPatch) -
         "https://127.1",
         "https://0177.0.0.1",
         "https://0x7f000001",
+        "https://xn--a.example",
     ],
 )
 def test_invalid_origin_is_rejected(monkeypatch: pytest.MonkeyPatch, origin: str) -> None:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import pytest
+
+from mcpserver.settings import ServerSettings
+
+
+def test_secure_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in (
+        "MCPSERVER_HOST",
+        "MCPSERVER_PORT",
+        "MCPSERVER_ALLOWED_HOSTS",
+        "MCPSERVER_ALLOWED_ORIGINS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    settings = ServerSettings.from_environment()
+
+    assert settings.host == "127.0.0.1"
+    assert settings.port == 8765
+    assert settings.allowed_hosts == ("127.0.0.1:8765", "localhost:8765")
+    assert settings.allowed_origins == ()
+
+
+@pytest.mark.parametrize("host", ["0.0.0.0", "::", "192.0.2.10"])
+def test_non_loopback_bind_is_rejected(monkeypatch: pytest.MonkeyPatch, host: str) -> None:
+    monkeypatch.setenv("MCPSERVER_HOST", host)
+    with pytest.raises(ValueError, match="must remain 127.0.0.1"):
+        ServerSettings.from_environment()
+
+
+@pytest.mark.parametrize("port", ["abc", "0", "1023", "65536"])
+def test_invalid_port_is_rejected(monkeypatch: pytest.MonkeyPatch, port: str) -> None:
+    monkeypatch.setenv("MCPSERVER_PORT", port)
+    with pytest.raises(ValueError, match="MCPSERVER_PORT"):
+        ServerSettings.from_environment()
+
+
+@pytest.mark.parametrize(
+    "origin",
+    ["ftp://example.test", "https://user@example.test", "https://example.test/path"],
+)
+def test_invalid_origin_is_rejected(monkeypatch: pytest.MonkeyPatch, origin: str) -> None:
+    monkeypatch.setenv("MCPSERVER_ALLOWED_ORIGINS", origin)
+    with pytest.raises(ValueError, match="MCPSERVER_ALLOWED_ORIGINS"):
+        ServerSettings.from_environment()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -47,6 +47,7 @@ def test_invalid_port_is_rejected(monkeypatch: pytest.MonkeyPatch, port: str) ->
         "https://client.example:443",
         "http://client.example:80",
         "HTTPS://client.example",
+        "https://bücher.example",
     ],
 )
 def test_invalid_origin_is_rejected(monkeypatch: pytest.MonkeyPatch, origin: str) -> None:
@@ -63,3 +64,11 @@ def test_canonical_non_default_origin_port_is_retained(
     settings = ServerSettings.from_environment()
 
     assert settings.allowed_origins == ("https://client.example:8443",)
+
+
+def test_canonical_idna_origin_is_retained(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MCPSERVER_ALLOWED_ORIGINS", "https://xn--bcher-kva.example")
+
+    settings = ServerSettings.from_environment()
+
+    assert settings.allowed_origins == ("https://xn--bcher-kva.example",)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -38,7 +38,12 @@ def test_invalid_port_is_rejected(monkeypatch: pytest.MonkeyPatch, port: str) ->
 
 @pytest.mark.parametrize(
     "origin",
-    ["ftp://example.test", "https://user@example.test", "https://example.test/path"],
+    [
+        "ftp://example.test",
+        "https://user@example.test",
+        "https://:secret@example.test",
+        "https://example.test/path",
+    ],
 )
 def test_invalid_origin_is_rejected(monkeypatch: pytest.MonkeyPatch, origin: str) -> None:
     monkeypatch.setenv("MCPSERVER_ALLOWED_ORIGINS", origin)

--- a/tools/test.py
+++ b/tools/test.py
@@ -1,0 +1,24 @@
+"""Run the deterministic checks used locally and in CI."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def main() -> int:
+    commands = (
+        (sys.executable, "-m", "ruff", "format", "--check", "."),
+        (sys.executable, "-m", "ruff", "check", "."),
+        (sys.executable, "-m", "mypy"),
+        (sys.executable, "-m", "pytest"),
+    )
+    for command in commands:
+        completed = subprocess.run(command, check=False)
+        if completed.returncode:
+            return completed.returncode
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a Python 3.13 MCP 1.28.1 Streamable HTTP foundation bound to loopback
- enforce safe host/origin settings and expose only a small health route
- pin runtime/dev dependencies, add one local test command, and run it in CI
- record real arm64 start, memory, and package measurements

## Verification
- Windows/Python 3.12 compatibility run: format, lint, mypy, 15 tests passed
- LoxBerry 4 Debian 13 arm64/Python 3.13.5: format, lint, mypy, 15 tests passed
- five cold starts: 4.088-4.386 s
- RSS after 10 minutes idle: 53,448 KiB
- venv: 51 MiB

## Scope
This PR is stacked on PR #3 and intentionally contains no Loxone tools, OAuth flow, service installation, or Apache mutation yet.