### PR TITLE
Validate Apache MCP transport

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,5 @@ jobs:
           python -m pip install --disable-pip-version-check --no-deps -e .
       - name: Test
         run: python tools/test.py
+      - name: Check target integration scripts
+        run: sh -n tests/integration/test_apache_transport.sh

--- a/config/apache/mcpserver.conf
+++ b/config/apache/mcpserver.conf
@@ -1,0 +1,5 @@
+# Installed as an Apache conf fragment by the LoxBerry root lifecycle hook.
+# The backend remains loopback-only; public host and Origin validation is also
+# enforced by the MCP process.
+ProxyPass "/plugins/mcpserver/mcp" "http://127.0.0.1:8765/mcp" nocanon retry=0 timeout=300
+ProxyPassReverse "/plugins/mcpserver/mcp" "http://127.0.0.1:8765/mcp"

--- a/docs/development/adr/0001-phase-0-foundation.md
+++ b/docs/development/adr/0001-phase-0-foundation.md
@@ -136,9 +136,15 @@ Health-Endpunkt war nach 4,088 bis 4,386 Sekunden erreichbar. Der RSS lag direkt
 danach zwischen 53.428 und 53.452 KiB und nach zehn Minuten Idle bei 53.448 KiB.
 Damit sind Paket-, Startzeit- und Speichergrenze erfüllt.
 
+Der Transport-Spike lief auf demselben Zielsystem mit Apache 2.4.68 als zweite,
+unprivilegierte Instanz auf einem hohen Loopback-Port. Die Konfiguration war
+syntaktisch gültig, MCP-Initialisierung über `/plugins/mcpserver/mcp` gelang,
+eine fremde Origin wurde abgewiesen und die SSE-Verbindung blieb 120 Sekunden
+offen. Die produktive System-Apache-Konfiguration wurde dabei nicht verändert.
+
 ## Folgen
 
-Python ist nach den erfolgreichen Wheel-, Startzeit- und Idle-RSS-Spikes für die
-Referenzplattform bestätigt; ein vorsorglicher paralleler Go-Build entfällt.
-Apache-, Loxone-, WebSocket- und OAuth-Aussagen bleiben bis zu den jeweiligen
-reproduzierbaren Spikes als noch nicht real bestätigt gekennzeichnet.
+Python und der Apache-Transport sind für die Referenzplattform bestätigt; ein
+vorsorglicher paralleler Go-Build entfällt. Loxone-, WebSocket- und OAuth-
+Aussagen bleiben bis zu den jeweiligen reproduzierbaren Spikes als noch nicht
+real bestätigt gekennzeichnet.

--- a/docs/development/adr/0001-phase-0-foundation.md
+++ b/docs/development/adr/0001-phase-0-foundation.md
@@ -30,10 +30,9 @@ Implementierungsdetails ersetzen.
 
 - Ein einzelner unprivilegierter Dienst läuft als `loxberry`, bindet nur an
   `127.0.0.1` und stellt Streamable HTTP bereit.
-- Kandidat für den öffentlichen MCP-Pfad im Transport-Spike ist
-  `/plugins/mcpserver/mcp`. Der endgültige Pfad und die separat weitergeleiteten
-  OAuth-Discovery-Pfade unter `/.well-known/` werden erst nach dem realen
-  Apache-Nachweis festgelegt.
+- Der durch den realen Apache-Transport-Spike bestätigte öffentliche MCP-Pfad ist
+  `/plugins/mcpserver/mcp`. Die separat weitergeleiteten OAuth-Discovery-Pfade
+  unter `/.well-known/` werden im OAuth-Spike festgelegt.
 - Externer HTTPS-Zugriff bleibt im ersten öffentlichen Test deaktiviert.
 - Proxy-Header werden nur vom lokalen Apache akzeptiert. Host und Origin werden
   gegen explizite Allowlisten geprüft.

--- a/docs/development/plugin-concept.md
+++ b/docs/development/plugin-concept.md
@@ -743,7 +743,7 @@ Support-Matrix.
 | 1 | Plugin-ID und Ordner | festgelegt: `NAME=mcpserver`, `FOLDER=mcpserver`, `TITLE=LoxBerry MCP Server` |
 | 2 | erste CPU-Architektur | festgelegt: LoxBerry 4 auf Debian 13, `arm64` |
 | 3 | Runtime | festgelegt: Python 3.13 und MCP-SDK 1.28.1; Wheel-, Start- und RAM-Gates erfolgreich |
-| 4 | öffentlicher Pluginpfad/Apache | Spike-Kandidat: `/plugins/mcpserver/mcp` plus Root-Discovery; Festlegung erst nach realer Apache-Prüfung |
+| 4 | öffentlicher Pluginpfad/Apache | `/plugins/mcpserver/mcp` mit Apache 2.4.68 real bestätigt; Root-Discovery folgt mit dem OAuth-Spike |
 | 5 | MCP-OAuth-Clientregistrierung und Sessionpersistenz | festgelegt: öffentliche Registrierung, PKCE S256, opaque Tokens und atomare dateibasierte Persistenz; Clientprüfung ausstehend |
 | 6 | Miniserver-Firmware | Gen. 1 mindestens `17.1.7.27`; Gen.-2-Stände werden durch die öffentliche Beta bestätigt |
 | 7 | erste unterstützte Control-Typen | festgelegt für Phase 2: `Switch` mit explizitem `on` und `off` |

--- a/docs/development/plugin-concept.md
+++ b/docs/development/plugin-concept.md
@@ -171,16 +171,16 @@ LoxBerry Admin-UI (htmlauth)
 ## 7. Netzwerk und Veröffentlichung
 
 Der Dienst lauscht ausschließlich auf `127.0.0.1` an einem konfigurierten,
-konfliktgeprüften Port. Apache veröffentlicht den MCP-Endpunkt unter einem
-Pluginpfad, beispielsweise:
+konfliktgeprüften Port. Apache veröffentlicht den MCP-Endpunkt verbindlich unter:
 
 ```text
 https://<loxberry>/plugins/mcpserver/mcp
 ```
 
-Der genaue Pfad wird im Transport-Spike festgelegt. Er muss GET und POST sowie
-die zugehörige OAuth-Discovery unterstützen. Reverse-Proxy-Header werden nur von
-einem explizit vertrauten lokalen Proxy akzeptiert.
+Dieser MCP-Pfad ist durch den realen Apache-Transport-Spike bestätigt und muss
+GET und POST unterstützen. Die separat weitergeleiteten OAuth-Discovery-Pfade
+unter `/.well-known/` werden im OAuth-Spike festgelegt. Reverse-Proxy-Header
+werden nur von einem explizit vertrauten lokalen Proxy akzeptiert.
 
 Für externe Nutzung gilt:
 

--- a/docs/development/plugin-concept.md
+++ b/docs/development/plugin-concept.md
@@ -170,8 +170,10 @@ LoxBerry Admin-UI (htmlauth)
 
 ## 7. Netzwerk und Veröffentlichung
 
-Der Dienst lauscht ausschließlich auf `127.0.0.1` an einem konfigurierten,
-konfliktgeprüften Port. Apache veröffentlicht den MCP-Endpunkt verbindlich unter:
+Der Dienst lauscht ausschließlich auf `127.0.0.1:8765`. Dieser feste interne
+Port ist Teil des gemeinsam ausgelieferten Dienst-/Apache-Vertrags und wird vor
+dem Dienststart auf Konflikte geprüft. Apache veröffentlicht den MCP-Endpunkt
+verbindlich unter:
 
 ```text
 https://<loxberry>/plugins/mcpserver/mcp

--- a/docs/development/plugin-concept.md
+++ b/docs/development/plugin-concept.md
@@ -445,7 +445,6 @@ Vorgesehene Bereiche:
 
 ```text
 schema_version
-server.listen_port
 server.local_base_url
 server.external_base_url
 server.allowed_origins
@@ -469,7 +468,7 @@ und sind kein Ersatz für die Admin-UI:
 | Variable | Default | Vertrag |
 | --- | --- | --- |
 | `MCPSERVER_HOST` | `127.0.0.1` | ausschließlich exakt dieser Loopback-Host |
-| `MCPSERVER_PORT` | `8765` | ganzzahlig von `1024` bis `65535`; Apache und Dienst müssen denselben Wert erhalten |
+| `MCPSERVER_PORT` | `8765` | ausschließlich exakt dieser interne Port; Dienst und Apache teilen diesen Vertrag |
 | `MCPSERVER_ALLOWED_HOSTS` | `127.0.0.1:<Port>,localhost:<Port>` | kommaseparierte exakte Host-/Port-Werte oder ein Host mit `:*`; mindestens ein Eintrag |
 | `MCPSERVER_ALLOWED_ORIGINS` | leer | kommaseparierte kanonische `http`-/`https`-Origins ohne Pfad, Zugangsdaten, Query oder Fragment; Standardports und Unicode-Hostnamen werden nicht als alternative Schreibweise akzeptiert |
 
@@ -487,6 +486,9 @@ Origins mit internationalisierten Domains werden in der vom Browser gesendeten
 IDNA-ASCII-Schreibweise eingetragen, beispielsweise
 `https://xn--bcher-kva.example`. Zugangsdaten, Tokens oder Sessionwerte gehören
 in keine dieser Variablen.
+
+Der interne Loopback-Port `8765` ist nicht benutzerkonfigurierbar. Eine Änderung
+erfordert eine synchronisierte Migration beider Komponenten.
 
 ### Secrets und Sessions
 

--- a/src/mcpserver/server.py
+++ b/src/mcpserver/server.py
@@ -7,8 +7,11 @@ from typing import Final
 
 from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecurityMiddleware, TransportSecuritySettings
+from starlette.applications import Starlette
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
+from starlette.types import ASGIApp
 
 from mcpserver import __version__
 from mcpserver.settings import ServerSettings
@@ -40,6 +43,45 @@ if not any(isinstance(item, _RedactRejectedTransportHeader) for item in _transpo
     _transport_logger.addFilter(_RedactRejectedTransportHeader())
 
 
+def _host_is_allowed(host: str, allowed_hosts: tuple[str, ...]) -> bool:
+    if host in allowed_hosts:
+        return True
+    return any(
+        allowed.endswith(":*") and host.startswith(f"{allowed[:-2]}:") for allowed in allowed_hosts
+    )
+
+
+class _ForwardedHostValidationMiddleware(BaseHTTPMiddleware):
+    """Validate the original Host supplied by the trusted loopback proxy."""
+
+    def __init__(self, app: ASGIApp, *, allowed_hosts: tuple[str, ...]) -> None:
+        super().__init__(app)
+        self._allowed_hosts = allowed_hosts
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        forwarded_host = request.headers.get("x-forwarded-host")
+        if forwarded_host is not None and not _host_is_allowed(forwarded_host, self._allowed_hosts):
+            logging.getLogger(_TRANSPORT_LOGGER_NAME).warning(
+                "Invalid forwarded Host header: [redacted]"
+            )
+            return Response("Invalid forwarded Host header", status_code=421)
+        return await call_next(request)
+
+
+class _ForwardedHostFastMCP(FastMCP):
+    """FastMCP application that also validates Apache's original Host header."""
+
+    forwarded_allowed_hosts: tuple[str, ...] = ()
+
+    def streamable_http_app(self) -> Starlette:
+        app = super().streamable_http_app()
+        app.add_middleware(
+            _ForwardedHostValidationMiddleware,
+            allowed_hosts=self.forwarded_allowed_hosts,
+        )
+        return app
+
+
 def create_server(settings: ServerSettings) -> FastMCP:
     """Create the MCP server from already validated settings."""
     transport_security = TransportSecuritySettings(
@@ -48,7 +90,7 @@ def create_server(settings: ServerSettings) -> FastMCP:
         allowed_origins=list(settings.allowed_origins),
     )
     transport_guard = TransportSecurityMiddleware(transport_security)
-    server = FastMCP(
+    server = _ForwardedHostFastMCP(
         SERVER_NAME,
         host=settings.host,
         port=settings.port,
@@ -57,6 +99,7 @@ def create_server(settings: ServerSettings) -> FastMCP:
         stateless_http=True,
         transport_security=transport_security,
     )
+    server.forwarded_allowed_hosts = settings.allowed_hosts
 
     @server.custom_route(  # type: ignore[misc]
         "/healthz", methods=["GET"], include_in_schema=False

--- a/src/mcpserver/server.py
+++ b/src/mcpserver/server.py
@@ -44,6 +44,8 @@ if not any(isinstance(item, _RedactRejectedTransportHeader) for item in _transpo
 
 
 def _host_is_allowed(host: str, allowed_hosts: tuple[str, ...]) -> bool:
+    if "," in host:
+        return False
     if host in allowed_hosts:
         return True
     return any(

--- a/src/mcpserver/settings.py
+++ b/src/mcpserver/settings.py
@@ -5,19 +5,18 @@ from __future__ import annotations
 import ipaddress
 import os
 from dataclasses import dataclass
+from typing import Final
 from urllib.parse import urlsplit
 
 import idna
 
+SERVER_PORT: Final = 8765
 
-def _parse_port(value: str) -> int:
-    try:
-        port = int(value, 10)
-    except ValueError as exc:
-        raise ValueError("MCPSERVER_PORT must be an integer") from exc
-    if not 1024 <= port <= 65535:
-        raise ValueError("MCPSERVER_PORT must be between 1024 and 65535")
-    return port
+
+def _fixed_port_from_environment() -> int:
+    if os.getenv("MCPSERVER_PORT", str(SERVER_PORT)) != str(SERVER_PORT):
+        raise ValueError(f"MCPSERVER_PORT must remain {SERVER_PORT} to match the Apache proxy")
+    return SERVER_PORT
 
 
 def _parse_csv(value: str, *, setting: str) -> tuple[str, ...]:
@@ -167,7 +166,7 @@ class ServerSettings:
 
     @classmethod
     def from_environment(cls) -> ServerSettings:
-        port = _parse_port(os.getenv("MCPSERVER_PORT", "8765"))
+        port = _fixed_port_from_environment()
         host = os.getenv("MCPSERVER_HOST", "127.0.0.1").strip()
         if host != "127.0.0.1":
             raise ValueError("MCPSERVER_HOST must remain 127.0.0.1")

--- a/tests/integration/test_apache_transport.sh
+++ b/tests/integration/test_apache_transport.sh
@@ -69,7 +69,7 @@ EOF
 
 /usr/sbin/apache2 -t -f "$work_dir/apache.conf"
 
-MCPSERVER_ALLOWED_HOSTS="127.0.0.1:8765" \
+MCPSERVER_ALLOWED_HOSTS="127.0.0.1:8765,127.0.0.1:18888" \
 	MCPSERVER_ALLOWED_ORIGINS="http://127.0.0.1:18888" \
 	PYTHONPATH="$repository_root/src" \
 	"$python" -m mcpserver.server >"$work_dir/server.log" 2>&1 &
@@ -105,6 +105,14 @@ response=$(curl -fsS \
 printf '%s' "$response" | "$python" -c \
 	'import json,sys; body=json.load(sys.stdin); assert body["result"]["protocolVersion"] == "2025-11-25"'
 
+untrusted_host_status=$(curl -sS -o /dev/null -w '%{http_code}' \
+	-H 'Host: untrusted.example' \
+	-H 'Accept: application/json, text/event-stream' \
+	-H 'Content-Type: application/json' \
+	--data "$request" \
+	http://127.0.0.1:18888/plugins/mcpserver/mcp)
+test "$untrusted_host_status" = "421"
+
 untrusted_status=$(curl -sS -o /dev/null -w '%{http_code}' \
 	-H 'Accept: application/json, text/event-stream' \
 	-H 'Content-Type: application/json' \
@@ -124,5 +132,6 @@ set -e
 test "$stream_status" = "124"
 
 printf 'APACHE_STREAMABLE_HTTP=pass\n'
+printf 'APACHE_HOST_REJECTION=pass\n'
 printf 'APACHE_ORIGIN_REJECTION=pass\n'
 printf 'APACHE_SSE_%s_SECONDS=pass\n' "$stream_seconds"

--- a/tests/integration/test_apache_transport.sh
+++ b/tests/integration/test_apache_transport.sh
@@ -25,6 +25,28 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
+require_running() {
+	process_name=$1
+	process_pid=$2
+	process_log=$3
+	if ! kill -0 "$process_pid" 2>/dev/null; then
+		printf '%s exited before owning its test port\n' "$process_name" >&2
+		cat "$process_log" >&2 2>/dev/null || true
+		exit 1
+	fi
+}
+
+"$python" - <<'PY'
+import socket
+
+for port in (8765, 18888):
+    with socket.socket() as listener:
+        try:
+            listener.bind(("127.0.0.1", port))
+        except OSError as error:
+            raise SystemExit(f"test port {port} is already occupied: {error}") from error
+PY
+
 mkdir "$work_dir/empty"
 cat >"$work_dir/apache.conf" <<EOF
 ServerRoot "/etc/apache2"
@@ -58,12 +80,20 @@ apache_pid=$!
 
 attempt=0
 while [ "$attempt" -lt 100 ]; do
+	require_running "MCP server" "$server_pid" "$work_dir/server.log"
+	require_running "Apache" "$apache_pid" "$work_dir/apache-error.log"
 	if curl -fsS http://127.0.0.1:8765/healthz >/dev/null 2>&1; then
 		break
 	fi
 	attempt=$((attempt + 1))
 	sleep 0.05
 done
+require_running "MCP server" "$server_pid" "$work_dir/server.log"
+require_running "Apache" "$apache_pid" "$work_dir/apache-error.log"
+if [ "$attempt" -eq 100 ]; then
+	printf 'MCP server did not become ready\n' >&2
+	exit 1
+fi
 
 request='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"apache-spike","version":"1"}}}'
 response=$(curl -fsS \

--- a/tests/integration/test_apache_transport.sh
+++ b/tests/integration/test_apache_transport.sh
@@ -1,0 +1,98 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -ne 2 ]; then
+	echo "usage: $0 PYTHON REPOSITORY_ROOT" >&2
+	exit 2
+fi
+
+python=$1
+repository_root=$2
+work_dir=$(mktemp -d /tmp/mcpserver-apache-test.XXXXXX)
+server_pid=""
+apache_pid=""
+
+cleanup() {
+	if [ -n "$apache_pid" ]; then
+		kill "$apache_pid" 2>/dev/null || true
+		wait "$apache_pid" 2>/dev/null || true
+	fi
+	if [ -n "$server_pid" ]; then
+		kill "$server_pid" 2>/dev/null || true
+		wait "$server_pid" 2>/dev/null || true
+	fi
+	rm -rf "$work_dir"
+}
+trap cleanup EXIT INT TERM
+
+mkdir "$work_dir/empty"
+cat >"$work_dir/apache.conf" <<EOF
+ServerRoot "/etc/apache2"
+PidFile "$work_dir/apache.pid"
+DefaultRuntimeDir "$work_dir"
+Listen 127.0.0.1:18888
+ServerName localhost
+ErrorLog "$work_dir/apache-error.log"
+LogLevel warn
+LoadModule mpm_event_module /usr/lib/apache2/modules/mod_mpm_event.so
+LoadModule authz_core_module /usr/lib/apache2/modules/mod_authz_core.so
+LoadModule proxy_module /usr/lib/apache2/modules/mod_proxy.so
+LoadModule proxy_http_module /usr/lib/apache2/modules/mod_proxy_http.so
+DocumentRoot "$work_dir/empty"
+<Directory "$work_dir/empty">
+    Require all denied
+</Directory>
+Include "$repository_root/config/apache/mcpserver.conf"
+EOF
+
+/usr/sbin/apache2 -t -f "$work_dir/apache.conf"
+
+MCPSERVER_ALLOWED_HOSTS="127.0.0.1:8765" \
+	MCPSERVER_ALLOWED_ORIGINS="http://127.0.0.1:18888" \
+	PYTHONPATH="$repository_root/src" \
+	"$python" -m mcpserver.server >"$work_dir/server.log" 2>&1 &
+server_pid=$!
+
+/usr/sbin/apache2 -f "$work_dir/apache.conf" -DFOREGROUND &
+apache_pid=$!
+
+attempt=0
+while [ "$attempt" -lt 100 ]; do
+	if curl -fsS http://127.0.0.1:8765/healthz >/dev/null 2>&1; then
+		break
+	fi
+	attempt=$((attempt + 1))
+	sleep 0.05
+done
+
+request='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"apache-spike","version":"1"}}}'
+response=$(curl -fsS \
+	-H 'Accept: application/json, text/event-stream' \
+	-H 'Content-Type: application/json' \
+	-H 'Origin: http://127.0.0.1:18888' \
+	--data "$request" \
+	http://127.0.0.1:18888/plugins/mcpserver/mcp)
+printf '%s' "$response" | "$python" -c \
+	'import json,sys; body=json.load(sys.stdin); assert body["result"]["protocolVersion"] == "2025-11-25"'
+
+untrusted_status=$(curl -sS -o /dev/null -w '%{http_code}' \
+	-H 'Accept: application/json, text/event-stream' \
+	-H 'Content-Type: application/json' \
+	-H 'Origin: https://untrusted.example' \
+	--data "$request" \
+	http://127.0.0.1:18888/plugins/mcpserver/mcp)
+test "$untrusted_status" = "403"
+
+stream_seconds=${MCPSERVER_STREAM_TEST_SECONDS:-3}
+set +e
+timeout "$stream_seconds" curl -NsS \
+	-H 'Accept: text/event-stream' \
+	-H 'Origin: http://127.0.0.1:18888' \
+	http://127.0.0.1:18888/plugins/mcpserver/mcp >/dev/null
+stream_status=$?
+set -e
+test "$stream_status" = "124"
+
+printf 'APACHE_STREAMABLE_HTTP=pass\n'
+printf 'APACHE_ORIGIN_REJECTION=pass\n'
+printf 'APACHE_SSE_%s_SECONDS=pass\n' "$stream_seconds"

--- a/tests/test_apache_config.py
+++ b/tests/test_apache_config.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_apache_proxy_is_narrow_and_loopback_only() -> None:
+    config = Path("config/apache/mcpserver.conf").read_text(encoding="utf-8")
+
+    assert 'ProxyPass "/plugins/mcpserver/mcp" "http://127.0.0.1:8765/mcp"' in config
+    assert "ProxyRequests" not in config
+    assert "ProxyPreserveHost" not in config
+    assert "\nProxyTimeout " not in config
+    assert "timeout=300" in config
+    assert "0.0.0.0" not in config
+    assert "ProxyPass / " not in config

--- a/tests/test_apache_config.py
+++ b/tests/test_apache_config.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from mcpserver.settings import SERVER_PORT
+
 
 def test_apache_proxy_is_narrow_and_loopback_only() -> None:
     config = Path("config/apache/mcpserver.conf").read_text(encoding="utf-8")
 
-    assert 'ProxyPass "/plugins/mcpserver/mcp" "http://127.0.0.1:8765/mcp"' in config
+    assert f'ProxyPass "/plugins/mcpserver/mcp" "http://127.0.0.1:{SERVER_PORT}/mcp"' in config
     assert "ProxyRequests" not in config
     assert "ProxyPreserveHost" not in config
     assert "\nProxyTimeout " not in config

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -54,6 +54,22 @@ def test_unknown_host_is_rejected() -> None:
     assert response.status_code == 421
 
 
+def test_unknown_forwarded_host_is_rejected_and_redacted(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    app = create_server(_settings()).streamable_http_app()
+    secret = "host-value-that-must-not-be-logged"
+    headers = {"X-Forwarded-Host": secret}
+    caplog.set_level(logging.WARNING, logger="mcp.server.transport_security")
+
+    with TestClient(app, base_url="http://testserver") as client:
+        response = client.get("/mcp", headers=headers)
+
+    assert response.status_code == 421
+    assert secret not in caplog.text
+    assert "Invalid forwarded Host header: [redacted]" in caplog.text
+
+
 def test_unknown_origin_is_rejected() -> None:
     app = create_server(_settings()).streamable_http_app()
     headers = {"Origin": "https://untrusted.example"}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -70,6 +70,22 @@ def test_unknown_forwarded_host_is_rejected_and_redacted(
     assert "Invalid forwarded Host header: [redacted]" in caplog.text
 
 
+def test_concatenated_forwarded_host_does_not_match_wildcard() -> None:
+    settings = ServerSettings(
+        host="127.0.0.1",
+        port=8765,
+        allowed_hosts=("testserver:*",),
+        allowed_origins=(),
+    )
+    app = create_server(settings).streamable_http_app()
+    headers = {"X-Forwarded-Host": "testserver:123, untrusted.example"}
+
+    with TestClient(app, base_url="http://testserver:8765") as client:
+        response = client.get("/mcp", headers=headers)
+
+    assert response.status_code == 421
+
+
 def test_unknown_origin_is_rejected() -> None:
     app = create_server(_settings()).streamable_http_app()
     headers = {"Origin": "https://untrusted.example"}

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -29,10 +29,10 @@ def test_non_loopback_bind_is_rejected(monkeypatch: pytest.MonkeyPatch, host: st
         ServerSettings.from_environment()
 
 
-@pytest.mark.parametrize("port", ["abc", "0", "1023", "65536"])
-def test_invalid_port_is_rejected(monkeypatch: pytest.MonkeyPatch, port: str) -> None:
+@pytest.mark.parametrize("port", ["abc", "8766", "08765"])
+def test_non_proxy_port_is_rejected(monkeypatch: pytest.MonkeyPatch, port: str) -> None:
     monkeypatch.setenv("MCPSERVER_PORT", port)
-    with pytest.raises(ValueError, match="MCPSERVER_PORT"):
+    with pytest.raises(ValueError, match="must remain 8765"):
         ServerSettings.from_environment()
 
 


### PR DESCRIPTION
## Summary
- add a narrow loopback Apache proxy fragment for the MCP endpoint
- add a reproducible isolated Apache integration test
- verify MCP initialize, Origin rejection, and a 120-second SSE connection on LoxBerry 4
- record the real Apache 2.4.68 evidence in the ADR and concept

## Verification
- deterministic suite: 16 tests passed
- target Apache syntax: OK
- Streamable HTTP initialize through proxy: passed
- untrusted Origin rejected: passed
- SSE remained open for 120 seconds: passed

## Scope
This PR is stacked on PR #4. It does not install or reload the system Apache and does not yet add OAuth discovery routes.