### PR TITLE
Add secure Gen 1 Loxone and WebSocket spike

### DIFF
--- a/docs/development/phase-0-loxone-test.md
+++ b/docs/development/phase-0-loxone-test.md
@@ -67,12 +67,17 @@ mit Code `200`. Außerdem serialisiert der Adapter Client-IDs im von Loxone
 geforderten UUID-Format `8-4-4-16`. Fehler des HTTP-Unterbaus werden ohne die
 möglicherweise sensitive verschlüsselte Request-URL weitergegeben.
 
-Die reale WebSocket-Prüfung bestätigte anschließend `keyexchange` und das
-verschlüsselte `getkey2`. Erst die verschlüsselte JWT-Anforderung antwortete mit
-`401`, identisch für die Tokenrechte Web (`2`) und App (`4`). Im gespeicherten
-Loxone-Projekt sind beide Rechte für den vorgesehenen Testbenutzer gesetzt; ob
-dieser Benutzerstand unverändert auf dem aktiven Miniserver liegt, kann der
-Client nicht prüfen. Daher bleiben die im externen Testdatenordner ausgewählten
-sichtbaren und unsichtbaren Controls bis zur Bestätigung der aktiven
-Testanmeldung ausdrücklich unbestätigt; Rechtefilterung, Statusereignisse,
-Reconnect und Tokenwiderruf sind noch offen.
+Die reale WebSocket-Prüfung bestätigte anschließend `keyexchange`, das
+verschlüsselte `getkey2` und die verschlüsselte JWT-Anforderung mit dem
+vorgesehenen Testbenutzer. Der `apiKey`-Probe berücksichtigt dabei das
+historische Gen.-1-Format, in dem `LL.value` ein flaches, einfach quotiertes
+Objekt statt standardkonformem JSON enthält. Passwort- und Token-Hashverfahren
+werden getrennt behandelt: `getkey2` bestimmt dynamisch SHA1 oder SHA256 für den
+Passworthash, während nachfolgende Tokenoperationen den `getkey`-kompatiblen
+HMAC-SHA1 verwenden.
+
+Die im externen Testdatenordner ausgewählten sichtbaren und unsichtbaren
+Controls bleiben bis zum vollständigen Strukturnachweis ausdrücklich
+unbestätigt. Rechtefilterung, Statusereignisse und Reconnect sind noch offen;
+der korrigierte Tokenwiderruf ist nach lokalem Regressionstest noch einmal am
+Zielgerät zu bestätigen.

--- a/docs/development/phase-0-loxone-test.md
+++ b/docs/development/phase-0-loxone-test.md
@@ -36,9 +36,9 @@ Der Test akzeptiert für Gen. 1 ausschließlich eine kanonische private IP-Adres
 Authentifizierung zusätzlich Loxone Command Encryption. Das kurzlebig gehaltene
 Test-JWT wird auch nach einem Fehler bestmöglich mit `killtoken` widerrufen.
 
-Ein erfolgreicher Bericht enthält nur Firmware, einen SHA-256-Fingerprint der
-Seriennummer und benannte PASS-Zeilen. Passwort, JWT, interne Adresse,
-Benutzernamen, Control-Namen und vollständige UUIDs werden nicht ausgegeben.
+Ein erfolgreicher Bericht enthält nur die Firmware und benannte PASS-Zeilen.
+Passwort, JWT, Seriennummer, interne Adresse, Benutzernamen, Control-Namen und
+vollständige UUIDs werden nicht ausgegeben.
 
 ## Runtime-Nachweis für PR 1
 
@@ -100,5 +100,4 @@ Mit dieser Filterung bestätigte der Test ein sichtbares und ein verweigertes
 Control, den initialen Zustandssnapshot, eine reale Temperaturänderung, sofortiges
 `stale` nach Verbindungsabbruch, einen neuen Snapshot nach Reconnect und den
 abschließenden Tokenwiderruf. Ausgegeben wurden ausschließlich die Firmware
-`17.1.7.27`, der gekürzte SHA-256-Serienfingerprint `bf61df2269cd` und die
-benannten PASS-Zeilen.
+`17.1.7.27` und die benannten PASS-Zeilen.

--- a/docs/development/phase-0-loxone-test.md
+++ b/docs/development/phase-0-loxone-test.md
@@ -86,7 +86,19 @@ für Textstrukturen und gibt keine rohe Struktur aus. Der Miniserver beendet die
 authentifizierte Verbindung nach erfolgreichem `killtoken` regulär mit Status
 `1000`; dieser Abschluss wurde am Zielgerät als erfolgreicher Widerruf bestätigt.
 
-Der vollständige Rechtefiltertest ist noch offen: Das als unsichtbar vorgesehene
-Control erschien im benutzerbezogenen Strukturfile und ist daher für den
-Testbenutzer derzeit noch berechtigt. Statusereignisse und Reconnect werden erst
-nach Korrektur dieser externen Testbenutzerrechte geprüft.
+Der vollständige Zieltest wurde am 2026-08-03 erfolgreich abgeschlossen. Dabei
+zeigte sich eine Gen.-1-Besonderheit: Ein in der Visualisierung ausdrücklich
+verweigertes Control bleibt mit `restrictions = 17` in der Rohstruktur enthalten,
+und der Miniserver liefert auch dessen Zustandsereignisse an die authentifizierte
+App-Verbindung. Die Bits kennzeichnen das Control intern und extern als „nur
+referenziert“. Der Adapter entfernt solche top-level Controls deshalb bei der
+Normalisierung für die lokale Verbindung und lässt den benutzerbezogenen Cache
+ausschließlich Zustands-UUIDs aus dieser gefilterten Struktur übernehmen.
+Referenzierte Subcontrols eines erlaubten Eltern-Controls bleiben erhalten.
+
+Mit dieser Filterung bestätigte der Test ein sichtbares und ein verweigertes
+Control, den initialen Zustandssnapshot, eine reale Temperaturänderung, sofortiges
+`stale` nach Verbindungsabbruch, einen neuen Snapshot nach Reconnect und den
+abschließenden Tokenwiderruf. Ausgegeben wurden ausschließlich die Firmware
+`17.1.7.27`, der gekürzte SHA-256-Serienfingerprint `bf61df2269cd` und die
+benannten PASS-Zeilen.

--- a/docs/development/phase-0-loxone-test.md
+++ b/docs/development/phase-0-loxone-test.md
@@ -78,8 +78,15 @@ oder SHA256 für den Passwort- und Tokenhash. Jede Tokenauthentifizierung,
 -erneuerung und -widerrufung bezieht über die jeweilige verschlüsselte
 WebSocket-Verbindung einen frischen `getkey`-Einmalschlüssel.
 
-Die im externen Testdatenordner ausgewählten sichtbaren und unsichtbaren
-Controls bleiben bis zum vollständigen Strukturnachweis ausdrücklich
-unbestätigt. Rechtefilterung, Statusereignisse und Reconnect sind noch offen;
-der korrigierte Tokenwiderruf ist nach lokalem Regressionstest noch einmal am
-Zielgerät zu bestätigen.
+Der reale Strukturabruf bestätigte außerdem das dokumentierte Estimated-Bit
+`0x80` vor dem exakten Header. Der getestete Gen.-1-Miniserver kennzeichnet die
+`LoxAPP3.json` im exakten Header abweichend als Binärdatei, überträgt den Inhalt
+aber als Textnachricht. Der Adapter akzeptiert ausschließlich diese Kombination
+für Textstrukturen und gibt keine rohe Struktur aus. Der Miniserver beendet die
+authentifizierte Verbindung nach erfolgreichem `killtoken` regulär mit Status
+`1000`; dieser Abschluss wurde am Zielgerät als erfolgreicher Widerruf bestätigt.
+
+Der vollständige Rechtefiltertest ist noch offen: Das als unsichtbar vorgesehene
+Control erschien im benutzerbezogenen Strukturfile und ist daher für den
+Testbenutzer derzeit noch berechtigt. Statusereignisse und Reconnect werden erst
+nach Korrektur dieser externen Testbenutzerrechte geprüft.

--- a/docs/development/phase-0-loxone-test.md
+++ b/docs/development/phase-0-loxone-test.md
@@ -73,10 +73,10 @@ Die reale WebSocket-Prüfung bestätigte anschließend `keyexchange`, das
 verschlüsselte `getkey2` und die verschlüsselte JWT-Anforderung mit dem
 vorgesehenen Testbenutzer. Der `apiKey`-Probe berücksichtigt dabei das
 historische Gen.-1-Format, in dem `LL.value` ein flaches, einfach quotiertes
-Objekt statt standardkonformem JSON enthält. Passwort- und Token-Hashverfahren
-werden getrennt behandelt: `getkey2` bestimmt dynamisch SHA1 oder SHA256 für den
-Passworthash, während nachfolgende Tokenoperationen den `getkey`-kompatiblen
-HMAC-SHA1 verwenden.
+Objekt statt standardkonformem JSON enthält. `getkey2` bestimmt dynamisch SHA1
+oder SHA256 für den Passwort- und Tokenhash. Jede Tokenauthentifizierung,
+-erneuerung und -widerrufung bezieht über die jeweilige verschlüsselte
+WebSocket-Verbindung einen frischen `getkey`-Einmalschlüssel.
 
 Die im externen Testdatenordner ausgewählten sichtbaren und unsichtbaren
 Controls bleiben bis zum vollständigen Strukturnachweis ausdrücklich

--- a/docs/development/phase-0-loxone-test.md
+++ b/docs/development/phase-0-loxone-test.md
@@ -57,17 +57,22 @@ dabei nicht verändert. Der nachfolgende Miniserver-Test ergänzt diesen
 Runtime-Nachweis um Anmeldung, Rechtefilterung, Ereignisse, Reconnect und
 Tokenwiderruf.
 
-Der reale Gen.-1-Endpunkt lieferte am selben Tag bei `getPublicKey` einen
-DER-codierten RSA-Public-Key mit dem historischen PEM-Label `CERTIFICATE`, aber
-kein X.509-Zertifikat. Der Adapter akzeptiert diese Gen.-1-Variante nur, wenn
-der Inhalt als DER-Public-Key parsebar und tatsächlich RSA ist. Ein über diesen
-Schlüssel vollständig per RSA/AES Command Encryption gesendeter `apiKey`-Probe
-antwortete mit Code `200`. Außerdem serialisiert der Adapter Client-IDs im von
-Loxone geforderten UUID-Format `8-4-4-16`. Fehler des HTTP-Unterbaus werden ohne
-die möglicherweise sensitive verschlüsselte Request-URL weitergegeben.
+Der reale Gen.-1-Endpunkt lieferte am selben Tag über `getcertificate` eine
+X.509-Kette mit dem Loxone-Root-Zertifikat und einem RSA-Leaf-Zertifikat. Der
+Adapter validiert Gültigkeitszeiträume, Ausstellerbeziehungen und Signaturen der
+Kette gegen den fest hinterlegten SHA-256-Fingerprint des Loxone-Roots und nutzt
+erst danach den öffentlichen Leaf-Schlüssel. Ein über diesen Schlüssel
+vollständig per RSA/AES Command Encryption gesendeter `apiKey`-Probe antwortete
+mit Code `200`. Außerdem serialisiert der Adapter Client-IDs im von Loxone
+geforderten UUID-Format `8-4-4-16`. Fehler des HTTP-Unterbaus werden ohne die
+möglicherweise sensitive verschlüsselte Request-URL weitergegeben.
 
-Die anschließende JWT-Anforderung antwortete noch mit `401`. Daher bleiben die
-im externen Testdatenordner ausgewählten sichtbaren und unsichtbaren Controls
-bis zur Korrektur beziehungsweise Bestätigung der Testanmeldung ausdrücklich
-unbestätigt; Rechtefilterung, Statusereignisse, Reconnect und Tokenwiderruf sind
-noch offen.
+Die reale WebSocket-Prüfung bestätigte anschließend `keyexchange` und das
+verschlüsselte `getkey2`. Erst die verschlüsselte JWT-Anforderung antwortete mit
+`401`, identisch für die Tokenrechte Web (`2`) und App (`4`). Im gespeicherten
+Loxone-Projekt sind beide Rechte für den vorgesehenen Testbenutzer gesetzt; ob
+dieser Benutzerstand unverändert auf dem aktiven Miniserver liegt, kann der
+Client nicht prüfen. Daher bleiben die im externen Testdatenordner ausgewählten
+sichtbaren und unsichtbaren Controls bis zur Bestätigung der aktiven
+Testanmeldung ausdrücklich unbestätigt; Rechtefilterung, Statusereignisse,
+Reconnect und Tokenwiderruf sind noch offen.

--- a/docs/development/phase-0-loxone-test.md
+++ b/docs/development/phase-0-loxone-test.md
@@ -13,8 +13,10 @@ Miniserver Gen. 1 mit Firmware `17.1.7.27`.
 - ein anderes Control, das für den Testbenutzer unsichtbar ist
 - beide Control-UUIDs, aber keine Strukturdatei oder Zugangsdaten im Repository
 
-Das Passwort wird ausschließlich interaktiv und ohne Echo abgefragt. Es wird
-weder als Argument noch als Umgebungsvariable übergeben. Während des Tests darf
+Das Passwort wird standardmäßig interaktiv und ohne Echo abgefragt. Für einen
+lokalen Automationsprozess kann es mit `--password-stdin` als genau eine
+umgeleitete Eingabezeile übergeben werden. Es wird niemals als Argument oder
+Umgebungsvariable übergeben oder vom Test gespeichert. Während des Tests darf
 der Benutzer ein sichtbares Control auf normalem Weg bedienen, damit ein
 Zustands-Delta beobachtet werden kann; der Test selbst sendet keinen
 Steuerbefehl.

--- a/docs/development/phase-0-loxone-test.md
+++ b/docs/development/phase-0-loxone-test.md
@@ -1,0 +1,73 @@
+# Phase-0-Test: Loxone Gen. 1
+
+Dieser gezielte Test bestätigt Grenzen, die Mocks nicht beweisen können. Er ist
+kein allgemeiner Installationstest und verändert keine Steuerung. Verwendet wird
+ein dedizierter, eingeschränkter Loxone-Benutzer auf dem vorhandenen
+Miniserver Gen. 1 mit Firmware `17.1.7.27`.
+
+## Voraussetzungen
+
+- LoxBerry 4 auf Debian 13 und `arm64` im selben lokalen Netz
+- Python 3.13 mit dem exakt fixierten Offline-Wheelhouse
+- ein Control, das der Testbenutzer sehen darf
+- ein anderes Control, das für den Testbenutzer unsichtbar ist
+- beide Control-UUIDs, aber keine Strukturdatei oder Zugangsdaten im Repository
+
+Das Passwort wird ausschließlich interaktiv und ohne Echo abgefragt. Es wird
+weder als Argument noch als Umgebungsvariable übergeben. Während des Tests darf
+der Benutzer ein sichtbares Control auf normalem Weg bedienen, damit ein
+Zustands-Delta beobachtet werden kann; der Test selbst sendet keinen
+Steuerbefehl.
+
+## Ausführung
+
+```text
+python tools/test_loxone_target.py \
+  --endpoint http://PRIVATE-IP \
+  --username RESTRICTED-USER \
+  --visible-control VISIBLE-UUID \
+  --hidden-control HIDDEN-UUID
+```
+
+Der Test akzeptiert für Gen. 1 ausschließlich eine kanonische private IP-Adresse
+über HTTP und verwendet für Anmeldung, Tokenoperationen und WebSocket-
+Authentifizierung zusätzlich Loxone Command Encryption. Das kurzlebig gehaltene
+Test-JWT wird auch nach einem Fehler bestmöglich mit `killtoken` widerrufen.
+
+Ein erfolgreicher Bericht enthält nur Firmware, einen SHA-256-Fingerprint der
+Seriennummer und benannte PASS-Zeilen. Passwort, JWT, interne Adresse,
+Benutzernamen, Control-Namen und vollständige UUIDs werden nicht ausgegeben.
+
+## Runtime-Nachweis für PR 1
+
+Der aktualisierte Lockfile- und Runtime-Gate wurde am 2026-08-01 erneut auf
+LoxBerry `4.0.0.14`, Debian 13, `aarch64`, Python `3.13.5` und Apache `2.4.68`
+ausgeführt. Der plattformspezifische Download verwendete den vollständig
+transitiv fixierten Lockfile mit `pip download --no-deps`, anschließend wurde
+im isolierten Ziel-`venv` mit `--no-index --no-deps` installiert.
+
+- 31 Wheels einschließlich des Projekt-Wheels, Wheelhouse: 9.360 KiB
+- vollständiges `venv`: 53.836 KiB
+- `websockets 17.0.1`, `mcp 1.28.1`, `cryptography 50.0.0` und `httpx 0.28.1`
+- Health-Endpunkt nach 4.178 ms erreichbar
+- RSS direkt danach 54.796 KiB, nach 30 Sekunden Idle 54.808 KiB
+
+Der produktive System-Python und die produktive Apache-Konfiguration wurden
+dabei nicht verändert. Der nachfolgende Miniserver-Test ergänzt diesen
+Runtime-Nachweis um Anmeldung, Rechtefilterung, Ereignisse, Reconnect und
+Tokenwiderruf.
+
+Der reale Gen.-1-Endpunkt lieferte am selben Tag bei `getPublicKey` einen
+DER-codierten RSA-Public-Key mit dem historischen PEM-Label `CERTIFICATE`, aber
+kein X.509-Zertifikat. Der Adapter akzeptiert diese Gen.-1-Variante nur, wenn
+der Inhalt als DER-Public-Key parsebar und tatsächlich RSA ist. Ein über diesen
+Schlüssel vollständig per RSA/AES Command Encryption gesendeter `apiKey`-Probe
+antwortete mit Code `200`. Außerdem serialisiert der Adapter Client-IDs im von
+Loxone geforderten UUID-Format `8-4-4-16`. Fehler des HTTP-Unterbaus werden ohne
+die möglicherweise sensitive verschlüsselte Request-URL weitergegeben.
+
+Die anschließende JWT-Anforderung antwortete noch mit `401`. Daher bleiben die
+im externen Testdatenordner ausgewählten sichtbaren und unsichtbaren Controls
+bis zur Korrektur beziehungsweise Bestätigung der Testanmeldung ausdrücklich
+unbestätigt; Rechtefilterung, Statusereignisse, Reconnect und Tokenwiderruf sind
+noch offen.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ license = "Apache-2.0"
 dependencies = [
     "idna==3.18",
     "mcp==1.28.1",
+    "websockets==17.0.1",
 ]
 
 [project.optional-dependencies]

--- a/requirements/runtime-arm64.lock
+++ b/requirements/runtime-arm64.lock
@@ -23,7 +23,6 @@ pydantic-settings==2.14.2
 pyjwt==2.13.0
 python-dotenv==1.2.2
 python-multipart==0.0.32
-pywin32==312; sys_platform == "win32"
 referencing==0.37.0
 rpds-py==2026.6.3
 sse-starlette==3.4.6
@@ -31,3 +30,4 @@ starlette==1.3.1
 typing-extensions==4.16.0
 typing-inspection==0.4.2
 uvicorn==0.52.0
+websockets==17.0.1

--- a/src/mcpserver/loxone/__init__.py
+++ b/src/mcpserver/loxone/__init__.py
@@ -1,0 +1,13 @@
+"""Secure, user-scoped Loxone Gen. 1 integration primitives."""
+
+from mcpserver.loxone.cache import UserStateCache
+from mcpserver.loxone.client import LoxoneClient, MiniserverEndpoint
+from mcpserver.loxone.models import LoxoneStructure, StateRecord
+
+__all__ = [
+    "LoxoneClient",
+    "LoxoneStructure",
+    "MiniserverEndpoint",
+    "StateRecord",
+    "UserStateCache",
+]

--- a/src/mcpserver/loxone/cache.py
+++ b/src/mcpserver/loxone/cache.py
@@ -34,6 +34,9 @@ class UserStateCache:
         self, subject: str, events: Iterable[StateEvent], *, allowed_uuids: Container[str]
     ) -> None:
         values = self._values.setdefault(subject, OrderedDict())
+        for uuid in tuple(values):
+            if uuid not in allowed_uuids:
+                del values[uuid]
         observed_at = self._clock()
         for event in events:
             if event.uuid not in allowed_uuids:

--- a/src/mcpserver/loxone/cache.py
+++ b/src/mcpserver/loxone/cache.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import time
 from collections import OrderedDict
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Container, Iterable
 from dataclasses import replace
 
 from mcpserver.loxone.events import StateEvent
@@ -30,10 +30,14 @@ class UserStateCache:
             values[uuid] = replace(record, freshness=Freshness.STALE)
         self._available[subject] = True
 
-    def apply(self, subject: str, events: Iterable[StateEvent]) -> None:
+    def apply(
+        self, subject: str, events: Iterable[StateEvent], *, allowed_uuids: Container[str]
+    ) -> None:
         values = self._values.setdefault(subject, OrderedDict())
         observed_at = self._clock()
         for event in events:
+            if event.uuid not in allowed_uuids:
+                continue
             values[event.uuid] = StateRecord(
                 uuid=event.uuid,
                 value=event.value,

--- a/src/mcpserver/loxone/cache.py
+++ b/src/mcpserver/loxone/cache.py
@@ -1,0 +1,66 @@
+"""Bounded in-memory state caches separated by Loxone identity."""
+
+from __future__ import annotations
+
+import time
+from collections import OrderedDict
+from collections.abc import Callable, Iterable
+from dataclasses import replace
+
+from mcpserver.loxone.events import StateEvent
+from mcpserver.loxone.models import Freshness, StateRecord
+
+
+class UserStateCache:
+    """Keep state values isolated by immutable Miniserver/user subject."""
+
+    def __init__(
+        self, *, max_states_per_user: int = 10_000, clock: Callable[[], float] = time.time
+    ):
+        if max_states_per_user < 1:
+            raise ValueError("max_states_per_user must be positive")
+        self._max_states = max_states_per_user
+        self._clock = clock
+        self._values: dict[str, OrderedDict[str, StateRecord]] = {}
+        self._available: dict[str, bool] = {}
+
+    def begin_connection(self, subject: str) -> None:
+        values = self._values.setdefault(subject, OrderedDict())
+        for uuid, record in tuple(values.items()):
+            values[uuid] = replace(record, freshness=Freshness.STALE)
+        self._available[subject] = True
+
+    def apply(self, subject: str, events: Iterable[StateEvent]) -> None:
+        values = self._values.setdefault(subject, OrderedDict())
+        observed_at = self._clock()
+        for event in events:
+            values[event.uuid] = StateRecord(
+                uuid=event.uuid,
+                value=event.value,
+                freshness=Freshness.CURRENT,
+                observed_at=observed_at,
+            )
+            values.move_to_end(event.uuid)
+            while len(values) > self._max_states:
+                values.popitem(last=False)
+        self._available[subject] = True
+
+    def disconnect(self, subject: str) -> None:
+        values = self._values.setdefault(subject, OrderedDict())
+        for uuid, record in tuple(values.items()):
+            values[uuid] = replace(record, freshness=Freshness.STALE)
+        self._available[subject] = False
+
+    def get(self, subject: str, uuid: str) -> StateRecord:
+        values = self._values.get(subject)
+        record = values.get(uuid) if values is not None else None
+        if record is not None:
+            return record
+        freshness = (
+            Freshness.UNKNOWN if self._available.get(subject, False) else Freshness.UNAVAILABLE
+        )
+        return StateRecord(uuid=uuid, value=None, freshness=freshness, observed_at=None)
+
+    def clear(self, subject: str) -> None:
+        self._values.pop(subject, None)
+        self._available.pop(subject, None)

--- a/src/mcpserver/loxone/client.py
+++ b/src/mcpserver/loxone/client.py
@@ -1,0 +1,403 @@
+"""Asynchronous Gen. 1 client with strict local transport boundaries."""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import json
+import logging
+from collections.abc import AsyncIterator, Mapping
+from dataclasses import dataclass, field
+from typing import Any, Final
+from urllib.parse import quote, urlsplit
+from uuid import UUID
+
+import httpx
+from websockets.asyncio.client import ClientConnection, connect
+from websockets.typing import Subprotocol
+
+from mcpserver.loxone.events import (
+    LoxoneProtocolError,
+    MessageHeader,
+    MessageType,
+    StateEvent,
+    parse_header,
+    parse_state_events,
+)
+from mcpserver.loxone.models import LoxoneStructure
+from mcpserver.loxone.security import (
+    CommandEncryptor,
+    LoxoneSecurityError,
+    normalize_rsa_public_key_pem,
+    password_hmac,
+    token_hmac,
+)
+from mcpserver.loxone.structure import normalize_structure
+
+_LOGGER = logging.getLogger(__name__)
+_MAX_RESPONSE_BYTES: Final = 8 * 1024 * 1024
+_DEFAULT_TIMEOUT_SECONDS: Final = 10.0
+_APP_PERMISSION: Final = 4
+_GEN1_IPV4_NETWORKS: Final = tuple(
+    ipaddress.ip_network(value) for value in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")
+)
+_GEN1_IPV6_NETWORK: Final = ipaddress.ip_network("fc00::/7")
+
+
+class LoxoneConnectionError(RuntimeError):
+    """Sanitized error raised when the Miniserver cannot be used securely."""
+
+
+def _loxone_uuid(value: UUID) -> str:
+    """Serialize a standard UUID using Loxone's 8-4-4-16 representation."""
+    first, second, third, fourth, fifth = str(value).split("-")
+    return f"{first}-{second}-{third}-{fourth}{fifth}"
+
+
+@dataclass(frozen=True, slots=True)
+class MiniserverEndpoint:
+    """A literal private Gen. 1 HTTP endpoint without path or credentials."""
+
+    origin: str
+    host: str
+    port: int
+
+    @classmethod
+    def parse_gen1(cls, value: str) -> MiniserverEndpoint:
+        parsed = urlsplit(value)
+        if (
+            parsed.scheme != "http"
+            or parsed.hostname is None
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.path not in {"", "/"}
+            or parsed.query
+            or parsed.fragment
+        ):
+            raise ValueError("Gen. 1 endpoint must be a plain HTTP origin without credentials")
+        try:
+            address = ipaddress.ip_address(parsed.hostname)
+            port = parsed.port or 80
+        except ValueError as exc:
+            raise ValueError("Gen. 1 endpoint must use a literal private IP address") from exc
+        is_allowed = (
+            any(address in network for network in _GEN1_IPV4_NETWORKS)
+            if isinstance(address, ipaddress.IPv4Address)
+            else address in _GEN1_IPV6_NETWORK
+        )
+        if not is_allowed:
+            raise ValueError("Gen. 1 endpoint must use a private local IP address")
+        host = f"[{address}]" if address.version == 6 else str(address)
+        origin = f"http://{host}" if port == 80 else f"http://{host}:{port}"
+        if value.rstrip("/") != origin:
+            raise ValueError("Gen. 1 endpoint must use a canonical origin")
+        return cls(origin=origin, host=str(address), port=port)
+
+    @property
+    def websocket_url(self) -> str:
+        host = f"[{self.host}]" if ":" in self.host else self.host
+        authority = host if self.port == 80 else f"{host}:{self.port}"
+        return f"ws://{authority}/ws/rfc6455"
+
+
+@dataclass(frozen=True, slots=True)
+class ProbeResult:
+    firmware: str
+    serial: str
+    is_local: bool | None
+    has_event_slots: bool | None
+
+
+@dataclass(slots=True)
+class LoxoneToken:
+    """Ephemeral JWT and the hash key returned with it."""
+
+    value: str = field(repr=False)
+    username: str
+    hash_key: str = field(repr=False)
+    hash_algorithm: str
+    valid_until: int
+
+    def destroy(self) -> None:
+        self.value = ""
+        self.hash_key = ""
+        self.hash_algorithm = ""
+
+
+def _response_value(document: Mapping[str, Any]) -> Any:
+    wrapper = document.get("LL")
+    if not isinstance(wrapper, Mapping):
+        raise LoxoneConnectionError("Miniserver returned an invalid response")
+    code = wrapper.get("Code", wrapper.get("code"))
+    if str(code) != "200":
+        raise LoxoneConnectionError("Miniserver rejected the request")
+    return wrapper.get("value")
+
+
+class LoxoneClient:
+    """Acquire an ephemeral JWT and open user-filtered WebSocket sessions."""
+
+    def __init__(
+        self,
+        endpoint: MiniserverEndpoint,
+        *,
+        client_uuid: UUID,
+        client_name: str = "LoxBerry MCP Server",
+        timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+        max_response_bytes: int = _MAX_RESPONSE_BYTES,
+    ) -> None:
+        self.endpoint = endpoint
+        self.client_uuid = client_uuid
+        self.client_name = client_name
+        self.timeout_seconds = timeout_seconds
+        self.max_response_bytes = max_response_bytes
+
+    async def _get_json(self, path: str) -> Mapping[str, Any]:
+        try:
+            async with httpx.AsyncClient(
+                base_url=self.endpoint.origin,
+                follow_redirects=False,
+                timeout=self.timeout_seconds,
+                trust_env=False,
+            ) as client:
+                response = await client.get(path)
+                response.raise_for_status()
+                if len(response.content) > self.max_response_bytes:
+                    raise LoxoneConnectionError("Miniserver response exceeds the configured limit")
+                value = response.json()
+        except (httpx.HTTPError, json.JSONDecodeError):
+            # httpx exceptions may contain the complete encrypted request URL.
+            # Suppress the cause so callers and logs only see this fixed text.
+            raise LoxoneConnectionError("Miniserver request failed") from None
+        if not isinstance(value, Mapping):
+            raise LoxoneConnectionError("Miniserver returned an invalid response")
+        return value
+
+    async def probe(self) -> ProbeResult:
+        value = _response_value(await self._get_json("/jdev/cfg/apiKey"))
+        if not isinstance(value, Mapping):
+            raise LoxoneConnectionError("Miniserver probe returned an invalid value")
+        https_status = value.get("httpsStatus")
+        if https_status not in {None, 0, "0"}:
+            raise LoxoneConnectionError("TLS-capable Miniservers require the Gen. 2 HTTPS adapter")
+        firmware = value.get("version", value.get("versionStr"))
+        serial = value.get("snr", value.get("serialNr"))
+        if not isinstance(firmware, str) or not isinstance(serial, str):
+            raise LoxoneConnectionError("Miniserver probe omitted identity data")
+        local = value.get("local")
+        if local is False or local == 0:
+            raise LoxoneConnectionError("Gen. 1 connections must be local")
+        slots = value.get("hasEventSlots")
+        return ProbeResult(
+            firmware=firmware,
+            serial=serial,
+            is_local=local if isinstance(local, bool) else None,
+            has_event_slots=slots if isinstance(slots, bool) else None,
+        )
+
+    async def public_key(self) -> str:
+        value = _response_value(await self._get_json("/jdev/sys/getPublicKey"))
+        if not isinstance(value, str):
+            raise LoxoneConnectionError("Miniserver returned an invalid public key")
+        try:
+            return normalize_rsa_public_key_pem(value)
+        except LoxoneSecurityError as exc:
+            raise LoxoneConnectionError("Miniserver returned an invalid public key") from exc
+
+    async def acquire_token(self, username: str, password: str) -> LoxoneToken:
+        public_key = await self.public_key()
+        escaped_user = quote(username, safe="")
+        key_value = _response_value(await self._get_json(f"/jdev/sys/getkey2/{escaped_user}"))
+        if not isinstance(key_value, Mapping):
+            raise LoxoneConnectionError("Miniserver returned invalid hashing parameters")
+        key = key_value.get("key")
+        salt = key_value.get("salt")
+        algorithm = key_value.get("hashAlg")
+        if not isinstance(key, str) or not isinstance(salt, str) or not isinstance(algorithm, str):
+            raise LoxoneConnectionError("Miniserver returned invalid hashing parameters")
+        credential_hash = password_hmac(username, password, key, salt, algorithm)
+        info = quote(self.client_name, safe="")
+        command = (
+            f"jdev/sys/getjwt/{credential_hash}/{escaped_user}/{_APP_PERMISSION}/"
+            f"{_loxone_uuid(self.client_uuid)}/{info}"
+        )
+        encrypted_path = CommandEncryptor.generate().encrypted_http_request(command, public_key)
+        token_value = _response_value(await self._get_json(encrypted_path))
+        if not isinstance(token_value, Mapping):
+            raise LoxoneConnectionError("Miniserver returned an invalid token")
+        token = token_value.get("token")
+        token_key = token_value.get("key")
+        valid_until = token_value.get("validUntil")
+        if (
+            not isinstance(token, str)
+            or not isinstance(token_key, str)
+            or not isinstance(valid_until, int)
+        ):
+            raise LoxoneConnectionError("Miniserver returned an invalid token")
+        return LoxoneToken(token, username, token_key, algorithm, valid_until)
+
+    async def kill_token(self, token: LoxoneToken) -> None:
+        if not token.value:
+            return
+        public_key = await self.public_key()
+        digest = token_hmac(token.value, token.hash_key, token.hash_algorithm)
+        user = quote(token.username, safe="")
+        command = f"jdev/sys/killtoken/{digest}/{user}"
+        try:
+            encrypted_path = CommandEncryptor.generate().encrypted_http_request(command, public_key)
+            _response_value(await self._get_json(encrypted_path))
+        finally:
+            token.destroy()
+
+    async def open_session(self, token: LoxoneToken) -> LoxoneWebSocketSession:
+        if not token.value:
+            raise LoxoneConnectionError("Loxone token is no longer available")
+        public_key = await self.public_key()
+        try:
+            websocket = await asyncio.wait_for(
+                connect(
+                    self.endpoint.websocket_url,
+                    subprotocols=[Subprotocol("remotecontrol")],
+                    max_size=self.max_response_bytes,
+                    open_timeout=self.timeout_seconds,
+                    proxy=None,
+                ),
+                timeout=self.timeout_seconds,
+            )
+        except (OSError, TimeoutError) as exc:
+            raise LoxoneConnectionError("Miniserver WebSocket connection failed") from exc
+        session = LoxoneWebSocketSession(
+            websocket,
+            public_key=public_key,
+            token=token,
+            timeout_seconds=self.timeout_seconds,
+            max_payload_bytes=self.max_response_bytes,
+        )
+        try:
+            await session.authenticate()
+        except Exception:
+            await session.close()
+            raise
+        return session
+
+
+class LoxoneWebSocketSession:
+    """One authenticated, user-bound WebSocket session."""
+
+    def __init__(
+        self,
+        websocket: ClientConnection,
+        *,
+        public_key: str,
+        token: LoxoneToken,
+        timeout_seconds: float,
+        max_payload_bytes: int,
+    ) -> None:
+        self._websocket = websocket
+        self._public_key = public_key
+        self._token = token
+        self._timeout = timeout_seconds
+        self._max_payload = max_payload_bytes
+        self._encryptor = CommandEncryptor.generate()
+
+    async def _receive(self) -> tuple[MessageHeader, str | bytes | None]:
+        while True:
+            raw_header = await asyncio.wait_for(self._websocket.recv(), timeout=self._timeout)
+            if not isinstance(raw_header, bytes):
+                raise LoxoneProtocolError("Expected a binary WebSocket header")
+            header = parse_header(raw_header, max_payload_bytes=self._max_payload)
+            if header.estimated:
+                continue
+            if header.message_type in {MessageType.OUT_OF_SERVICE, MessageType.KEEPALIVE}:
+                return header, None
+            payload = await asyncio.wait_for(self._websocket.recv(), timeout=self._timeout)
+            actual_size = len(payload.encode() if isinstance(payload, str) else payload)
+            if actual_size != header.payload_length:
+                raise LoxoneProtocolError("WebSocket payload length does not match its header")
+            return header, payload
+
+    async def _command(self, command: str, *, encrypted: bool = False) -> Any:
+        outgoing = self._encryptor.encrypted_command(command) if encrypted else command
+        await self._websocket.send(outgoing)
+        header, payload = await self._receive()
+        if header.message_type is not MessageType.TEXT or not isinstance(payload, str):
+            raise LoxoneProtocolError("Miniserver command response is not text")
+        try:
+            response = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise LoxoneProtocolError("Miniserver command response is not JSON") from exc
+        if not isinstance(response, Mapping):
+            raise LoxoneProtocolError("Miniserver command response is invalid")
+        return _response_value(response)
+
+    async def authenticate(self) -> None:
+        session_key = self._encryptor.encrypted_session_key(self._public_key)
+        await self._command(f"jdev/sys/keyexchange/{session_key}")
+        digest = token_hmac(
+            self._token.value,
+            self._token.hash_key,
+            self._token.hash_algorithm,
+        )
+        await self._command(
+            f"authwithtoken/{digest}/{quote(self._token.username, safe='')}",
+            encrypted=True,
+        )
+
+    async def load_structure(self) -> LoxoneStructure:
+        await self._websocket.send("data/LoxAPP3.json")
+        header, payload = await self._receive()
+        if header.message_type is not MessageType.TEXT or not isinstance(payload, str):
+            raise LoxoneProtocolError("Miniserver structure response is not text")
+        try:
+            document = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise LoxoneProtocolError("Miniserver structure response is not JSON") from exc
+        if not isinstance(document, Mapping):
+            raise LoxoneProtocolError("Miniserver structure response is invalid")
+        return normalize_structure(document, username=self._token.username)
+
+    async def refresh_token(self) -> None:
+        """Rotate the in-memory JWT over the authenticated encrypted WebSocket."""
+        digest = token_hmac(
+            self._token.value,
+            self._token.hash_key,
+            self._token.hash_algorithm,
+        )
+        user = quote(self._token.username, safe="")
+        value = await self._command(f"jdev/sys/refreshjwt/{digest}/{user}", encrypted=True)
+        if not isinstance(value, Mapping):
+            raise LoxoneConnectionError("Miniserver returned an invalid refreshed token")
+        refreshed = value.get("token")
+        valid_until = value.get("validUntil")
+        if not isinstance(refreshed, str) or not isinstance(valid_until, int):
+            raise LoxoneConnectionError("Miniserver returned an invalid refreshed token")
+        self._token.value = refreshed
+        self._token.valid_until = valid_until
+
+    async def state_events(self) -> AsyncIterator[tuple[StateEvent, ...]]:
+        await self._command("jdev/sps/enablebinstatusupdate")
+        while True:
+            header, payload = await self._receive()
+            if header.message_type is MessageType.OUT_OF_SERVICE:
+                raise LoxoneConnectionError("Miniserver is temporarily out of service")
+            if header.message_type in {
+                MessageType.VALUE_STATES,
+                MessageType.TEXT_STATES,
+                MessageType.DAYTIMER_STATES,
+                MessageType.WEATHER_STATES,
+            }:
+                if not isinstance(payload, bytes):
+                    raise LoxoneProtocolError("State event payload is not binary")
+                yield parse_state_events(header.message_type, payload)
+
+    async def keepalive(self) -> None:
+        await self._websocket.send("keepalive")
+        header, _ = await self._receive()
+        if header.message_type is not MessageType.KEEPALIVE:
+            raise LoxoneProtocolError("Miniserver did not acknowledge keepalive")
+
+    async def close(self) -> None:
+        try:
+            await self._websocket.close()
+        except Exception as exc:  # pragma: no cover - best effort close
+            _LOGGER.debug("WebSocket close failed: %s", type(exc).__name__)

--- a/src/mcpserver/loxone/client.py
+++ b/src/mcpserver/loxone/client.py
@@ -50,6 +50,10 @@ class LoxoneConnectionError(RuntimeError):
     """Sanitized error raised when the Miniserver cannot be used securely."""
 
 
+class _WebSocketIdleTimeout(TimeoutError):
+    """No WebSocket header arrived within the configured idle interval."""
+
+
 def _loxone_uuid(value: UUID) -> str:
     """Serialize a standard UUID using Loxone's 8-4-4-16 representation."""
     first, second, third, fourth, fifth = str(value).split("-")
@@ -143,7 +147,10 @@ async def _receive_websocket(
     max_payload_bytes: int,
 ) -> tuple[MessageHeader, str | bytes | None]:
     while True:
-        raw_header = await asyncio.wait_for(websocket.recv(), timeout=timeout_seconds)
+        try:
+            raw_header = await asyncio.wait_for(websocket.recv(), timeout=timeout_seconds)
+        except TimeoutError:
+            raise _WebSocketIdleTimeout from None
         if not isinstance(raw_header, bytes):
             raise LoxoneProtocolError("Expected a binary WebSocket header")
         header = parse_header(raw_header, max_payload_bytes=max_payload_bytes)
@@ -218,40 +225,45 @@ class LoxoneClient:
         self.max_response_bytes = max_response_bytes
 
     async def _get_json(self, path: str) -> Mapping[str, Any]:
+        body, _encoding = await self._get_bytes(path)
         try:
-            async with httpx.AsyncClient(
-                base_url=self.endpoint.origin,
-                follow_redirects=False,
-                timeout=self.timeout_seconds,
-                trust_env=False,
-            ) as client:
-                response = await client.get(path)
-                response.raise_for_status()
-                if len(response.content) > self.max_response_bytes:
-                    raise LoxoneConnectionError("Miniserver response exceeds the configured limit")
-                value = response.json()
-        except (httpx.HTTPError, json.JSONDecodeError):
-            # httpx exceptions may contain the complete encrypted request URL.
-            # Suppress the cause so callers and logs only see this fixed text.
+            value = json.loads(body)
+        except (json.JSONDecodeError, UnicodeDecodeError):
             raise LoxoneConnectionError("Miniserver request failed") from None
         if not isinstance(value, Mapping):
             raise LoxoneConnectionError("Miniserver returned an invalid response")
         return value
 
     async def _get_text(self, path: str) -> str:
+        body, encoding = await self._get_bytes(path)
         try:
-            async with httpx.AsyncClient(
-                base_url=self.endpoint.origin,
-                follow_redirects=False,
-                timeout=self.timeout_seconds,
-                trust_env=False,
-            ) as client:
-                response = await client.get(path)
+            return body.decode(encoding)
+        except (LookupError, UnicodeDecodeError):
+            raise LoxoneConnectionError("Miniserver request failed") from None
+
+    async def _get_bytes(self, path: str) -> tuple[bytes, str]:
+        try:
+            async with (
+                httpx.AsyncClient(
+                    base_url=self.endpoint.origin,
+                    follow_redirects=False,
+                    timeout=self.timeout_seconds,
+                    trust_env=False,
+                ) as client,
+                client.stream("GET", path) as response,
+            ):
                 response.raise_for_status()
-                if len(response.content) > self.max_response_bytes:
-                    raise LoxoneConnectionError("Miniserver response exceeds the configured limit")
-                return response.text
+                body = bytearray()
+                async for chunk in response.aiter_bytes():
+                    if len(body) + len(chunk) > self.max_response_bytes:
+                        raise LoxoneConnectionError(
+                            "Miniserver response exceeds the configured limit"
+                        )
+                    body.extend(chunk)
+                return bytes(body), response.encoding or "utf-8"
         except httpx.HTTPError:
+            # httpx exceptions may contain the complete encrypted request URL.
+            # Suppress the cause so callers and logs only see this fixed text.
             raise LoxoneConnectionError("Miniserver request failed") from None
 
     async def probe(self) -> ProbeResult:
@@ -511,8 +523,17 @@ class LoxoneWebSocketSession:
 
     async def state_events(self) -> AsyncIterator[tuple[StateEvent, ...]]:
         await self._command("jdev/sps/enablebinstatusupdate")
+        keepalive_pending = False
         while True:
-            header, payload = await self._receive()
+            try:
+                header, payload = await self._receive()
+            except _WebSocketIdleTimeout:
+                if keepalive_pending:
+                    raise LoxoneConnectionError("Miniserver did not respond to keepalive") from None
+                await self._websocket.send("keepalive")
+                keepalive_pending = True
+                continue
+            keepalive_pending = False
             if header.message_type is MessageType.OUT_OF_SERVICE:
                 raise LoxoneConnectionError("Miniserver is temporarily out of service")
             if header.message_type in {

--- a/src/mcpserver/loxone/client.py
+++ b/src/mcpserver/loxone/client.py
@@ -154,7 +154,7 @@ async def _receive_websocket(
         actual_size = len(payload.encode() if isinstance(payload, str) else payload)
         if actual_size != header.payload_length:
             raise LoxoneProtocolError("WebSocket payload length does not match its header")
-    return header, payload
+        return header, payload
 
 
 async def _close_websocket(websocket: ClientConnection, timeout_seconds: float) -> None:

--- a/src/mcpserver/loxone/client.py
+++ b/src/mcpserver/loxone/client.py
@@ -151,8 +151,10 @@ async def _receive_websocket(
         if header.message_type in {MessageType.OUT_OF_SERVICE, MessageType.KEEPALIVE}:
             return header, None
         payload = await asyncio.wait_for(websocket.recv(), timeout=timeout_seconds)
-        actual_size = len(payload.encode() if isinstance(payload, str) else payload)
-        if actual_size != header.payload_length:
+        actual_sizes = {len(payload)}
+        if isinstance(payload, str):
+            actual_sizes.add(len(payload.encode("utf-8")))
+        if header.payload_length not in actual_sizes:
             raise LoxoneProtocolError("WebSocket payload length does not match its header")
         return header, payload
 
@@ -378,17 +380,13 @@ class LoxoneClient:
             or not isinstance(valid_until, int)
         ):
             raise LoxoneConnectionError("Miniserver returned an invalid token")
-        # The token key is equivalent to a getkey result. Token operations use
-        # HMAC-SHA1 independently of getkey2's password hashing algorithm.
-        return LoxoneToken(token, username, token_key, "SHA1", valid_until)
+        return LoxoneToken(token, username, token_key, algorithm, valid_until)
 
     async def kill_token(self, token: LoxoneToken) -> None:
         if not token.value:
             return
         public_key = await self.websocket_public_key()
-        digest = token_hmac(token.value, token.hash_key, token.hash_algorithm)
         user = quote(token.username, safe="")
-        command = f"jdev/sys/killtoken/{digest}/{user}"
         websocket = await self._connect_websocket()
         encryptor = CommandEncryptor.generate()
         try:
@@ -401,10 +399,21 @@ class LoxoneClient:
                 timeout_seconds=self.timeout_seconds,
                 max_payload_bytes=self.max_response_bytes,
             )
+            key = await _websocket_command(
+                websocket,
+                encryptor,
+                "jdev/sys/getkey",
+                encrypted=True,
+                timeout_seconds=self.timeout_seconds,
+                max_payload_bytes=self.max_response_bytes,
+            )
+            if not isinstance(key, str):
+                raise LoxoneConnectionError("Miniserver returned an invalid token hashing key")
+            digest = token_hmac(token.value, key, token.hash_algorithm)
             await _websocket_command(
                 websocket,
                 encryptor,
-                command,
+                f"jdev/sys/killtoken/{digest}/{user}",
                 encrypted=True,
                 timeout_seconds=self.timeout_seconds,
                 max_payload_bytes=self.max_response_bytes,
@@ -472,20 +481,24 @@ class LoxoneWebSocketSession:
     async def authenticate(self) -> None:
         session_key = self._encryptor.encrypted_session_key(self._public_key)
         await self._command(f"jdev/sys/keyexchange/{session_key}")
-        digest = token_hmac(
-            self._token.value,
-            self._token.hash_key,
-            self._token.hash_algorithm,
-        )
+        digest = await self._fresh_token_digest()
         await self._command(
             f"authwithtoken/{digest}/{quote(self._token.username, safe='')}",
             encrypted=True,
         )
 
+    async def _fresh_token_digest(self) -> str:
+        key = await self._command("jdev/sys/getkey", encrypted=True)
+        if not isinstance(key, str):
+            raise LoxoneConnectionError("Miniserver returned an invalid token hashing key")
+        return token_hmac(self._token.value, key, self._token.hash_algorithm)
+
     async def load_structure(self) -> LoxoneStructure:
         await self._websocket.send("data/LoxAPP3.json")
         header, payload = await self._receive()
-        if header.message_type is not MessageType.TEXT or not isinstance(payload, str):
+        if header.message_type not in {MessageType.TEXT, MessageType.BINARY_FILE} or not isinstance(
+            payload, str
+        ):
             raise LoxoneProtocolError("Miniserver structure response is not text")
         try:
             document = json.loads(payload)
@@ -497,11 +510,7 @@ class LoxoneWebSocketSession:
 
     async def refresh_token(self) -> None:
         """Rotate the in-memory JWT over the authenticated encrypted WebSocket."""
-        digest = token_hmac(
-            self._token.value,
-            self._token.hash_key,
-            self._token.hash_algorithm,
-        )
+        digest = await self._fresh_token_digest()
         user = quote(self._token.username, safe="")
         value = await self._command(f"jdev/sys/refreshjwt/{digest}/{user}", encrypted=True)
         if not isinstance(value, Mapping):

--- a/src/mcpserver/loxone/client.py
+++ b/src/mcpserver/loxone/client.py
@@ -154,7 +154,15 @@ async def _receive_websocket(
         actual_size = len(payload.encode() if isinstance(payload, str) else payload)
         if actual_size != header.payload_length:
             raise LoxoneProtocolError("WebSocket payload length does not match its header")
-        return header, payload
+    return header, payload
+
+
+async def _close_websocket(websocket: ClientConnection, timeout_seconds: float) -> None:
+    """Close without allowing an unresponsive peer to block cleanup indefinitely."""
+    try:
+        await asyncio.wait_for(websocket.close(), timeout=timeout_seconds)
+    except (OSError, TimeoutError) as exc:  # pragma: no cover - transport dependent
+        _LOGGER.debug("WebSocket close failed: %s", type(exc).__name__)
 
 
 async def _websocket_command(
@@ -301,6 +309,7 @@ class LoxoneClient:
                     subprotocols=[Subprotocol("remotecontrol")],
                     max_size=self.max_response_bytes,
                     open_timeout=self.timeout_seconds,
+                    close_timeout=self.timeout_seconds,
                     proxy=None,
                 ),
                 timeout=self.timeout_seconds,
@@ -357,7 +366,7 @@ class LoxoneClient:
                 max_payload_bytes=self.max_response_bytes,
             )
         finally:
-            await websocket.close()
+            await _close_websocket(websocket, self.timeout_seconds)
         if not isinstance(token_value, Mapping):
             raise LoxoneConnectionError("Miniserver returned an invalid token")
         token = token_value.get("token")
@@ -401,7 +410,7 @@ class LoxoneClient:
                 max_payload_bytes=self.max_response_bytes,
             )
         finally:
-            await websocket.close()
+            await _close_websocket(websocket, self.timeout_seconds)
             token.destroy()
 
     async def open_session(self, token: LoxoneToken) -> LoxoneWebSocketSession:
@@ -527,7 +536,4 @@ class LoxoneWebSocketSession:
             raise LoxoneProtocolError("Miniserver did not acknowledge keepalive")
 
     async def close(self) -> None:
-        try:
-            await self._websocket.close()
-        except Exception as exc:  # pragma: no cover - best effort close
-            _LOGGER.debug("WebSocket close failed: %s", type(exc).__name__)
+        await _close_websocket(self._websocket, self._timeout)

--- a/src/mcpserver/loxone/client.py
+++ b/src/mcpserver/loxone/client.py
@@ -28,6 +28,7 @@ from mcpserver.loxone.models import LoxoneStructure
 from mcpserver.loxone.security import (
     CommandEncryptor,
     LoxoneSecurityError,
+    normalize_loxone_certificate_chain_pem,
     normalize_rsa_public_key_pem,
     password_hmac,
     token_hmac,
@@ -134,6 +135,55 @@ def _response_value(document: Mapping[str, Any]) -> Any:
     return wrapper.get("value")
 
 
+async def _receive_websocket(
+    websocket: ClientConnection,
+    *,
+    timeout_seconds: float,
+    max_payload_bytes: int,
+) -> tuple[MessageHeader, str | bytes | None]:
+    while True:
+        raw_header = await asyncio.wait_for(websocket.recv(), timeout=timeout_seconds)
+        if not isinstance(raw_header, bytes):
+            raise LoxoneProtocolError("Expected a binary WebSocket header")
+        header = parse_header(raw_header, max_payload_bytes=max_payload_bytes)
+        if header.estimated:
+            continue
+        if header.message_type in {MessageType.OUT_OF_SERVICE, MessageType.KEEPALIVE}:
+            return header, None
+        payload = await asyncio.wait_for(websocket.recv(), timeout=timeout_seconds)
+        actual_size = len(payload.encode() if isinstance(payload, str) else payload)
+        if actual_size != header.payload_length:
+            raise LoxoneProtocolError("WebSocket payload length does not match its header")
+        return header, payload
+
+
+async def _websocket_command(
+    websocket: ClientConnection,
+    encryptor: CommandEncryptor,
+    command: str,
+    *,
+    encrypted: bool,
+    timeout_seconds: float,
+    max_payload_bytes: int,
+) -> Any:
+    outgoing = encryptor.encrypted_command(command) if encrypted else command
+    await websocket.send(outgoing)
+    header, payload = await _receive_websocket(
+        websocket,
+        timeout_seconds=timeout_seconds,
+        max_payload_bytes=max_payload_bytes,
+    )
+    if header.message_type is not MessageType.TEXT or not isinstance(payload, str):
+        raise LoxoneProtocolError("Miniserver command response is not text")
+    try:
+        response = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise LoxoneProtocolError("Miniserver command response is not JSON") from exc
+    if not isinstance(response, Mapping):
+        raise LoxoneProtocolError("Miniserver command response is invalid")
+    return _response_value(response)
+
+
 class LoxoneClient:
     """Acquire an ephemeral JWT and open user-filtered WebSocket sessions."""
 
@@ -173,6 +223,22 @@ class LoxoneClient:
             raise LoxoneConnectionError("Miniserver returned an invalid response")
         return value
 
+    async def _get_text(self, path: str) -> str:
+        try:
+            async with httpx.AsyncClient(
+                base_url=self.endpoint.origin,
+                follow_redirects=False,
+                timeout=self.timeout_seconds,
+                trust_env=False,
+            ) as client:
+                response = await client.get(path)
+                response.raise_for_status()
+                if len(response.content) > self.max_response_bytes:
+                    raise LoxoneConnectionError("Miniserver response exceeds the configured limit")
+                return response.text
+        except httpx.HTTPError:
+            raise LoxoneConnectionError("Miniserver request failed") from None
+
     async def probe(self) -> ProbeResult:
         value = _response_value(await self._get_json("/jdev/cfg/apiKey"))
         if not isinstance(value, Mapping):
@@ -204,25 +270,78 @@ class LoxoneClient:
         except LoxoneSecurityError as exc:
             raise LoxoneConnectionError("Miniserver returned an invalid public key") from exc
 
+    async def websocket_public_key(self) -> str:
+        value = await self._get_text("/jdev/sys/getcertificate")
+        try:
+            return normalize_loxone_certificate_chain_pem(value)
+        except LoxoneSecurityError as exc:
+            raise LoxoneConnectionError("Miniserver returned an invalid certificate chain") from exc
+
+    async def _connect_websocket(self) -> ClientConnection:
+        try:
+            return await asyncio.wait_for(
+                connect(
+                    self.endpoint.websocket_url,
+                    subprotocols=[Subprotocol("remotecontrol")],
+                    max_size=self.max_response_bytes,
+                    open_timeout=self.timeout_seconds,
+                    proxy=None,
+                ),
+                timeout=self.timeout_seconds,
+            )
+        except (OSError, TimeoutError) as exc:
+            raise LoxoneConnectionError("Miniserver WebSocket connection failed") from exc
+
     async def acquire_token(self, username: str, password: str) -> LoxoneToken:
-        public_key = await self.public_key()
+        public_key = await self.websocket_public_key()
         escaped_user = quote(username, safe="")
-        key_value = _response_value(await self._get_json(f"/jdev/sys/getkey2/{escaped_user}"))
-        if not isinstance(key_value, Mapping):
-            raise LoxoneConnectionError("Miniserver returned invalid hashing parameters")
-        key = key_value.get("key")
-        salt = key_value.get("salt")
-        algorithm = key_value.get("hashAlg")
-        if not isinstance(key, str) or not isinstance(salt, str) or not isinstance(algorithm, str):
-            raise LoxoneConnectionError("Miniserver returned invalid hashing parameters")
-        credential_hash = password_hmac(username, password, key, salt, algorithm)
-        info = quote(self.client_name, safe="")
-        command = (
-            f"jdev/sys/getjwt/{credential_hash}/{escaped_user}/{_APP_PERMISSION}/"
-            f"{_loxone_uuid(self.client_uuid)}/{info}"
-        )
-        encrypted_path = CommandEncryptor.generate().encrypted_http_request(command, public_key)
-        token_value = _response_value(await self._get_json(encrypted_path))
+        websocket = await self._connect_websocket()
+        encryptor = CommandEncryptor.generate()
+        try:
+            session_key = encryptor.encrypted_session_key(public_key)
+            await _websocket_command(
+                websocket,
+                encryptor,
+                f"jdev/sys/keyexchange/{session_key}",
+                encrypted=False,
+                timeout_seconds=self.timeout_seconds,
+                max_payload_bytes=self.max_response_bytes,
+            )
+            key_value = await _websocket_command(
+                websocket,
+                encryptor,
+                f"jdev/sys/getkey2/{escaped_user}",
+                encrypted=True,
+                timeout_seconds=self.timeout_seconds,
+                max_payload_bytes=self.max_response_bytes,
+            )
+            if not isinstance(key_value, Mapping):
+                raise LoxoneConnectionError("Miniserver returned invalid hashing parameters")
+            key = key_value.get("key")
+            salt = key_value.get("salt")
+            algorithm = key_value.get("hashAlg")
+            if (
+                not isinstance(key, str)
+                or not isinstance(salt, str)
+                or not isinstance(algorithm, str)
+            ):
+                raise LoxoneConnectionError("Miniserver returned invalid hashing parameters")
+            credential_hash = password_hmac(username, password, key, salt, algorithm)
+            info = quote(self.client_name, safe="")
+            command = (
+                f"jdev/sys/getjwt/{credential_hash}/{escaped_user}/{_APP_PERMISSION}/"
+                f"{_loxone_uuid(self.client_uuid)}/{info}"
+            )
+            token_value = await _websocket_command(
+                websocket,
+                encryptor,
+                command,
+                encrypted=True,
+                timeout_seconds=self.timeout_seconds,
+                max_payload_bytes=self.max_response_bytes,
+            )
+        finally:
+            await websocket.close()
         if not isinstance(token_value, Mapping):
             raise LoxoneConnectionError("Miniserver returned an invalid token")
         token = token_value.get("token")
@@ -252,20 +371,8 @@ class LoxoneClient:
     async def open_session(self, token: LoxoneToken) -> LoxoneWebSocketSession:
         if not token.value:
             raise LoxoneConnectionError("Loxone token is no longer available")
-        public_key = await self.public_key()
-        try:
-            websocket = await asyncio.wait_for(
-                connect(
-                    self.endpoint.websocket_url,
-                    subprotocols=[Subprotocol("remotecontrol")],
-                    max_size=self.max_response_bytes,
-                    open_timeout=self.timeout_seconds,
-                    proxy=None,
-                ),
-                timeout=self.timeout_seconds,
-            )
-        except (OSError, TimeoutError) as exc:
-            raise LoxoneConnectionError("Miniserver WebSocket connection failed") from exc
+        public_key = await self.websocket_public_key()
+        websocket = await self._connect_websocket()
         session = LoxoneWebSocketSession(
             websocket,
             public_key=public_key,
@@ -301,34 +408,21 @@ class LoxoneWebSocketSession:
         self._encryptor = CommandEncryptor.generate()
 
     async def _receive(self) -> tuple[MessageHeader, str | bytes | None]:
-        while True:
-            raw_header = await asyncio.wait_for(self._websocket.recv(), timeout=self._timeout)
-            if not isinstance(raw_header, bytes):
-                raise LoxoneProtocolError("Expected a binary WebSocket header")
-            header = parse_header(raw_header, max_payload_bytes=self._max_payload)
-            if header.estimated:
-                continue
-            if header.message_type in {MessageType.OUT_OF_SERVICE, MessageType.KEEPALIVE}:
-                return header, None
-            payload = await asyncio.wait_for(self._websocket.recv(), timeout=self._timeout)
-            actual_size = len(payload.encode() if isinstance(payload, str) else payload)
-            if actual_size != header.payload_length:
-                raise LoxoneProtocolError("WebSocket payload length does not match its header")
-            return header, payload
+        return await _receive_websocket(
+            self._websocket,
+            timeout_seconds=self._timeout,
+            max_payload_bytes=self._max_payload,
+        )
 
     async def _command(self, command: str, *, encrypted: bool = False) -> Any:
-        outgoing = self._encryptor.encrypted_command(command) if encrypted else command
-        await self._websocket.send(outgoing)
-        header, payload = await self._receive()
-        if header.message_type is not MessageType.TEXT or not isinstance(payload, str):
-            raise LoxoneProtocolError("Miniserver command response is not text")
-        try:
-            response = json.loads(payload)
-        except json.JSONDecodeError as exc:
-            raise LoxoneProtocolError("Miniserver command response is not JSON") from exc
-        if not isinstance(response, Mapping):
-            raise LoxoneProtocolError("Miniserver command response is invalid")
-        return _response_value(response)
+        return await _websocket_command(
+            self._websocket,
+            self._encryptor,
+            command,
+            encrypted=encrypted,
+            timeout_seconds=self._timeout,
+            max_payload_bytes=self._max_payload,
+        )
 
     async def authenticate(self) -> None:
         session_key = self._encryptor.encrypted_session_key(self._public_key)

--- a/src/mcpserver/loxone/client.py
+++ b/src/mcpserver/loxone/client.py
@@ -14,6 +14,7 @@ from uuid import UUID
 
 import httpx
 from websockets.asyncio.client import ClientConnection, connect
+from websockets.exceptions import ConnectionClosedOK
 from websockets.typing import Subprotocol
 
 from mcpserver.loxone.events import (
@@ -152,35 +153,15 @@ async def _receive_websocket(
             return header, None
         payload = await asyncio.wait_for(websocket.recv(), timeout=timeout_seconds)
         if isinstance(payload, str):
-            combined_text = payload
-            while True:
-                actual_sizes = {len(combined_text)}
-                encoded_size = len(combined_text.encode("utf-8"))
-                if encoded_size > max_payload_bytes:
-                    raise LoxoneProtocolError("WebSocket text payload exceeds the configured limit")
-                actual_sizes.add(encoded_size)
-                if header.payload_length in actual_sizes:
-                    return header, combined_text
-                if min(actual_sizes) > header.payload_length:
-                    raise LoxoneProtocolError("WebSocket payload length does not match its header")
-                chunk = await asyncio.wait_for(websocket.recv(), timeout=timeout_seconds)
-                if not isinstance(chunk, str):
-                    raise LoxoneProtocolError("WebSocket payload changes type between chunks")
-                combined_text += chunk
-        else:
-            combined_bytes = payload
-            while len(combined_bytes) < header.payload_length:
-                chunk = await asyncio.wait_for(websocket.recv(), timeout=timeout_seconds)
-                if not isinstance(chunk, bytes):
-                    raise LoxoneProtocolError("WebSocket payload changes type between chunks")
-                combined_bytes += chunk
-                if len(combined_bytes) > max_payload_bytes:
-                    raise LoxoneProtocolError(
-                        "WebSocket binary payload exceeds the configured limit"
-                    )
-            if len(combined_bytes) != header.payload_length:
+            actual_sizes = {len(payload), len(payload.encode("utf-8"))}
+            if max(actual_sizes) > max_payload_bytes:
+                raise LoxoneProtocolError("WebSocket text payload exceeds the configured limit")
+            if header.payload_length not in actual_sizes:
                 raise LoxoneProtocolError("WebSocket payload length does not match its header")
-            return header, combined_bytes
+            return header, payload
+        if len(payload) != header.payload_length:
+            raise LoxoneProtocolError("WebSocket payload length does not match its header")
+        return header, payload
 
 
 async def _close_websocket(websocket: ClientConnection, timeout_seconds: float) -> None:
@@ -520,7 +501,13 @@ class LoxoneWebSocketSession:
         """Invalidate the current token over this authenticated session."""
         digest = await self._fresh_token_digest()
         user = quote(self._token.username, safe="")
-        await self._command(f"jdev/sys/killtoken/{digest}/{user}", encrypted=True)
+        try:
+            await self._command(f"jdev/sys/killtoken/{digest}/{user}", encrypted=True)
+        except ConnectionClosedOK:
+            # A Miniserver may close the authenticated connection immediately
+            # after invalidating the connection token. A normal close is the
+            # successful terminal response in that case.
+            return
 
     async def state_events(self) -> AsyncIterator[tuple[StateEvent, ...]]:
         await self._command("jdev/sps/enablebinstatusupdate")

--- a/src/mcpserver/loxone/client.py
+++ b/src/mcpserver/loxone/client.py
@@ -151,12 +151,36 @@ async def _receive_websocket(
         if header.message_type in {MessageType.OUT_OF_SERVICE, MessageType.KEEPALIVE}:
             return header, None
         payload = await asyncio.wait_for(websocket.recv(), timeout=timeout_seconds)
-        actual_sizes = {len(payload)}
         if isinstance(payload, str):
-            actual_sizes.add(len(payload.encode("utf-8")))
-        if header.payload_length not in actual_sizes:
-            raise LoxoneProtocolError("WebSocket payload length does not match its header")
-        return header, payload
+            combined_text = payload
+            while True:
+                actual_sizes = {len(combined_text)}
+                encoded_size = len(combined_text.encode("utf-8"))
+                if encoded_size > max_payload_bytes:
+                    raise LoxoneProtocolError("WebSocket text payload exceeds the configured limit")
+                actual_sizes.add(encoded_size)
+                if header.payload_length in actual_sizes:
+                    return header, combined_text
+                if min(actual_sizes) > header.payload_length:
+                    raise LoxoneProtocolError("WebSocket payload length does not match its header")
+                chunk = await asyncio.wait_for(websocket.recv(), timeout=timeout_seconds)
+                if not isinstance(chunk, str):
+                    raise LoxoneProtocolError("WebSocket payload changes type between chunks")
+                combined_text += chunk
+        else:
+            combined_bytes = payload
+            while len(combined_bytes) < header.payload_length:
+                chunk = await asyncio.wait_for(websocket.recv(), timeout=timeout_seconds)
+                if not isinstance(chunk, bytes):
+                    raise LoxoneProtocolError("WebSocket payload changes type between chunks")
+                combined_bytes += chunk
+                if len(combined_bytes) > max_payload_bytes:
+                    raise LoxoneProtocolError(
+                        "WebSocket binary payload exceeds the configured limit"
+                    )
+            if len(combined_bytes) != header.payload_length:
+                raise LoxoneProtocolError("WebSocket payload length does not match its header")
+            return header, combined_bytes
 
 
 async def _close_websocket(websocket: ClientConnection, timeout_seconds: float) -> None:
@@ -385,41 +409,11 @@ class LoxoneClient:
     async def kill_token(self, token: LoxoneToken) -> None:
         if not token.value:
             return
-        public_key = await self.websocket_public_key()
-        user = quote(token.username, safe="")
-        websocket = await self._connect_websocket()
-        encryptor = CommandEncryptor.generate()
+        session = await self.open_session(token)
         try:
-            session_key = encryptor.encrypted_session_key(public_key)
-            await _websocket_command(
-                websocket,
-                encryptor,
-                f"jdev/sys/keyexchange/{session_key}",
-                encrypted=False,
-                timeout_seconds=self.timeout_seconds,
-                max_payload_bytes=self.max_response_bytes,
-            )
-            key = await _websocket_command(
-                websocket,
-                encryptor,
-                "jdev/sys/getkey",
-                encrypted=True,
-                timeout_seconds=self.timeout_seconds,
-                max_payload_bytes=self.max_response_bytes,
-            )
-            if not isinstance(key, str):
-                raise LoxoneConnectionError("Miniserver returned an invalid token hashing key")
-            digest = token_hmac(token.value, key, token.hash_algorithm)
-            await _websocket_command(
-                websocket,
-                encryptor,
-                f"jdev/sys/killtoken/{digest}/{user}",
-                encrypted=True,
-                timeout_seconds=self.timeout_seconds,
-                max_payload_bytes=self.max_response_bytes,
-            )
+            await session.kill_token()
         finally:
-            await _close_websocket(websocket, self.timeout_seconds)
+            await session.close()
             token.destroy()
 
     async def open_session(self, token: LoxoneToken) -> LoxoneWebSocketSession:
@@ -521,6 +515,12 @@ class LoxoneWebSocketSession:
             raise LoxoneConnectionError("Miniserver returned an invalid refreshed token")
         self._token.value = refreshed
         self._token.valid_until = valid_until
+
+    async def kill_token(self) -> None:
+        """Invalidate the current token over this authenticated session."""
+        digest = await self._fresh_token_digest()
+        user = quote(self._token.username, safe="")
+        await self._command(f"jdev/sys/killtoken/{digest}/{user}", encrypted=True)
 
     async def state_events(self) -> AsyncIterator[tuple[StateEvent, ...]]:
         await self._command("jdev/sps/enablebinstatusupdate")

--- a/src/mcpserver/loxone/client.py
+++ b/src/mcpserver/loxone/client.py
@@ -241,6 +241,22 @@ class LoxoneClient:
 
     async def probe(self) -> ProbeResult:
         value = _response_value(await self._get_json("/jdev/cfg/apiKey"))
+        if isinstance(value, str):
+            try:
+                value = json.loads(value)
+            except json.JSONDecodeError:
+                # Gen. 1 returns this fixed, flat object with JavaScript-style
+                # single-quoted keys and strings instead of valid JSON.
+                if not value.startswith("{'") or '"' in value:
+                    raise LoxoneConnectionError(
+                        "Miniserver probe returned an invalid value"
+                    ) from None
+                try:
+                    value = json.loads(value.replace("'", '"'))
+                except json.JSONDecodeError:
+                    raise LoxoneConnectionError(
+                        "Miniserver probe returned an invalid value"
+                    ) from None
         if not isinstance(value, Mapping):
             raise LoxoneConnectionError("Miniserver probe returned an invalid value")
         https_status = value.get("httpsStatus")
@@ -353,19 +369,39 @@ class LoxoneClient:
             or not isinstance(valid_until, int)
         ):
             raise LoxoneConnectionError("Miniserver returned an invalid token")
-        return LoxoneToken(token, username, token_key, algorithm, valid_until)
+        # The token key is equivalent to a getkey result. Token operations use
+        # HMAC-SHA1 independently of getkey2's password hashing algorithm.
+        return LoxoneToken(token, username, token_key, "SHA1", valid_until)
 
     async def kill_token(self, token: LoxoneToken) -> None:
         if not token.value:
             return
-        public_key = await self.public_key()
+        public_key = await self.websocket_public_key()
         digest = token_hmac(token.value, token.hash_key, token.hash_algorithm)
         user = quote(token.username, safe="")
         command = f"jdev/sys/killtoken/{digest}/{user}"
+        websocket = await self._connect_websocket()
+        encryptor = CommandEncryptor.generate()
         try:
-            encrypted_path = CommandEncryptor.generate().encrypted_http_request(command, public_key)
-            _response_value(await self._get_json(encrypted_path))
+            session_key = encryptor.encrypted_session_key(public_key)
+            await _websocket_command(
+                websocket,
+                encryptor,
+                f"jdev/sys/keyexchange/{session_key}",
+                encrypted=False,
+                timeout_seconds=self.timeout_seconds,
+                max_payload_bytes=self.max_response_bytes,
+            )
+            await _websocket_command(
+                websocket,
+                encryptor,
+                command,
+                encrypted=True,
+                timeout_seconds=self.timeout_seconds,
+                max_payload_bytes=self.max_response_bytes,
+            )
         finally:
+            await websocket.close()
             token.destroy()
 
     async def open_session(self, token: LoxoneToken) -> LoxoneWebSocketSession:

--- a/src/mcpserver/loxone/events.py
+++ b/src/mcpserver/loxone/events.py
@@ -1,0 +1,154 @@
+"""Decode documented Loxone WebSocket headers and binary event tables."""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import Final
+from uuid import UUID
+
+from mcpserver.loxone.models import StateValue
+
+_HEADER: Final = struct.Struct("<BBBBI")
+_VALUE_EVENT: Final = struct.Struct("<16sd")
+_TEXT_PREFIX: Final = struct.Struct("<16s16sI")
+_DAYTIMER_PREFIX: Final = struct.Struct("<16sdi")
+_DAYTIMER_ENTRY: Final = struct.Struct("<iiiid")
+_WEATHER_PREFIX: Final = struct.Struct("<16sIi")
+_WEATHER_ENTRY: Final = struct.Struct("<iiiiidddddd")
+
+
+class MessageType(IntEnum):
+    TEXT = 0
+    BINARY_FILE = 1
+    VALUE_STATES = 2
+    TEXT_STATES = 3
+    DAYTIMER_STATES = 4
+    OUT_OF_SERVICE = 5
+    KEEPALIVE = 6
+    WEATHER_STATES = 7
+
+
+class LoxoneProtocolError(ValueError):
+    """Raised when a WebSocket payload violates the documented binary format."""
+
+
+@dataclass(frozen=True, slots=True)
+class MessageHeader:
+    message_type: MessageType
+    estimated: bool
+    payload_length: int
+
+
+@dataclass(frozen=True, slots=True)
+class StateEvent:
+    uuid: str
+    value: StateValue
+
+
+def parse_header(payload: bytes, *, max_payload_bytes: int) -> MessageHeader:
+    if len(payload) != _HEADER.size:
+        raise LoxoneProtocolError("WebSocket header must contain exactly 8 bytes")
+    marker, identifier, info, reserved, payload_length = _HEADER.unpack(payload)
+    if marker != 0x03 or reserved != 0:
+        raise LoxoneProtocolError("WebSocket header contains invalid reserved data")
+    try:
+        message_type = MessageType(identifier)
+    except ValueError as exc:
+        raise LoxoneProtocolError("WebSocket header contains an unknown message type") from exc
+    if payload_length > max_payload_bytes:
+        raise LoxoneProtocolError("WebSocket payload exceeds the configured limit")
+    return MessageHeader(
+        message_type=message_type,
+        estimated=bool(info & 0x01),
+        payload_length=payload_length,
+    )
+
+
+def _uuid(raw: bytes) -> str:
+    if len(raw) != 16:
+        raise LoxoneProtocolError("Event UUID must contain 16 bytes")
+    data1, data2, data3 = struct.unpack("<IHH", raw[:8])
+    tail = "".join(f"{byte:02x}" for byte in raw[8:])
+    return str(UUID(f"{data1:08x}-{data2:04x}-{data3:04x}-{tail[:4]}-{tail[4:]}"))
+
+
+def parse_value_events(payload: bytes) -> tuple[StateEvent, ...]:
+    if len(payload) % _VALUE_EVENT.size:
+        raise LoxoneProtocolError("Value event table has a truncated entry")
+    return tuple(
+        StateEvent(uuid=_uuid(raw_uuid), value=value)
+        for raw_uuid, value in _VALUE_EVENT.iter_unpack(payload)
+    )
+
+
+def parse_text_events(payload: bytes) -> tuple[StateEvent, ...]:
+    events: list[StateEvent] = []
+    offset = 0
+    while offset < len(payload):
+        if len(payload) - offset < _TEXT_PREFIX.size:
+            raise LoxoneProtocolError("Text event table has a truncated prefix")
+        raw_uuid, _icon_uuid, length = _TEXT_PREFIX.unpack_from(payload, offset)
+        offset += _TEXT_PREFIX.size
+        end = offset + length
+        if end > len(payload):
+            raise LoxoneProtocolError("Text event table has a truncated value")
+        try:
+            text = payload[offset:end].decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise LoxoneProtocolError("Text event is not valid UTF-8") from exc
+        events.append(StateEvent(uuid=_uuid(raw_uuid), value=text))
+        offset = end + ((-length) % 4)
+        if offset > len(payload):
+            raise LoxoneProtocolError("Text event table has invalid padding")
+    return tuple(events)
+
+
+def parse_daytimer_events(payload: bytes) -> tuple[StateEvent, ...]:
+    events: list[StateEvent] = []
+    offset = 0
+    while offset < len(payload):
+        if len(payload) - offset < _DAYTIMER_PREFIX.size:
+            raise LoxoneProtocolError("Daytimer table has a truncated prefix")
+        raw_uuid, default_value, count = _DAYTIMER_PREFIX.unpack_from(payload, offset)
+        offset += _DAYTIMER_PREFIX.size
+        if count < 0 or count > (len(payload) - offset) // _DAYTIMER_ENTRY.size:
+            raise LoxoneProtocolError("Daytimer table has an invalid entry count")
+        entries: list[object] = [default_value]
+        for _ in range(count):
+            entries.append(_DAYTIMER_ENTRY.unpack_from(payload, offset))
+            offset += _DAYTIMER_ENTRY.size
+        events.append(StateEvent(uuid=_uuid(raw_uuid), value=tuple(entries)))
+    return tuple(events)
+
+
+def parse_weather_events(payload: bytes) -> tuple[StateEvent, ...]:
+    events: list[StateEvent] = []
+    offset = 0
+    while offset < len(payload):
+        if len(payload) - offset < _WEATHER_PREFIX.size:
+            raise LoxoneProtocolError("Weather table has a truncated prefix")
+        raw_uuid, last_update, count = _WEATHER_PREFIX.unpack_from(payload, offset)
+        offset += _WEATHER_PREFIX.size
+        if count < 0 or count > (len(payload) - offset) // _WEATHER_ENTRY.size:
+            raise LoxoneProtocolError("Weather table has an invalid entry count")
+        entries: list[object] = [last_update]
+        for _ in range(count):
+            entries.append(_WEATHER_ENTRY.unpack_from(payload, offset))
+            offset += _WEATHER_ENTRY.size
+        events.append(StateEvent(uuid=_uuid(raw_uuid), value=tuple(entries)))
+    return tuple(events)
+
+
+def parse_state_events(message_type: MessageType, payload: bytes) -> tuple[StateEvent, ...]:
+    parsers = {
+        MessageType.VALUE_STATES: parse_value_events,
+        MessageType.TEXT_STATES: parse_text_events,
+        MessageType.DAYTIMER_STATES: parse_daytimer_events,
+        MessageType.WEATHER_STATES: parse_weather_events,
+    }
+    parser = parsers.get(message_type)
+    if parser is None:
+        raise LoxoneProtocolError("Message does not contain a state event table")
+    return parser(payload)

--- a/src/mcpserver/loxone/events.py
+++ b/src/mcpserver/loxone/events.py
@@ -6,7 +6,6 @@ import struct
 from dataclasses import dataclass
 from enum import IntEnum
 from typing import Final
-from uuid import UUID
 
 from mcpserver.loxone.models import StateValue
 
@@ -71,7 +70,7 @@ def _uuid(raw: bytes) -> str:
         raise LoxoneProtocolError("Event UUID must contain 16 bytes")
     data1, data2, data3 = struct.unpack("<IHH", raw[:8])
     tail = "".join(f"{byte:02x}" for byte in raw[8:])
-    return str(UUID(f"{data1:08x}-{data2:04x}-{data3:04x}-{tail[:4]}-{tail[4:]}"))
+    return f"{data1:08x}-{data2:04x}-{data3:04x}-{tail}"
 
 
 def parse_value_events(payload: bytes) -> tuple[StateEvent, ...]:

--- a/src/mcpserver/loxone/events.py
+++ b/src/mcpserver/loxone/events.py
@@ -51,7 +51,7 @@ def parse_header(payload: bytes, *, max_payload_bytes: int) -> MessageHeader:
     if len(payload) != _HEADER.size:
         raise LoxoneProtocolError("WebSocket header must contain exactly 8 bytes")
     marker, identifier, info, reserved, payload_length = _HEADER.unpack(payload)
-    if marker != 0x03 or reserved != 0:
+    if marker != 0x03 or reserved != 0 or info & 0x7F:
         raise LoxoneProtocolError("WebSocket header contains invalid reserved data")
     try:
         message_type = MessageType(identifier)
@@ -61,7 +61,7 @@ def parse_header(payload: bytes, *, max_payload_bytes: int) -> MessageHeader:
         raise LoxoneProtocolError("WebSocket payload exceeds the configured limit")
     return MessageHeader(
         message_type=message_type,
-        estimated=bool(info & 0x01),
+        estimated=bool(info & 0x80),
         payload_length=payload_length,
     )
 

--- a/src/mcpserver/loxone/models.py
+++ b/src/mcpserver/loxone/models.py
@@ -1,0 +1,61 @@
+"""Small normalized models that never expose a raw LoxAPP3 document."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class Freshness(StrEnum):
+    """Freshness of a user-scoped state value."""
+
+    CURRENT = "current"
+    STALE = "stale"
+    UNKNOWN = "unknown"
+    UNAVAILABLE = "unavailable"
+
+
+@dataclass(frozen=True, slots=True)
+class LoxoneIdentity:
+    """Identity returned by the user-filtered Miniserver session."""
+
+    username: str
+    miniserver_serial: str
+
+
+@dataclass(frozen=True, slots=True)
+class NamedGroup:
+    uuid: str
+    name: str
+
+
+@dataclass(frozen=True, slots=True)
+class Control:
+    uuid: str
+    name: str
+    control_type: str
+    room_uuid: str | None
+    category_uuid: str | None
+    action_uuid: str | None
+    state_uuids: tuple[tuple[str, str], ...]
+    subcontrols: tuple[Control, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class LoxoneStructure:
+    identity: LoxoneIdentity
+    last_modified: str
+    rooms: tuple[NamedGroup, ...]
+    categories: tuple[NamedGroup, ...]
+    controls: tuple[Control, ...]
+
+
+type StateValue = float | str | tuple[object, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class StateRecord:
+    uuid: str
+    value: StateValue | None
+    freshness: Freshness
+    observed_at: float | None

--- a/src/mcpserver/loxone/security.py
+++ b/src/mcpserver/loxone/security.py
@@ -1,0 +1,160 @@
+"""Loxone hashing and Command Encryption without credential logging."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import hmac
+import secrets
+from dataclasses import dataclass, field
+from typing import Final
+from urllib.parse import quote
+
+from cryptography import x509
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import padding as asymmetric_padding
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+_AES_BLOCK_BYTES: Final = 16
+_SUPPORTED_HASHES: Final = {"SHA1": hashlib.sha1, "SHA256": hashlib.sha256}
+
+
+class LoxoneSecurityError(ValueError):
+    """Raised for an unsupported or malformed security response."""
+
+
+def password_hmac(username: str, password: str, key_hex: str, salt: str, algorithm: str) -> str:
+    """Create the getjwt password HMAC exactly as documented by Loxone."""
+    digest = _SUPPORTED_HASHES.get(algorithm.upper())
+    if digest is None:
+        raise LoxoneSecurityError("Miniserver returned an unsupported password hash algorithm")
+    try:
+        key = bytes.fromhex(key_hex)
+    except ValueError as exc:
+        raise LoxoneSecurityError("Miniserver returned an invalid hashing key") from exc
+    password_hash = digest(f"{password}:{salt}".encode()).hexdigest().upper()
+    return hmac.new(key, f"{username}:{password_hash}".encode(), digest).hexdigest()
+
+
+def token_hmac(token: str, key_hex: str, algorithm: str = "SHA1") -> str:
+    """Hash a token for auth, refresh, check, or kill operations."""
+    digest = _SUPPORTED_HASHES.get(algorithm.upper())
+    if digest is None:
+        raise LoxoneSecurityError("Miniserver returned an unsupported token hash algorithm")
+    try:
+        key = bytes.fromhex(key_hex)
+    except ValueError as exc:
+        raise LoxoneSecurityError("Miniserver returned an invalid hashing key") from exc
+    return hmac.new(key, token.encode(), digest).hexdigest()
+
+
+def _zero_pad(value: bytes) -> bytes:
+    remainder = len(value) % _AES_BLOCK_BYTES
+    return value if remainder == 0 else value + (b"\0" * (_AES_BLOCK_BYTES - remainder))
+
+
+def _encrypt_aes_plaintext(plaintext: str, key: bytes, iv: bytes) -> str:
+    if len(key) != 32 or len(iv) != 16:
+        raise LoxoneSecurityError("Invalid AES session material")
+    padded = _zero_pad(plaintext.encode())
+    encryptor = Cipher(algorithms.AES(key), modes.CBC(iv)).encryptor()
+    cipher = encryptor.update(padded) + encryptor.finalize()
+    return quote(base64.b64encode(cipher).decode("ascii"), safe="")
+
+
+def encrypt_aes_command(command: str, key: bytes, iv: bytes, salt: str) -> str:
+    """Encrypt a salted command and return URI-encoded Base64 without line wraps."""
+    return _encrypt_aes_plaintext(f"salt/{salt}/{command}", key, iv)
+
+
+def _canonical_pem(value: str, label: str) -> bytes:
+    begin = f"-----BEGIN {label}-----"
+    end = f"-----END {label}-----"
+    if begin not in value or end not in value:
+        raise LoxoneSecurityError("Miniserver returned an invalid public key")
+    body = "".join(value.split(begin, 1)[1].split(end, 1)[0].split())
+    if not body:
+        raise LoxoneSecurityError("Miniserver returned an invalid public key")
+    lines = [body[index : index + 64] for index in range(0, len(body), 64)]
+    return f"{begin}\n{'\n'.join(lines)}\n{end}\n".encode()
+
+
+def _pem_der(value: str, label: str) -> bytes:
+    begin = f"-----BEGIN {label}-----"
+    end = f"-----END {label}-----"
+    body = "".join(value.split(begin, 1)[1].split(end, 1)[0].split())
+    return base64.b64decode(body, validate=True)
+
+
+def _load_rsa_public_key(value: str) -> RSAPublicKey:
+    loaded: object
+    try:
+        if "BEGIN CERTIFICATE" in value:
+            try:
+                loaded = x509.load_pem_x509_certificate(
+                    _canonical_pem(value, "CERTIFICATE")
+                ).public_key()
+            except ValueError:
+                # Gen. 1 firmware labels a DER SubjectPublicKeyInfo value as a
+                # certificate even though it isn't an X.509 certificate.
+                loaded = serialization.load_der_public_key(_pem_der(value, "CERTIFICATE"))
+        else:
+            loaded = serialization.load_pem_public_key(_canonical_pem(value, "PUBLIC KEY"))
+    except (binascii.Error, IndexError, TypeError, ValueError) as exc:
+        raise LoxoneSecurityError("Miniserver returned an invalid public key") from exc
+    if not isinstance(loaded, RSAPublicKey):
+        raise LoxoneSecurityError("Miniserver public key is not RSA")
+    return loaded
+
+
+def normalize_rsa_public_key_pem(value: str) -> str:
+    """Accept a raw RSA key or Gen. 1 certificate and return a canonical RSA key."""
+    loaded = _load_rsa_public_key(value)
+    return loaded.public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode("ascii")
+
+
+def encrypt_session_key(public_key_pem: str, key: bytes, iv: bytes) -> str:
+    """Encrypt the hexadecimal AES key and IV with RSA PKCS#1 v1.5."""
+    loaded = _load_rsa_public_key(public_key_pem)
+    payload = f"{key.hex()}:{iv.hex()}".encode("ascii")
+    encrypted = loaded.encrypt(payload, asymmetric_padding.PKCS1v15())
+    return quote(base64.b64encode(encrypted).decode("ascii"), safe="")
+
+
+@dataclass(slots=True)
+class CommandEncryptor:
+    """Ephemeral Command Encryption material for one operation or WebSocket."""
+
+    key: bytes
+    iv: bytes
+    salt: str
+    _used: bool = field(default=False, init=False, repr=False)
+
+    @classmethod
+    def generate(cls) -> CommandEncryptor:
+        return cls(
+            key=secrets.token_bytes(32), iv=secrets.token_bytes(16), salt=secrets.token_hex(8)
+        )
+
+    def encrypted_command(self, command: str) -> str:
+        if self._used:
+            previous = self.salt
+            self.salt = secrets.token_hex(8)
+            plaintext = f"nextSalt/{previous}/{self.salt}/{command}"
+            cipher = _encrypt_aes_plaintext(plaintext, self.key, self.iv)
+        else:
+            self._used = True
+            cipher = encrypt_aes_command(command, self.key, self.iv, self.salt)
+        return f"jdev/sys/enc/{cipher}"
+
+    def encrypted_session_key(self, public_key_pem: str) -> str:
+        return encrypt_session_key(public_key_pem, self.key, self.iv)
+
+    def encrypted_http_request(self, command: str, public_key_pem: str) -> str:
+        session_key = self.encrypted_session_key(public_key_pem)
+        return f"/{self.encrypted_command(command)}?sk={session_key}"

--- a/src/mcpserver/loxone/security.py
+++ b/src/mcpserver/loxone/security.py
@@ -6,19 +6,24 @@ import base64
 import binascii
 import hashlib
 import hmac
+import re
 import secrets
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from itertools import pairwise
 from typing import Final
 from urllib.parse import quote
 
 from cryptography import x509
-from cryptography.hazmat.primitives import serialization
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding as asymmetric_padding
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 _AES_BLOCK_BYTES: Final = 16
 _SUPPORTED_HASHES: Final = {"SHA1": hashlib.sha1, "SHA256": hashlib.sha256}
+_LOXONE_ROOT_SHA256: Final = "db486e6a9d868ae2fd7e1b199c038924b3d270ce669b5ef37f1113b5bc3ec1d7"
 
 
 class LoxoneSecurityError(ValueError):
@@ -118,12 +123,70 @@ def normalize_rsa_public_key_pem(value: str) -> str:
     ).decode("ascii")
 
 
+def normalize_loxone_certificate_chain_pem(value: str) -> str:
+    """Verify the pinned Gen. 1 certificate chain and return its leaf RSA key."""
+    blocks = re.findall(
+        r"-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----",
+        value,
+        flags=re.DOTALL,
+    )
+    if len(blocks) < 2:
+        raise LoxoneSecurityError("Miniserver returned an invalid certificate chain")
+    try:
+        certificates = [x509.load_pem_x509_certificate(block.encode()) for block in blocks]
+        root = certificates[0]
+        if root.fingerprint(hashes.SHA256()).hex() != _LOXONE_ROOT_SHA256:
+            raise LoxoneSecurityError("Miniserver certificate chain has an untrusted root")
+        now = datetime.now(UTC)
+        for certificate in certificates:
+            if not certificate.not_valid_before_utc <= now <= certificate.not_valid_after_utc:
+                raise LoxoneSecurityError("Miniserver certificate chain is outside its validity")
+        for issuer, certificate in pairwise(certificates):
+            if certificate.issuer != issuer.subject:
+                raise LoxoneSecurityError("Miniserver certificate chain has an invalid issuer")
+            issuer_key = issuer.public_key()
+            if not isinstance(issuer_key, RSAPublicKey):
+                raise LoxoneSecurityError("Miniserver certificate issuer key is not RSA")
+            signature_hash = certificate.signature_hash_algorithm
+            if signature_hash is None:
+                raise LoxoneSecurityError("Miniserver certificate signature is unsupported")
+            issuer_key.verify(
+                certificate.signature,
+                certificate.tbs_certificate_bytes,
+                asymmetric_padding.PKCS1v15(),
+                signature_hash,
+            )
+        root_key = root.public_key()
+        if not isinstance(root_key, RSAPublicKey):
+            raise LoxoneSecurityError("Miniserver certificate root key is not RSA")
+        root_signature_hash = root.signature_hash_algorithm
+        if root_signature_hash is None:
+            raise LoxoneSecurityError("Miniserver root certificate signature is unsupported")
+        root_key.verify(
+            root.signature,
+            root.tbs_certificate_bytes,
+            asymmetric_padding.PKCS1v15(),
+            root_signature_hash,
+        )
+    except LoxoneSecurityError:
+        raise
+    except (InvalidSignature, TypeError, ValueError) as exc:
+        raise LoxoneSecurityError("Miniserver returned an invalid certificate chain") from exc
+    leaf_key = certificates[-1].public_key()
+    if not isinstance(leaf_key, RSAPublicKey):
+        raise LoxoneSecurityError("Miniserver certificate leaf key is not RSA")
+    return leaf_key.public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode("ascii")
+
+
 def encrypt_session_key(public_key_pem: str, key: bytes, iv: bytes) -> str:
-    """Encrypt the hexadecimal AES key and IV with RSA PKCS#1 v1.5."""
+    """Encrypt the hexadecimal AES key and IV as raw Base64 for WebSocket use."""
     loaded = _load_rsa_public_key(public_key_pem)
     payload = f"{key.hex()}:{iv.hex()}".encode("ascii")
     encrypted = loaded.encrypt(payload, asymmetric_padding.PKCS1v15())
-    return quote(base64.b64encode(encrypted).decode("ascii"), safe="")
+    return base64.b64encode(encrypted).decode("ascii")
 
 
 @dataclass(slots=True)
@@ -156,5 +219,5 @@ class CommandEncryptor:
         return encrypt_session_key(public_key_pem, self.key, self.iv)
 
     def encrypted_http_request(self, command: str, public_key_pem: str) -> str:
-        session_key = self.encrypted_session_key(public_key_pem)
+        session_key = quote(self.encrypted_session_key(public_key_pem), safe="")
         return f"/{self.encrypted_command(command)}?sk={session_key}"

--- a/src/mcpserver/loxone/structure.py
+++ b/src/mcpserver/loxone/structure.py
@@ -7,6 +7,8 @@ from typing import Any
 
 from mcpserver.loxone.models import Control, LoxoneIdentity, LoxoneStructure, NamedGroup
 
+_REFERENCED_ONLY_INTERNAL = 1 << 0
+
 
 class LoxoneStructureError(ValueError):
     """Raised when the user-filtered structure is malformed."""
@@ -18,13 +20,15 @@ def _text(value: object, *, field: str) -> str:
     return value
 
 
-def _groups(value: object, *, field: str) -> tuple[NamedGroup, ...]:
+def _groups(value: object, *, field: str, allowed_uuids: set[str]) -> tuple[NamedGroup, ...]:
     if not isinstance(value, Mapping):
         raise LoxoneStructureError(f"Structure field {field} must be an object")
     groups: list[NamedGroup] = []
     for uuid, item in value.items():
         if not isinstance(uuid, str) or not isinstance(item, Mapping):
             raise LoxoneStructureError(f"Structure field {field} contains an invalid entry")
+        if uuid not in allowed_uuids:
+            continue
         groups.append(NamedGroup(uuid=uuid, name=_text(item.get("name"), field=f"{field}.name")))
     return tuple(groups)
 
@@ -33,13 +37,18 @@ def _optional_uuid(value: object) -> str | None:
     return value if isinstance(value, str) and value else None
 
 
-def _controls(value: object) -> tuple[Control, ...]:
+def _controls(value: object, *, referenced: bool = False) -> tuple[Control, ...]:
     if not isinstance(value, Mapping):
         raise LoxoneStructureError("Structure field controls must be an object")
     controls: list[Control] = []
     for uuid, item in value.items():
         if not isinstance(uuid, str) or not isinstance(item, Mapping):
             raise LoxoneStructureError("Structure contains an invalid control")
+        restrictions = item.get("restrictions", 0)
+        if not isinstance(restrictions, int) or isinstance(restrictions, bool) or restrictions < 0:
+            raise LoxoneStructureError("Control restrictions must be a non-negative integer")
+        if not referenced and restrictions & _REFERENCED_ONLY_INTERNAL:
+            continue
         states_value = item.get("states", {})
         if not isinstance(states_value, Mapping):
             raise LoxoneStructureError("Control states must be an object")
@@ -58,10 +67,22 @@ def _controls(value: object) -> tuple[Control, ...]:
                 category_uuid=_optional_uuid(item.get("cat")),
                 action_uuid=_optional_uuid(item.get("action")),
                 state_uuids=states,
-                subcontrols=_controls(subcontrols_value) if subcontrols_value else (),
+                subcontrols=(
+                    _controls(subcontrols_value, referenced=True) if subcontrols_value else ()
+                ),
             )
         )
     return tuple(controls)
+
+
+def _group_references(controls: tuple[Control, ...], *, field: str) -> set[str]:
+    result: set[str] = set()
+    for control in controls:
+        uuid = control.room_uuid if field == "room" else control.category_uuid
+        if uuid is not None:
+            result.add(uuid)
+        result.update(_group_references(control.subcontrols, field=field))
+    return result
 
 
 def normalize_structure(document: Mapping[str, Any], *, username: str) -> LoxoneStructure:
@@ -71,13 +92,22 @@ def normalize_structure(document: Mapping[str, Any], *, username: str) -> Loxone
         raise LoxoneStructureError("Structure field msInfo must be an object")
     serial = ms_info.get("serialNr", ms_info.get("serial"))
     last_modified = document.get("lastModified", "")
+    controls = _controls(document.get("controls", {}))
     return LoxoneStructure(
         identity=LoxoneIdentity(
             username=username,
             miniserver_serial=_text(serial, field="msInfo.serialNr"),
         ),
         last_modified=_text(last_modified, field="lastModified"),
-        rooms=_groups(document.get("rooms", {}), field="rooms"),
-        categories=_groups(document.get("cats", {}), field="cats"),
-        controls=_controls(document.get("controls", {})),
+        rooms=_groups(
+            document.get("rooms", {}),
+            field="rooms",
+            allowed_uuids=_group_references(controls, field="room"),
+        ),
+        categories=_groups(
+            document.get("cats", {}),
+            field="cats",
+            allowed_uuids=_group_references(controls, field="category"),
+        ),
+        controls=controls,
     )

--- a/src/mcpserver/loxone/structure.py
+++ b/src/mcpserver/loxone/structure.py
@@ -1,0 +1,83 @@
+"""Normalize the user-filtered LoxAPP3 response into a minimal model."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from mcpserver.loxone.models import Control, LoxoneIdentity, LoxoneStructure, NamedGroup
+
+
+class LoxoneStructureError(ValueError):
+    """Raised when the user-filtered structure is malformed."""
+
+
+def _text(value: object, *, field: str) -> str:
+    if not isinstance(value, str):
+        raise LoxoneStructureError(f"Structure field {field} must be text")
+    return value
+
+
+def _groups(value: object, *, field: str) -> tuple[NamedGroup, ...]:
+    if not isinstance(value, Mapping):
+        raise LoxoneStructureError(f"Structure field {field} must be an object")
+    groups: list[NamedGroup] = []
+    for uuid, item in value.items():
+        if not isinstance(uuid, str) or not isinstance(item, Mapping):
+            raise LoxoneStructureError(f"Structure field {field} contains an invalid entry")
+        groups.append(NamedGroup(uuid=uuid, name=_text(item.get("name"), field=f"{field}.name")))
+    return tuple(groups)
+
+
+def _optional_uuid(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _controls(value: object) -> tuple[Control, ...]:
+    if not isinstance(value, Mapping):
+        raise LoxoneStructureError("Structure field controls must be an object")
+    controls: list[Control] = []
+    for uuid, item in value.items():
+        if not isinstance(uuid, str) or not isinstance(item, Mapping):
+            raise LoxoneStructureError("Structure contains an invalid control")
+        states_value = item.get("states", {})
+        if not isinstance(states_value, Mapping):
+            raise LoxoneStructureError("Control states must be an object")
+        states = tuple(
+            (name, state_uuid)
+            for name, state_uuid in states_value.items()
+            if isinstance(name, str) and isinstance(state_uuid, str)
+        )
+        subcontrols_value = item.get("subControls", {})
+        controls.append(
+            Control(
+                uuid=uuid,
+                name=_text(item.get("name"), field="controls.name"),
+                control_type=_text(item.get("type"), field="controls.type"),
+                room_uuid=_optional_uuid(item.get("room")),
+                category_uuid=_optional_uuid(item.get("cat")),
+                action_uuid=_optional_uuid(item.get("action")),
+                state_uuids=states,
+                subcontrols=_controls(subcontrols_value) if subcontrols_value else (),
+            )
+        )
+    return tuple(controls)
+
+
+def normalize_structure(document: Mapping[str, Any], *, username: str) -> LoxoneStructure:
+    """Return only fields required for read-only discovery and state association."""
+    ms_info = document.get("msInfo")
+    if not isinstance(ms_info, Mapping):
+        raise LoxoneStructureError("Structure field msInfo must be an object")
+    serial = ms_info.get("serialNr", ms_info.get("serial"))
+    last_modified = document.get("lastModified", "")
+    return LoxoneStructure(
+        identity=LoxoneIdentity(
+            username=username,
+            miniserver_serial=_text(serial, field="msInfo.serialNr"),
+        ),
+        last_modified=_text(last_modified, field="lastModified"),
+        rooms=_groups(document.get("rooms", {}), field="rooms"),
+        categories=_groups(document.get("cats", {}), field="cats"),
+        controls=_controls(document.get("controls", {})),
+    )

--- a/tests/test_loxone_cache.py
+++ b/tests/test_loxone_cache.py
@@ -8,7 +8,11 @@ from mcpserver.loxone.models import Freshness
 def test_cache_isolates_users_and_marks_disconnect_stale() -> None:
     cache = UserStateCache(clock=lambda: 123.0)
     cache.begin_connection("miniserver:user-a")
-    cache.apply("miniserver:user-a", [StateEvent(uuid="state", value=1.0)])
+    cache.apply(
+        "miniserver:user-a",
+        [StateEvent(uuid="state", value=1.0)],
+        allowed_uuids={"state"},
+    )
     cache.begin_connection("miniserver:user-b")
 
     assert cache.get("miniserver:user-a", "state").freshness is Freshness.CURRENT
@@ -30,7 +34,25 @@ def test_cache_evicts_oldest_state_at_limit() -> None:
             StateEvent(uuid="two", value=2.0),
             StateEvent(uuid="three", value=3.0),
         ],
+        allowed_uuids={"one", "two", "three"},
     )
 
     assert cache.get("subject", "one").freshness is Freshness.UNKNOWN
     assert cache.get("subject", "two").freshness is Freshness.CURRENT
+
+
+def test_cache_drops_states_outside_the_filtered_structure() -> None:
+    cache = UserStateCache()
+    cache.begin_connection("subject")
+
+    cache.apply(
+        "subject",
+        [
+            StateEvent(uuid="allowed", value=1.0),
+            StateEvent(uuid="denied", value=2.0),
+        ],
+        allowed_uuids={"allowed"},
+    )
+
+    assert cache.get("subject", "allowed").freshness is Freshness.CURRENT
+    assert cache.get("subject", "denied").freshness is Freshness.UNKNOWN

--- a/tests/test_loxone_cache.py
+++ b/tests/test_loxone_cache.py
@@ -56,3 +56,21 @@ def test_cache_drops_states_outside_the_filtered_structure() -> None:
 
     assert cache.get("subject", "allowed").freshness is Freshness.CURRENT
     assert cache.get("subject", "denied").freshness is Freshness.UNKNOWN
+
+
+def test_cache_purges_state_removed_from_the_filtered_structure() -> None:
+    cache = UserStateCache()
+    cache.begin_connection("subject")
+    cache.apply(
+        "subject",
+        [
+            StateEvent(uuid="still-allowed", value=1.0),
+            StateEvent(uuid="revoked", value=2.0),
+        ],
+        allowed_uuids={"still-allowed", "revoked"},
+    )
+
+    cache.apply("subject", [], allowed_uuids={"still-allowed"})
+
+    assert cache.get("subject", "still-allowed").freshness is Freshness.CURRENT
+    assert cache.get("subject", "revoked").freshness is Freshness.UNKNOWN

--- a/tests/test_loxone_cache.py
+++ b/tests/test_loxone_cache.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from mcpserver.loxone.cache import UserStateCache
+from mcpserver.loxone.events import StateEvent
+from mcpserver.loxone.models import Freshness
+
+
+def test_cache_isolates_users_and_marks_disconnect_stale() -> None:
+    cache = UserStateCache(clock=lambda: 123.0)
+    cache.begin_connection("miniserver:user-a")
+    cache.apply("miniserver:user-a", [StateEvent(uuid="state", value=1.0)])
+    cache.begin_connection("miniserver:user-b")
+
+    assert cache.get("miniserver:user-a", "state").freshness is Freshness.CURRENT
+    assert cache.get("miniserver:user-b", "state").freshness is Freshness.UNKNOWN
+
+    cache.disconnect("miniserver:user-a")
+
+    assert cache.get("miniserver:user-a", "state").freshness is Freshness.STALE
+    assert cache.get("miniserver:user-a", "missing").freshness is Freshness.UNAVAILABLE
+
+
+def test_cache_evicts_oldest_state_at_limit() -> None:
+    cache = UserStateCache(max_states_per_user=2)
+    cache.begin_connection("subject")
+    cache.apply(
+        "subject",
+        [
+            StateEvent(uuid="one", value=1.0),
+            StateEvent(uuid="two", value=2.0),
+            StateEvent(uuid="three", value=3.0),
+        ],
+    )
+
+    assert cache.get("subject", "one").freshness is Freshness.UNKNOWN
+    assert cache.get("subject", "two").freshness is Freshness.CURRENT

--- a/tests/test_loxone_client.py
+++ b/tests/test_loxone_client.py
@@ -19,7 +19,7 @@ from mcpserver.loxone.client import (
     _loxone_uuid,
     _receive_websocket,
 )
-from mcpserver.loxone.events import MessageType
+from mcpserver.loxone.events import MessageHeader, MessageType
 from mcpserver.loxone.security import token_hmac
 
 
@@ -91,6 +91,26 @@ async def test_websocket_receive_skips_estimated_header() -> None:
 
     assert header.estimated is False
     assert payload == "{}"
+
+
+@pytest.mark.asyncio
+async def test_websocket_receive_accepts_gen1_character_count_for_text() -> None:
+    class FakeWebSocket:
+        def __init__(self) -> None:
+            self.messages: list[bytes | str] = [
+                bytes((3, MessageType.BINARY_FILE, 0, 0, 1, 0, 0, 0)),
+                "ä",
+            ]
+
+        async def recv(self) -> bytes | str:
+            return self.messages.pop(0)
+
+    header, payload = await _receive_websocket(
+        cast(Any, FakeWebSocket()), timeout_seconds=0.1, max_payload_bytes=100
+    )
+
+    assert header.message_type is MessageType.BINARY_FILE
+    assert payload == "ä"
 
 
 def test_gen1_endpoint_builds_canonical_websocket_url() -> None:
@@ -251,7 +271,7 @@ async def test_token_acquisition_encrypts_credentials_and_retains_hash_algorithm
 
     token = await client.acquire_token("restricted-reader", "password-secret")
 
-    assert token.hash_algorithm == "SHA1"
+    assert token.hash_algorithm == "SHA256"
     assert "jwt-secret" not in repr(token)
     assert "password-secret" not in "".join(command for command, _ in commands)
     assert commands[0][1] is False
@@ -350,22 +370,100 @@ async def test_token_revocation_uses_encrypted_websocket_and_destroys_token(
         assert timeout_seconds == client.timeout_seconds
         assert max_payload_bytes == client.max_response_bytes
         commands.append((command, encrypted))
+        if command == "jdev/sys/getkey":
+            return "aabbccdd"
         return "OK"
 
     monkeypatch.setattr(client, "websocket_public_key", fake_websocket_public_key)
     monkeypatch.setattr(client, "_connect_websocket", fake_connect_websocket)
     monkeypatch.setattr("mcpserver.loxone.client._websocket_command", fake_websocket_command)
-    token = LoxoneToken("jwt-secret", "restricted-reader", "00112233", "SHA1", 123)
+    token = LoxoneToken("jwt-secret", "restricted-reader", "00112233", "SHA256", 123)
 
     await client.kill_token(token)
 
     assert commands[0][0].startswith("jdev/sys/keyexchange/")
     assert commands[0][1] is False
-    assert commands[1][0].startswith("jdev/sys/killtoken/")
-    assert commands[1][1] is True
-    assert "jwt-secret" not in commands[1][0]
+    assert commands[1] == ("jdev/sys/getkey", True)
+    assert commands[2][0].startswith("jdev/sys/killtoken/")
+    assert commands[2][1] is True
+    assert "jwt-secret" not in commands[2][0]
     assert websocket.closed is True
     assert token.value == ""
+
+
+@pytest.mark.asyncio
+async def test_session_authentication_requests_a_fresh_token_hash_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_pem = (
+        private_key.public_key()
+        .public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode()
+    )
+    token = LoxoneToken("jwt-secret", "reader", "expired-key", "SHA256", 100)
+    session = LoxoneWebSocketSession(
+        cast(Any, object()),
+        public_key=public_pem,
+        token=token,
+        timeout_seconds=1,
+        max_payload_bytes=100,
+    )
+    commands: list[tuple[str, bool]] = []
+
+    async def fake_command(command: str, *, encrypted: bool = False) -> object:
+        commands.append((command, encrypted))
+        if command == "jdev/sys/getkey":
+            return "aabbccdd"
+        return "OK"
+
+    monkeypatch.setattr(session, "_command", fake_command)
+
+    await session.authenticate()
+
+    expected = token_hmac("jwt-secret", "aabbccdd", "SHA256")
+    assert commands[0][0].startswith("jdev/sys/keyexchange/")
+    assert commands[1] == ("jdev/sys/getkey", True)
+    assert commands[2] == (f"authwithtoken/{expected}/reader", True)
+
+
+@pytest.mark.asyncio
+async def test_structure_accepts_text_content_in_file_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = (
+        '{"lastModified":"now","msInfo":{"serialNr":"000000000000"},'
+        '"rooms":{},"cats":{},"controls":{}}'
+    )
+
+    class FakeWebSocket:
+        def __init__(self) -> None:
+            self.sent: list[str] = []
+
+        async def send(self, command: str) -> None:
+            self.sent.append(command)
+
+    websocket = FakeWebSocket()
+    session = LoxoneWebSocketSession(
+        cast(Any, websocket),
+        public_key="unused",
+        token=LoxoneToken("jwt", "reader", "key", "SHA256", 100),
+        timeout_seconds=1,
+        max_payload_bytes=1_000,
+    )
+
+    async def fake_receive() -> tuple[MessageHeader, str]:
+        return MessageHeader(MessageType.BINARY_FILE, False, len(payload)), payload
+
+    monkeypatch.setattr(session, "_receive", fake_receive)
+
+    structure = await session.load_structure()
+
+    assert websocket.sent == ["data/LoxAPP3.json"]
+    assert structure.identity.username == "reader"
 
 
 @pytest.mark.asyncio
@@ -381,8 +479,11 @@ async def test_refresh_rotates_in_memory_token_with_dynamic_hash(
         max_payload_bytes=100,
     )
 
-    async def fake_command(command: str, *, encrypted: bool = False) -> dict[str, object]:
-        expected = token_hmac("old-secret", "00112233", "SHA256")
+    async def fake_command(command: str, *, encrypted: bool = False) -> object:
+        if command == "jdev/sys/getkey":
+            assert encrypted is True
+            return "aabbccdd"
+        expected = token_hmac("old-secret", "aabbccdd", "SHA256")
         assert command == f"jdev/sys/refreshjwt/{expected}/reader"
         assert encrypted is True
         return {"token": "new-secret", "validUntil": 200}

--- a/tests/test_loxone_client.py
+++ b/tests/test_loxone_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any, cast
 from uuid import UUID
 
@@ -14,6 +15,7 @@ from mcpserver.loxone.client import (
     LoxoneToken,
     LoxoneWebSocketSession,
     MiniserverEndpoint,
+    _close_websocket,
     _loxone_uuid,
 )
 from mcpserver.loxone.security import token_hmac
@@ -32,6 +34,15 @@ from mcpserver.loxone.security import token_hmac
 def test_gen1_endpoint_rejects_nonlocal_or_credentialed_values(value: str) -> None:
     with pytest.raises(ValueError):
         MiniserverEndpoint.parse_gen1(value)
+
+
+@pytest.mark.asyncio
+async def test_websocket_close_is_bounded() -> None:
+    class BlockingWebSocket:
+        async def close(self) -> None:
+            await asyncio.Event().wait()
+
+    await _close_websocket(cast(Any, BlockingWebSocket()), 0.001)
 
 
 def test_gen1_endpoint_builds_canonical_websocket_url() -> None:

--- a/tests/test_loxone_client.py
+++ b/tests/test_loxone_client.py
@@ -113,6 +113,27 @@ async def test_websocket_receive_accepts_gen1_character_count_for_text() -> None
     assert payload == "ä"
 
 
+@pytest.mark.asyncio
+async def test_websocket_receive_assembles_a_chunked_file() -> None:
+    class FakeWebSocket:
+        def __init__(self) -> None:
+            self.messages: list[bytes | str] = [
+                bytes((3, MessageType.BINARY_FILE, 0, 0, 6, 0, 0, 0)),
+                "abc",
+                "def",
+            ]
+
+        async def recv(self) -> bytes | str:
+            return self.messages.pop(0)
+
+    header, payload = await _receive_websocket(
+        cast(Any, FakeWebSocket()), timeout_seconds=0.1, max_payload_bytes=100
+    )
+
+    assert header.message_type is MessageType.BINARY_FILE
+    assert payload == "abcdef"
+
+
 def test_gen1_endpoint_builds_canonical_websocket_url() -> None:
     endpoint = MiniserverEndpoint.parse_gen1("http://192.168.1.10:8080")
 
@@ -333,61 +354,29 @@ async def test_token_revocation_uses_encrypted_websocket_and_destroys_token(
         MiniserverEndpoint.parse_gen1("http://192.168.1.10"),
         client_uuid=UUID("098802e1-02b4-603c-ffff-eee000d80cfd"),
     )
-    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-    public_pem = (
-        private_key.public_key()
-        .public_bytes(
-            serialization.Encoding.PEM,
-            serialization.PublicFormat.SubjectPublicKeyInfo,
-        )
-        .decode()
-    )
-    commands: list[tuple[str, bool]] = []
 
-    class FakeWebSocket:
+    class FakeSession:
+        killed = False
         closed = False
+
+        async def kill_token(self) -> None:
+            self.killed = True
 
         async def close(self) -> None:
             self.closed = True
 
-    websocket = FakeWebSocket()
+    session = FakeSession()
 
-    async def fake_websocket_public_key() -> str:
-        return public_pem
+    async def fake_open_session(_token: LoxoneToken) -> Any:
+        return session
 
-    async def fake_connect_websocket() -> Any:
-        return websocket
-
-    async def fake_websocket_command(
-        _websocket: Any,
-        _encryptor: Any,
-        command: str,
-        *,
-        encrypted: bool,
-        timeout_seconds: float,
-        max_payload_bytes: int,
-    ) -> object:
-        assert timeout_seconds == client.timeout_seconds
-        assert max_payload_bytes == client.max_response_bytes
-        commands.append((command, encrypted))
-        if command == "jdev/sys/getkey":
-            return "aabbccdd"
-        return "OK"
-
-    monkeypatch.setattr(client, "websocket_public_key", fake_websocket_public_key)
-    monkeypatch.setattr(client, "_connect_websocket", fake_connect_websocket)
-    monkeypatch.setattr("mcpserver.loxone.client._websocket_command", fake_websocket_command)
+    monkeypatch.setattr(client, "open_session", fake_open_session)
     token = LoxoneToken("jwt-secret", "restricted-reader", "00112233", "SHA256", 123)
 
     await client.kill_token(token)
 
-    assert commands[0][0].startswith("jdev/sys/keyexchange/")
-    assert commands[0][1] is False
-    assert commands[1] == ("jdev/sys/getkey", True)
-    assert commands[2][0].startswith("jdev/sys/killtoken/")
-    assert commands[2][1] is True
-    assert "jwt-secret" not in commands[2][0]
-    assert websocket.closed is True
+    assert session.killed is True
+    assert session.closed is True
     assert token.value == ""
 
 
@@ -428,6 +417,37 @@ async def test_session_authentication_requests_a_fresh_token_hash_key(
     assert commands[0][0].startswith("jdev/sys/keyexchange/")
     assert commands[1] == ("jdev/sys/getkey", True)
     assert commands[2] == (f"authwithtoken/{expected}/reader", True)
+
+
+@pytest.mark.asyncio
+async def test_authenticated_session_kills_token_with_a_fresh_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = LoxoneToken("jwt-secret", "reader", "expired-key", "SHA256", 100)
+    session = LoxoneWebSocketSession(
+        cast(Any, object()),
+        public_key="unused",
+        token=token,
+        timeout_seconds=1,
+        max_payload_bytes=100,
+    )
+    commands: list[tuple[str, bool]] = []
+
+    async def fake_command(command: str, *, encrypted: bool = False) -> object:
+        commands.append((command, encrypted))
+        if command == "jdev/sys/getkey":
+            return "aabbccdd"
+        return "OK"
+
+    monkeypatch.setattr(session, "_command", fake_command)
+
+    await session.kill_token()
+
+    expected = token_hmac("jwt-secret", "aabbccdd", "SHA256")
+    assert commands == [
+        ("jdev/sys/getkey", True),
+        (f"jdev/sys/killtoken/{expected}/reader", True),
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_loxone_client.py
+++ b/tests/test_loxone_client.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from typing import Any, cast
+from uuid import UUID
+
+import httpx
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from mcpserver.loxone.client import (
+    LoxoneClient,
+    LoxoneConnectionError,
+    LoxoneToken,
+    LoxoneWebSocketSession,
+    MiniserverEndpoint,
+    _loxone_uuid,
+)
+from mcpserver.loxone.security import token_hmac
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "https://192.168.1.10",
+        "http://user:pass@192.168.1.10",
+        "http://example.test",
+        "http://203.0.113.10",
+        "http://192.168.1.10/path",
+    ],
+)
+def test_gen1_endpoint_rejects_nonlocal_or_credentialed_values(value: str) -> None:
+    with pytest.raises(ValueError):
+        MiniserverEndpoint.parse_gen1(value)
+
+
+def test_gen1_endpoint_builds_canonical_websocket_url() -> None:
+    endpoint = MiniserverEndpoint.parse_gen1("http://192.168.1.10:8080")
+
+    assert endpoint.websocket_url == "ws://192.168.1.10:8080/ws/rfc6455"
+
+
+def test_client_uuid_uses_loxone_8_4_4_16_representation() -> None:
+    value = UUID("098802e1-02b4-603c-ffff-eee000d80cfd")
+
+    assert _loxone_uuid(value) == "098802e1-02b4-603c-ffffeee000d80cfd"
+
+
+@pytest.mark.asyncio
+async def test_http_errors_suppress_encrypted_request_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = LoxoneClient(
+        MiniserverEndpoint.parse_gen1("http://192.168.1.10"),
+        client_uuid=UUID("098802e1-02b4-603c-ffff-eee000d80cfd"),
+    )
+
+    class FailingClient:
+        async def __aenter__(self) -> FailingClient:
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+        async def get(self, _path: str) -> httpx.Response:
+            request = httpx.Request("GET", "http://192.168.1.10/secret-encrypted-path")
+            raise httpx.ConnectError("request failed", request=request)
+
+    monkeypatch.setattr(
+        "mcpserver.loxone.client.httpx.AsyncClient", lambda **_kwargs: FailingClient()
+    )
+
+    with pytest.raises(LoxoneConnectionError) as captured:
+        await client._get_json("/secret-encrypted-path")
+
+    assert captured.value.__cause__ is None
+    assert captured.value.__suppress_context__ is True
+    assert "secret-encrypted-path" not in str(captured.value)
+
+
+@pytest.mark.asyncio
+async def test_probe_rejects_tls_capable_miniserver(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = LoxoneClient(
+        MiniserverEndpoint.parse_gen1("http://192.168.1.10"),
+        client_uuid=UUID("098802e1-02b4-603c-ffff-eee000d80cfd"),
+    )
+
+    async def fake_get_json(path: str) -> dict[str, object]:
+        assert path == "/jdev/cfg/apiKey"
+        return {
+            "LL": {
+                "Code": "200",
+                "value": {
+                    "version": "17.1.7.27",
+                    "snr": "000000000000",
+                    "httpsStatus": 1,
+                },
+            }
+        }
+
+    monkeypatch.setattr(client, "_get_json", fake_get_json)
+
+    with pytest.raises(LoxoneConnectionError, match="Gen. 2"):
+        await client.probe()
+
+
+@pytest.mark.asyncio
+async def test_token_acquisition_encrypts_credentials_and_retains_hash_algorithm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = LoxoneClient(
+        MiniserverEndpoint.parse_gen1("http://192.168.1.10"),
+        client_uuid=UUID("098802e1-02b4-603c-ffff-eee000d80cfd"),
+    )
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_pem = (
+        private_key.public_key()
+        .public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode()
+    )
+    paths: list[str] = []
+
+    async def fake_get_json(path: str) -> dict[str, object]:
+        paths.append(path)
+        if path == "/jdev/sys/getPublicKey":
+            return {"LL": {"Code": "200", "value": public_pem}}
+        if path == "/jdev/sys/getkey2/restricted-reader":
+            return {
+                "LL": {
+                    "Code": "200",
+                    "value": {"key": "00112233", "salt": "a1b2", "hashAlg": "SHA256"},
+                }
+            }
+        assert path.startswith("/jdev/sys/enc/")
+        return {
+            "LL": {
+                "Code": "200",
+                "value": {"token": "jwt-secret", "key": "44556677", "validUntil": 123},
+            }
+        }
+
+    monkeypatch.setattr(client, "_get_json", fake_get_json)
+
+    token = await client.acquire_token("restricted-reader", "password-secret")
+
+    assert token.hash_algorithm == "SHA256"
+    assert "jwt-secret" not in repr(token)
+    assert "password-secret" not in "".join(paths)
+    assert all("getjwt" not in path for path in paths)
+
+
+@pytest.mark.asyncio
+async def test_refresh_rotates_in_memory_token_with_dynamic_hash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = LoxoneToken("old-secret", "reader", "00112233", "SHA256", 100)
+    session = LoxoneWebSocketSession(
+        cast(Any, object()),
+        public_key="unused",
+        token=token,
+        timeout_seconds=1,
+        max_payload_bytes=100,
+    )
+
+    async def fake_command(command: str, *, encrypted: bool = False) -> dict[str, object]:
+        expected = token_hmac("old-secret", "00112233", "SHA256")
+        assert command == f"jdev/sys/refreshjwt/{expected}/reader"
+        assert encrypted is True
+        return {"token": "new-secret", "validUntil": 200}
+
+    monkeypatch.setattr(session, "_command", fake_command)
+
+    await session.refresh_token()
+
+    assert token.value == "new-secret"
+    assert token.valid_until == 200
+    assert "new-secret" not in repr(token)

--- a/tests/test_loxone_client.py
+++ b/tests/test_loxone_client.py
@@ -121,35 +121,101 @@ async def test_token_acquisition_encrypts_credentials_and_retains_hash_algorithm
         )
         .decode()
     )
-    paths: list[str] = []
+    commands: list[tuple[str, bool]] = []
 
-    async def fake_get_json(path: str) -> dict[str, object]:
-        paths.append(path)
-        if path == "/jdev/sys/getPublicKey":
-            return {"LL": {"Code": "200", "value": public_pem}}
-        if path == "/jdev/sys/getkey2/restricted-reader":
-            return {
-                "LL": {
-                    "Code": "200",
-                    "value": {"key": "00112233", "salt": "a1b2", "hashAlg": "SHA256"},
-                }
-            }
-        assert path.startswith("/jdev/sys/enc/")
-        return {
-            "LL": {
-                "Code": "200",
-                "value": {"token": "jwt-secret", "key": "44556677", "validUntil": 123},
-            }
-        }
+    class FakeWebSocket:
+        closed = False
 
-    monkeypatch.setattr(client, "_get_json", fake_get_json)
+        async def close(self) -> None:
+            self.closed = True
+
+    websocket = FakeWebSocket()
+
+    async def fake_websocket_public_key() -> str:
+        return public_pem
+
+    async def fake_connect_websocket() -> Any:
+        return websocket
+
+    async def fake_websocket_command(
+        _websocket: Any,
+        _encryptor: Any,
+        command: str,
+        *,
+        encrypted: bool,
+        timeout_seconds: float,
+        max_payload_bytes: int,
+    ) -> object:
+        assert timeout_seconds == client.timeout_seconds
+        assert max_payload_bytes == client.max_response_bytes
+        commands.append((command, encrypted))
+        if not encrypted:
+            assert command.startswith("jdev/sys/keyexchange/")
+            return "OK"
+        if command == "jdev/sys/getkey2/restricted-reader":
+            return {"key": "00112233", "salt": "a1b2", "hashAlg": "SHA256"}
+        assert command.startswith("jdev/sys/getjwt/")
+        assert "/restricted-reader/4/098802e1-02b4-603c-ffffeee000d80cfd/" in command
+        return {"token": "jwt-secret", "key": "44556677", "validUntil": 123}
+
+    monkeypatch.setattr(client, "websocket_public_key", fake_websocket_public_key)
+    monkeypatch.setattr(client, "_connect_websocket", fake_connect_websocket)
+    monkeypatch.setattr("mcpserver.loxone.client._websocket_command", fake_websocket_command)
 
     token = await client.acquire_token("restricted-reader", "password-secret")
 
     assert token.hash_algorithm == "SHA256"
     assert "jwt-secret" not in repr(token)
-    assert "password-secret" not in "".join(paths)
-    assert all("getjwt" not in path for path in paths)
+    assert "password-secret" not in "".join(command for command, _ in commands)
+    assert commands[0][1] is False
+    assert commands[1] == ("jdev/sys/getkey2/restricted-reader", True)
+    assert commands[2][1] is True
+    assert websocket.closed is True
+
+
+@pytest.mark.asyncio
+async def test_token_acquisition_closes_websocket_when_keyexchange_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = LoxoneClient(
+        MiniserverEndpoint.parse_gen1("http://192.168.1.10"),
+        client_uuid=UUID("098802e1-02b4-603c-ffff-eee000d80cfd"),
+    )
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_pem = (
+        private_key.public_key()
+        .public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode()
+    )
+
+    class FakeWebSocket:
+        closed = False
+
+        async def close(self) -> None:
+            self.closed = True
+
+    websocket = FakeWebSocket()
+
+    async def fake_websocket_public_key() -> str:
+        return public_pem
+
+    async def fake_connect_websocket() -> Any:
+        return websocket
+
+    async def fail_command(*_args: object, **_kwargs: object) -> object:
+        raise LoxoneConnectionError("Miniserver rejected the request")
+
+    monkeypatch.setattr(client, "websocket_public_key", fake_websocket_public_key)
+    monkeypatch.setattr(client, "_connect_websocket", fake_connect_websocket)
+    monkeypatch.setattr("mcpserver.loxone.client._websocket_command", fail_command)
+
+    with pytest.raises(LoxoneConnectionError, match="rejected"):
+        await client.acquire_token("restricted-reader", "password-secret")
+
+    assert websocket.closed is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_loxone_client.py
+++ b/tests/test_loxone_client.py
@@ -143,7 +143,7 @@ async def test_http_errors_suppress_encrypted_request_url(
         async def __aexit__(self, *_args: object) -> None:
             return None
 
-        async def get(self, _path: str) -> httpx.Response:
+        def stream(self, _method: str, _path: str) -> Any:
             request = httpx.Request("GET", "http://192.168.1.10/secret-encrypted-path")
             raise httpx.ConnectError("request failed", request=request)
 
@@ -157,6 +157,58 @@ async def test_http_errors_suppress_encrypted_request_url(
     assert captured.value.__cause__ is None
     assert captured.value.__suppress_context__ is True
     assert "secret-encrypted-path" not in str(captured.value)
+
+
+@pytest.mark.asyncio
+async def test_http_response_limit_is_enforced_while_streaming(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = LoxoneClient(
+        MiniserverEndpoint.parse_gen1("http://192.168.1.10"),
+        client_uuid=UUID("098802e1-02b4-603c-ffff-eee000d80cfd"),
+        max_response_bytes=5,
+    )
+    chunks_read = 0
+
+    class FakeResponse:
+        encoding = "utf-8"
+
+        async def __aenter__(self) -> FakeResponse:
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+        def raise_for_status(self) -> None:
+            return None
+
+        async def aiter_bytes(self) -> Any:
+            nonlocal chunks_read
+            for chunk in (b"123", b"456", b"unused"):
+                chunks_read += 1
+                yield chunk
+
+    class FakeClient:
+        async def __aenter__(self) -> FakeClient:
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+        def stream(self, method: str, path: str) -> FakeResponse:
+            assert method == "GET"
+            assert path == "/large"
+            return FakeResponse()
+
+    monkeypatch.setattr(
+        "mcpserver.loxone.client.httpx.AsyncClient",
+        lambda **_kwargs: FakeClient(),
+    )
+
+    with pytest.raises(LoxoneConnectionError, match="exceeds"):
+        await client._get_text("/large")
+
+    assert chunks_read == 2
 
 
 @pytest.mark.asyncio
@@ -520,3 +572,50 @@ async def test_refresh_rotates_in_memory_token_with_dynamic_hash(
     assert token.value == "new-secret"
     assert token.valid_until == 200
     assert "new-secret" not in repr(token)
+
+
+@pytest.mark.asyncio
+async def test_state_events_uses_keepalive_after_idle_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    value_payload = b"\0" * 24
+
+    class FakeWebSocket:
+        def __init__(self) -> None:
+            self.sent: list[str] = []
+            self.messages: list[bytes | BaseException] = [
+                TimeoutError(),
+                bytes((3, MessageType.KEEPALIVE, 0, 0, 0, 0, 0, 0)),
+                bytes((3, MessageType.VALUE_STATES, 0, 0, 24, 0, 0, 0)),
+                value_payload,
+            ]
+
+        async def recv(self) -> bytes:
+            message = self.messages.pop(0)
+            if isinstance(message, BaseException):
+                raise message
+            return message
+
+        async def send(self, command: str) -> None:
+            self.sent.append(command)
+
+    websocket = FakeWebSocket()
+    session = LoxoneWebSocketSession(
+        cast(Any, websocket),
+        public_key="unused",
+        token=LoxoneToken("jwt", "reader", "key", "SHA256", 100),
+        timeout_seconds=0.1,
+        max_payload_bytes=100,
+    )
+
+    async def fake_command(command: str, *, encrypted: bool = False) -> object:
+        assert command == "jdev/sps/enablebinstatusupdate"
+        assert encrypted is False
+        return "OK"
+
+    monkeypatch.setattr(session, "_command", fake_command)
+
+    events = await anext(session.state_events())
+
+    assert len(events) == 1
+    assert websocket.sent == ["keepalive"]

--- a/tests/test_loxone_client.py
+++ b/tests/test_loxone_client.py
@@ -8,6 +8,8 @@ import httpx
 import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
+from websockets.exceptions import ConnectionClosedOK
+from websockets.frames import Close
 
 from mcpserver.loxone.client import (
     LoxoneClient,
@@ -77,7 +79,7 @@ async def test_websocket_receive_skips_estimated_header() -> None:
     class FakeWebSocket:
         def __init__(self) -> None:
             self.messages: list[bytes | str] = [
-                bytes((3, MessageType.TEXT, 1, 0, 0, 0, 0, 0)),
+                bytes((3, MessageType.TEXT, 0x80, 0, 0, 0, 0, 0)),
                 bytes((3, MessageType.TEXT, 0, 0, 2, 0, 0, 0)),
                 "{}",
             ]
@@ -111,27 +113,6 @@ async def test_websocket_receive_accepts_gen1_character_count_for_text() -> None
 
     assert header.message_type is MessageType.BINARY_FILE
     assert payload == "ä"
-
-
-@pytest.mark.asyncio
-async def test_websocket_receive_assembles_a_chunked_file() -> None:
-    class FakeWebSocket:
-        def __init__(self) -> None:
-            self.messages: list[bytes | str] = [
-                bytes((3, MessageType.BINARY_FILE, 0, 0, 6, 0, 0, 0)),
-                "abc",
-                "def",
-            ]
-
-        async def recv(self) -> bytes | str:
-            return self.messages.pop(0)
-
-    header, payload = await _receive_websocket(
-        cast(Any, FakeWebSocket()), timeout_seconds=0.1, max_payload_bytes=100
-    )
-
-    assert header.message_type is MessageType.BINARY_FILE
-    assert payload == "abcdef"
 
 
 def test_gen1_endpoint_builds_canonical_websocket_url() -> None:
@@ -451,7 +432,31 @@ async def test_authenticated_session_kills_token_with_a_fresh_key(
 
 
 @pytest.mark.asyncio
-async def test_structure_accepts_text_content_in_file_message(
+async def test_authenticated_session_accepts_normal_close_after_killing_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = LoxoneToken("jwt-secret", "reader", "expired-key", "SHA256", 100)
+    session = LoxoneWebSocketSession(
+        cast(Any, object()),
+        public_key="unused",
+        token=token,
+        timeout_seconds=1,
+        max_payload_bytes=100,
+    )
+
+    async def fake_command(command: str, *, encrypted: bool = False) -> object:
+        if command == "jdev/sys/getkey":
+            return "aabbccdd"
+        assert encrypted is True
+        raise ConnectionClosedOK(Close(1000, ""), Close(1000, ""), True)
+
+    monkeypatch.setattr(session, "_command", fake_command)
+
+    await session.kill_token()
+
+
+@pytest.mark.asyncio
+async def test_structure_accepts_gen1_text_content_in_file_message(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     payload = (

--- a/tests/test_loxone_client.py
+++ b/tests/test_loxone_client.py
@@ -17,7 +17,9 @@ from mcpserver.loxone.client import (
     MiniserverEndpoint,
     _close_websocket,
     _loxone_uuid,
+    _receive_websocket,
 )
+from mcpserver.loxone.events import MessageType
 from mcpserver.loxone.security import token_hmac
 
 
@@ -43,6 +45,52 @@ async def test_websocket_close_is_bounded() -> None:
             await asyncio.Event().wait()
 
     await _close_websocket(cast(Any, BlockingWebSocket()), 0.001)
+
+
+@pytest.mark.asyncio
+async def test_websocket_receive_returns_complete_payload_without_waiting_again() -> None:
+    class FakeWebSocket:
+        def __init__(self) -> None:
+            self.messages: list[bytes | str] = [
+                bytes((3, MessageType.TEXT, 0, 0, 2, 0, 0, 0)),
+                "{}",
+            ]
+            self.receive_count = 0
+
+        async def recv(self) -> bytes | str:
+            self.receive_count += 1
+            return self.messages.pop(0)
+
+    websocket = FakeWebSocket()
+
+    header, payload = await _receive_websocket(
+        cast(Any, websocket), timeout_seconds=0.1, max_payload_bytes=100
+    )
+
+    assert header.message_type is MessageType.TEXT
+    assert payload == "{}"
+    assert websocket.receive_count == 2
+
+
+@pytest.mark.asyncio
+async def test_websocket_receive_skips_estimated_header() -> None:
+    class FakeWebSocket:
+        def __init__(self) -> None:
+            self.messages: list[bytes | str] = [
+                bytes((3, MessageType.TEXT, 1, 0, 0, 0, 0, 0)),
+                bytes((3, MessageType.TEXT, 0, 0, 2, 0, 0, 0)),
+                "{}",
+            ]
+
+        async def recv(self) -> bytes | str:
+            return self.messages.pop(0)
+
+    header, payload = await _receive_websocket(
+        cast(Any, FakeWebSocket()), timeout_seconds=0.1, max_payload_bytes=100
+    )
+
+    assert header.estimated is False
+    assert payload == "{}"
 
 
 def test_gen1_endpoint_builds_canonical_websocket_url() -> None:

--- a/tests/test_loxone_client.py
+++ b/tests/test_loxone_client.py
@@ -79,6 +79,34 @@ async def test_http_errors_suppress_encrypted_request_url(
 
 
 @pytest.mark.asyncio
+async def test_probe_accepts_gen1_nested_json_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = LoxoneClient(
+        MiniserverEndpoint.parse_gen1("http://192.168.1.10"),
+        client_uuid=UUID("098802e1-02b4-603c-ffff-eee000d80cfd"),
+    )
+
+    async def fake_get_json(path: str) -> dict[str, object]:
+        assert path == "/jdev/cfg/apiKey"
+        return {
+            "LL": {
+                "Code": "200",
+                "value": (
+                    "{'version':'17.1.7.27','snr':'000000000000','local':true,'hasEventSlots':true}"
+                ),
+            }
+        }
+
+    monkeypatch.setattr(client, "_get_json", fake_get_json)
+
+    result = await client.probe()
+
+    assert result.firmware == "17.1.7.27"
+    assert result.serial == "000000000000"
+    assert result.is_local is True
+    assert result.has_event_slots is True
+
+
+@pytest.mark.asyncio
 async def test_probe_rejects_tls_capable_miniserver(monkeypatch: pytest.MonkeyPatch) -> None:
     client = LoxoneClient(
         MiniserverEndpoint.parse_gen1("http://192.168.1.10"),
@@ -164,7 +192,7 @@ async def test_token_acquisition_encrypts_credentials_and_retains_hash_algorithm
 
     token = await client.acquire_token("restricted-reader", "password-secret")
 
-    assert token.hash_algorithm == "SHA256"
+    assert token.hash_algorithm == "SHA1"
     assert "jwt-secret" not in repr(token)
     assert "password-secret" not in "".join(command for command, _ in commands)
     assert commands[0][1] is False
@@ -216,6 +244,69 @@ async def test_token_acquisition_closes_websocket_when_keyexchange_fails(
         await client.acquire_token("restricted-reader", "password-secret")
 
     assert websocket.closed is True
+
+
+@pytest.mark.asyncio
+async def test_token_revocation_uses_encrypted_websocket_and_destroys_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = LoxoneClient(
+        MiniserverEndpoint.parse_gen1("http://192.168.1.10"),
+        client_uuid=UUID("098802e1-02b4-603c-ffff-eee000d80cfd"),
+    )
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_pem = (
+        private_key.public_key()
+        .public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode()
+    )
+    commands: list[tuple[str, bool]] = []
+
+    class FakeWebSocket:
+        closed = False
+
+        async def close(self) -> None:
+            self.closed = True
+
+    websocket = FakeWebSocket()
+
+    async def fake_websocket_public_key() -> str:
+        return public_pem
+
+    async def fake_connect_websocket() -> Any:
+        return websocket
+
+    async def fake_websocket_command(
+        _websocket: Any,
+        _encryptor: Any,
+        command: str,
+        *,
+        encrypted: bool,
+        timeout_seconds: float,
+        max_payload_bytes: int,
+    ) -> object:
+        assert timeout_seconds == client.timeout_seconds
+        assert max_payload_bytes == client.max_response_bytes
+        commands.append((command, encrypted))
+        return "OK"
+
+    monkeypatch.setattr(client, "websocket_public_key", fake_websocket_public_key)
+    monkeypatch.setattr(client, "_connect_websocket", fake_connect_websocket)
+    monkeypatch.setattr("mcpserver.loxone.client._websocket_command", fake_websocket_command)
+    token = LoxoneToken("jwt-secret", "restricted-reader", "00112233", "SHA1", 123)
+
+    await client.kill_token(token)
+
+    assert commands[0][0].startswith("jdev/sys/keyexchange/")
+    assert commands[0][1] is False
+    assert commands[1][0].startswith("jdev/sys/killtoken/")
+    assert commands[1][1] is True
+    assert "jwt-secret" not in commands[1][0]
+    assert websocket.closed is True
+    assert token.value == ""
 
 
 @pytest.mark.asyncio

--- a/tests/test_loxone_events.py
+++ b/tests/test_loxone_events.py
@@ -43,7 +43,10 @@ def test_value_table_decodes_multiple_events() -> None:
 
     events = parse_value_events(payload)
 
-    assert [(event.uuid, event.value) for event in events] == [(first, 1.5), (second, -2.0)]
+    assert [(event.uuid, event.value) for event in events] == [
+        ("00112233-4455-6677-8899aabbccddeeff", 1.5),
+        ("11112222-3333-4444-aaaabbbbccccdddd", -2.0),
+    ]
 
 
 def test_text_table_honors_four_byte_padding() -> None:
@@ -53,4 +56,7 @@ def test_text_table_honors_four_byte_padding() -> None:
     payload = _loxone_uuid(state_uuid) + _loxone_uuid(icon_uuid) + struct.pack("<I", len(text))
     payload += text + b"\0\0"
 
-    assert parse_text_events(payload)[0].value == "on"
+    event = parse_text_events(payload)[0]
+
+    assert event.uuid == "00112233-4455-6677-8899aabbccddeeff"
+    assert event.value == "on"

--- a/tests/test_loxone_events.py
+++ b/tests/test_loxone_events.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import struct
+from uuid import UUID
+
+import pytest
+
+from mcpserver.loxone.events import (
+    LoxoneProtocolError,
+    MessageType,
+    parse_header,
+    parse_text_events,
+    parse_value_events,
+)
+
+
+def _loxone_uuid(value: str) -> bytes:
+    parsed = UUID(value)
+    return (
+        struct.pack("<IHH", parsed.time_low, parsed.time_mid, parsed.time_hi_version)
+        + parsed.bytes[8:]
+    )
+
+
+def test_header_parses_little_endian_length() -> None:
+    header = parse_header(struct.pack("<BBBBI", 3, 2, 0, 0, 24), max_payload_bytes=100)
+
+    assert header.message_type is MessageType.VALUE_STATES
+    assert header.payload_length == 24
+    assert header.estimated is False
+
+
+def test_header_rejects_oversized_payload() -> None:
+    with pytest.raises(LoxoneProtocolError, match="exceeds"):
+        parse_header(struct.pack("<BBBBI", 3, 2, 0, 0, 101), max_payload_bytes=100)
+
+
+def test_value_table_decodes_multiple_events() -> None:
+    first = "00112233-4455-6677-8899-aabbccddeeff"
+    second = "11112222-3333-4444-aaaa-bbbbccccdddd"
+    payload = _loxone_uuid(first) + struct.pack("<d", 1.5)
+    payload += _loxone_uuid(second) + struct.pack("<d", -2.0)
+
+    events = parse_value_events(payload)
+
+    assert [(event.uuid, event.value) for event in events] == [(first, 1.5), (second, -2.0)]
+
+
+def test_text_table_honors_four_byte_padding() -> None:
+    state_uuid = "00112233-4455-6677-8899-aabbccddeeff"
+    icon_uuid = "00000000-0000-0000-0000-000000000000"
+    text = b"on"
+    payload = _loxone_uuid(state_uuid) + _loxone_uuid(icon_uuid) + struct.pack("<I", len(text))
+    payload += text + b"\0\0"
+
+    assert parse_text_events(payload)[0].value == "on"

--- a/tests/test_loxone_security.py
+++ b/tests/test_loxone_security.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+from datetime import UTC, datetime, timedelta
+from urllib.parse import unquote
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.x509.oid import NameOID
+
+from mcpserver.loxone.security import (
+    CommandEncryptor,
+    LoxoneSecurityError,
+    encrypt_aes_command,
+    encrypt_session_key,
+    normalize_rsa_public_key_pem,
+    password_hmac,
+)
+
+
+def test_password_hmac_uses_server_selected_sha256() -> None:
+    result = password_hmac("reader", "correct horse", "00112233", "a1b2", "SHA256")
+
+    password_hash = hashlib.sha256(b"correct horse:a1b2").hexdigest().upper()
+    expected = hmac.new(
+        bytes.fromhex("00112233"), f"reader:{password_hash}".encode(), hashlib.sha256
+    )
+    assert result == expected.hexdigest()
+
+
+def test_password_hmac_rejects_unknown_algorithm_without_echoing_it() -> None:
+    with pytest.raises(LoxoneSecurityError, match="unsupported"):
+        password_hmac("reader", "secret", "0011", "salt", "MD5-secret")
+
+
+def test_session_key_uses_rsa_pkcs1_v15() -> None:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_pem = (
+        private_key.public_key()
+        .public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode()
+    )
+
+    encoded = encrypt_session_key(public_pem, b"k" * 32, b"i" * 16)
+    plaintext = private_key.decrypt(base64.b64decode(unquote(encoded)), padding.PKCS1v15())
+
+    assert plaintext == f"{'6b' * 32}:{'69' * 16}".encode()
+
+
+def test_gen1_certificate_without_line_breaks_yields_rsa_public_key() -> None:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Miniserver")])
+    certificate = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(private_key.public_key())
+        .serial_number(1)
+        .not_valid_before(datetime.now(UTC) - timedelta(minutes=1))
+        .not_valid_after(datetime.now(UTC) + timedelta(days=1))
+        .sign(private_key, hashes.SHA256())
+    )
+    compact = certificate.public_bytes(serialization.Encoding.PEM).decode().replace("\n", "")
+
+    normalized = normalize_rsa_public_key_pem(compact)
+    loaded = serialization.load_pem_public_key(normalized.encode())
+
+    assert isinstance(loaded, rsa.RSAPublicKey)
+    assert loaded.public_numbers() == private_key.public_key().public_numbers()
+
+
+def test_gen1_mislabelled_der_public_key_yields_rsa_public_key() -> None:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    der = private_key.public_key().public_bytes(
+        serialization.Encoding.DER,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    mislabelled = (
+        "-----BEGIN CERTIFICATE-----" + base64.b64encode(der).decode() + "-----END CERTIFICATE-----"
+    )
+
+    normalized = normalize_rsa_public_key_pem(mislabelled)
+    loaded = serialization.load_pem_public_key(normalized.encode())
+
+    assert isinstance(loaded, rsa.RSAPublicKey)
+    assert loaded.public_numbers() == private_key.public_key().public_numbers()
+
+
+def test_aes_command_validates_session_material() -> None:
+    with pytest.raises(LoxoneSecurityError, match="session material"):
+        encrypt_aes_command("jdev/test", b"short", b"short", "salt")
+
+
+def test_websocket_encryptor_rotates_salt(monkeypatch: pytest.MonkeyPatch) -> None:
+    encryptor = CommandEncryptor(key=b"k" * 32, iv=b"i" * 16, salt="first")
+    monkeypatch.setattr("mcpserver.loxone.security.secrets.token_hex", lambda _size: "second")
+
+    first = encryptor.encrypted_command("auth")
+    second = encryptor.encrypted_command("refresh")
+
+    first_cipher = base64.b64decode(unquote(first.rsplit("/", 1)[1]))
+    second_cipher = base64.b64decode(unquote(second.rsplit("/", 1)[1]))
+    decryptor = Cipher(algorithms.AES(b"k" * 32), modes.CBC(b"i" * 16)).decryptor()
+    first_plaintext = (decryptor.update(first_cipher) + decryptor.finalize()).rstrip(b"\0")
+    decryptor = Cipher(algorithms.AES(b"k" * 32), modes.CBC(b"i" * 16)).decryptor()
+    second_plaintext = (decryptor.update(second_cipher) + decryptor.finalize()).rstrip(b"\0")
+
+    assert first_plaintext == b"salt/first/auth"
+    assert second_plaintext == b"nextSalt/first/second/refresh"
+    assert encryptor.salt == "second"

--- a/tests/test_loxone_security.py
+++ b/tests/test_loxone_security.py
@@ -18,6 +18,7 @@ from mcpserver.loxone.security import (
     LoxoneSecurityError,
     encrypt_aes_command,
     encrypt_session_key,
+    normalize_loxone_certificate_chain_pem,
     normalize_rsa_public_key_pem,
     password_hmac,
 )
@@ -50,9 +51,29 @@ def test_session_key_uses_rsa_pkcs1_v15() -> None:
     )
 
     encoded = encrypt_session_key(public_pem, b"k" * 32, b"i" * 16)
-    plaintext = private_key.decrypt(base64.b64decode(unquote(encoded)), padding.PKCS1v15())
+    plaintext = private_key.decrypt(base64.b64decode(encoded), padding.PKCS1v15())
 
     assert plaintext == f"{'6b' * 32}:{'69' * 16}".encode()
+
+
+def test_http_command_uri_encodes_the_raw_session_key() -> None:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_pem = (
+        private_key.public_key()
+        .public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode()
+    )
+    encryptor = CommandEncryptor(key=b"k" * 32, iv=b"i" * 16, salt="salt")
+
+    path = encryptor.encrypted_http_request("jdev/test", public_pem)
+    encoded_session_key = path.split("?sk=", 1)[1]
+
+    assert "/" not in encoded_session_key
+    assert "+" not in encoded_session_key
+    assert unquote(encoded_session_key) != encoded_session_key or "=" in encoded_session_key
 
 
 def test_gen1_certificate_without_line_breaks_yields_rsa_public_key() -> None:
@@ -92,6 +113,70 @@ def test_gen1_mislabelled_der_public_key_yields_rsa_public_key() -> None:
 
     assert isinstance(loaded, rsa.RSAPublicKey)
     assert loaded.public_numbers() == private_key.public_key().public_numbers()
+
+
+def test_loxone_certificate_chain_uses_verified_leaf_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    leaf_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    root_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Loxone test root")])
+    leaf_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Miniserver")])
+    now = datetime.now(UTC)
+    root = (
+        x509.CertificateBuilder()
+        .subject_name(root_name)
+        .issuer_name(root_name)
+        .public_key(root_key.public_key())
+        .serial_number(1)
+        .not_valid_before(now - timedelta(minutes=1))
+        .not_valid_after(now + timedelta(days=1))
+        .sign(root_key, hashes.SHA256())
+    )
+    leaf = (
+        x509.CertificateBuilder()
+        .subject_name(leaf_name)
+        .issuer_name(root_name)
+        .public_key(leaf_key.public_key())
+        .serial_number(2)
+        .not_valid_before(now - timedelta(minutes=1))
+        .not_valid_after(now + timedelta(days=1))
+        .sign(root_key, hashes.SHA256())
+    )
+    monkeypatch.setattr(
+        "mcpserver.loxone.security._LOXONE_ROOT_SHA256",
+        root.fingerprint(hashes.SHA256()).hex(),
+    )
+    chain = (
+        root.public_bytes(serialization.Encoding.PEM)
+        + leaf.public_bytes(serialization.Encoding.PEM)
+    ).decode()
+
+    normalized = normalize_loxone_certificate_chain_pem(chain)
+    loaded = serialization.load_pem_public_key(normalized.encode())
+
+    assert isinstance(loaded, rsa.RSAPublicKey)
+    assert loaded.public_numbers() == leaf_key.public_key().public_numbers()
+
+
+def test_loxone_certificate_chain_rejects_unpinned_root() -> None:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Untrusted")])
+    now = datetime.now(UTC)
+    certificate = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(1)
+        .not_valid_before(now - timedelta(minutes=1))
+        .not_valid_after(now + timedelta(days=1))
+        .sign(key, hashes.SHA256())
+    )
+    chain = (certificate.public_bytes(serialization.Encoding.PEM) * 2).decode()
+
+    with pytest.raises(LoxoneSecurityError, match="untrusted root"):
+        normalize_loxone_certificate_chain_pem(chain)
 
 
 def test_aes_command_validates_session_material() -> None:

--- a/tests/test_loxone_structure.py
+++ b/tests/test_loxone_structure.py
@@ -7,8 +7,14 @@ def test_structure_is_reduced_to_user_visible_domain_fields() -> None:
     raw = {
         "lastModified": "2026-08-01 12:00:00",
         "msInfo": {"serialNr": "000000000000", "projectName": "must not leak"},
-        "rooms": {"room-1": {"name": "Kitchen", "image": "ignored"}},
-        "cats": {"cat-1": {"name": "Lights"}},
+        "rooms": {
+            "room-1": {"name": "Kitchen", "image": "ignored"},
+            "denied-room": {"name": "Secret room"},
+        },
+        "cats": {
+            "cat-1": {"name": "Lights"},
+            "denied-category": {"name": "Secret category"},
+        },
         "controls": {
             "control-1": {
                 "name": "Ceiling",
@@ -16,16 +22,26 @@ def test_structure_is_reduced_to_user_visible_domain_fields() -> None:
                 "room": "room-1",
                 "cat": "cat-1",
                 "action": "action-1",
+                "restrictions": 0,
                 "states": {"active": "state-1"},
                 "details": {"password": "must not leak"},
                 "subControls": {
                     "sub-1": {
                         "name": "Sub",
                         "type": "InfoOnlyDigital",
+                        "restrictions": 17,
                         "states": {"active": "state-2"},
                     }
                 },
-            }
+            },
+            "denied-control": {
+                "name": "Denied",
+                "type": "InfoOnlyAnalog",
+                "restrictions": 17,
+                "room": "denied-room",
+                "cat": "denied-category",
+                "states": {"value": "denied-state"},
+            },
         },
     }
 
@@ -36,6 +52,9 @@ def test_structure_is_reduced_to_user_visible_domain_fields() -> None:
     assert structure.rooms[0].name == "Kitchen"
     assert structure.controls[0].state_uuids == (("active", "state-1"),)
     assert structure.controls[0].subcontrols[0].uuid == "sub-1"
+    assert {control.uuid for control in structure.controls} == {"control-1"}
+    assert {room.uuid for room in structure.rooms} == {"room-1"}
+    assert {category.uuid for category in structure.categories} == {"cat-1"}
     assert "must not leak" not in repr(structure)
 
 

--- a/tests/test_loxone_structure.py
+++ b/tests/test_loxone_structure.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from mcpserver.loxone.structure import normalize_structure
+
+
+def test_structure_is_reduced_to_user_visible_domain_fields() -> None:
+    raw = {
+        "lastModified": "2026-08-01 12:00:00",
+        "msInfo": {"serialNr": "000000000000", "projectName": "must not leak"},
+        "rooms": {"room-1": {"name": "Kitchen", "image": "ignored"}},
+        "cats": {"cat-1": {"name": "Lights"}},
+        "controls": {
+            "control-1": {
+                "name": "Ceiling",
+                "type": "Switch",
+                "room": "room-1",
+                "cat": "cat-1",
+                "action": "action-1",
+                "states": {"active": "state-1"},
+                "details": {"password": "must not leak"},
+                "subControls": {
+                    "sub-1": {
+                        "name": "Sub",
+                        "type": "InfoOnlyDigital",
+                        "states": {"active": "state-2"},
+                    }
+                },
+            }
+        },
+    }
+
+    structure = normalize_structure(raw, username="restricted-reader")
+
+    assert structure.identity.username == "restricted-reader"
+    assert structure.identity.miniserver_serial == "000000000000"
+    assert structure.rooms[0].name == "Kitchen"
+    assert structure.controls[0].state_uuids == (("active", "state-1"),)
+    assert structure.controls[0].subcontrols[0].uuid == "sub-1"
+    assert "must not leak" not in repr(structure)
+
+
+def test_absent_controls_remain_absent() -> None:
+    raw = {
+        "lastModified": "now",
+        "msInfo": {"serialNr": "000000000000"},
+        "rooms": {},
+        "cats": {},
+        "controls": {},
+    }
+
+    structure = normalize_structure(raw, username="restricted-reader")
+
+    assert structure.controls == ()

--- a/tests/test_loxone_target.py
+++ b/tests/test_loxone_target.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from tools.test_loxone_target import _read_password
+
+
+def test_target_password_can_be_read_from_redirected_stdin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("tools.test_loxone_target.sys.stdin", io.StringIO("secret-value\n"))
+
+    assert _read_password(from_stdin=True) == "secret-value"
+
+
+def test_target_password_rejects_empty_redirected_input(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("tools.test_loxone_target.sys.stdin", io.StringIO(""))
+
+    with pytest.raises(RuntimeError, match="empty"):
+        _read_password(from_stdin=True)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,8 +1,16 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from mcpserver.settings import ServerSettings
+
+
+def test_arm64_runtime_lock_contains_no_windows_only_packages() -> None:
+    lock_path = Path(__file__).parents[1] / "requirements" / "runtime-arm64.lock"
+
+    assert "pywin32" not in lock_path.read_text(encoding="utf-8").lower()
 
 
 def test_secure_defaults(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tools/test_loxone_target.py
+++ b/tools/test_loxone_target.py
@@ -1,0 +1,155 @@
+"""Interactive, secret-safe Phase-0 test against an explicitly named Gen. 1 target."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import getpass
+import hashlib
+from collections.abc import Iterable
+from uuid import uuid4
+
+from mcpserver.loxone.cache import UserStateCache
+from mcpserver.loxone.client import LoxoneClient, LoxoneToken, MiniserverEndpoint
+from mcpserver.loxone.models import Control, Freshness
+
+
+def _control_uuids(controls: Iterable[Control]) -> set[str]:
+    result: set[str] = set()
+    for control in controls:
+        result.add(control.uuid)
+        result.update(_control_uuids(control.subcontrols))
+    return result
+
+
+def _state_uuids(controls: Iterable[Control]) -> set[str]:
+    result: set[str] = set()
+    for control in controls:
+        result.update(uuid for _name, uuid in control.state_uuids)
+        result.update(_state_uuids(control.subcontrols))
+    return result
+
+
+async def _observe_once(
+    client: LoxoneClient,
+    token_subject: str,
+    token: LoxoneToken,
+    cache: UserStateCache,
+    visible_states: set[str],
+    timeout: float,
+) -> str:
+    session = await client.open_session(token)
+    cache.begin_connection(token_subject)
+    try:
+        async with asyncio.timeout(timeout):
+            async for events in session.state_events():
+                cache.apply(token_subject, events)
+                matching = next(
+                    (event.uuid for event in events if event.uuid in visible_states), None
+                )
+                if matching is not None:
+                    return matching
+    finally:
+        await session.close()
+        cache.disconnect(token_subject)
+    raise RuntimeError("No user-visible state event was received")
+
+
+async def _observe_snapshot_and_delta(
+    client: LoxoneClient,
+    token_subject: str,
+    token: LoxoneToken,
+    cache: UserStateCache,
+    visible_states: set[str],
+    timeout: float,
+) -> str:
+    session = await client.open_session(token)
+    cache.begin_connection(token_subject)
+    initial: dict[str, object] = {}
+    try:
+        async with asyncio.timeout(timeout):
+            async for events in session.state_events():
+                cache.apply(token_subject, events)
+                for event in events:
+                    if event.uuid not in visible_states:
+                        continue
+                    if event.uuid in initial and initial[event.uuid] != event.value:
+                        return event.uuid
+                    initial[event.uuid] = event.value
+    finally:
+        await session.close()
+        cache.disconnect(token_subject)
+    raise RuntimeError("No changed user-visible state delta was received")
+
+
+async def _run(args: argparse.Namespace) -> None:
+    password = getpass.getpass("Dedicated Loxone test-user password: ")
+    endpoint = MiniserverEndpoint.parse_gen1(args.endpoint)
+    client = LoxoneClient(endpoint, client_uuid=uuid4(), client_name="LoxBerry MCP Phase-0 Test")
+    token = None
+    try:
+        probe = await client.probe()
+        if probe.firmware != args.expected_firmware:
+            raise RuntimeError("Miniserver firmware does not match the expected target")
+        token = await client.acquire_token(args.username, password)
+        password = ""
+
+        session = await client.open_session(token)
+        try:
+            structure = await session.load_structure()
+        finally:
+            await session.close()
+
+        controls = _control_uuids(structure.controls)
+        if args.visible_control not in controls:
+            raise RuntimeError("Expected visible control is absent from the restricted structure")
+        if args.hidden_control in controls:
+            raise RuntimeError("Expected hidden control leaked into the restricted structure")
+        visible_states = _state_uuids(structure.controls)
+        if not visible_states:
+            raise RuntimeError("Restricted structure does not contain a state UUID")
+
+        subject = f"{probe.serial}:{args.username}"
+        cache = UserStateCache()
+        print("Operate one visible test control through its normal UI now; waiting for a delta.")
+        observed = await _observe_snapshot_and_delta(
+            client, subject, token, cache, visible_states, args.observe_seconds
+        )
+        if cache.get(subject, observed).freshness is not Freshness.STALE:
+            raise RuntimeError("Disconnected state was not marked stale")
+        observed = await _observe_once(
+            client, subject, token, cache, visible_states, args.observe_seconds
+        )
+        if cache.get(subject, observed).freshness is not Freshness.STALE:
+            raise RuntimeError("Reconnected state was not marked stale after the second close")
+
+        serial_fingerprint = hashlib.sha256(probe.serial.encode()).hexdigest()[:12]
+        print(f"LOXONE_FIRMWARE={probe.firmware}")
+        print(f"LOXONE_SERIAL_FINGERPRINT={serial_fingerprint}")
+        print("LOXONE_RESTRICTED_STRUCTURE=pass")
+        print("LOXONE_WEBSOCKET_SNAPSHOT=pass")
+        print("LOXONE_WEBSOCKET_RECONNECT=pass")
+    finally:
+        password = ""
+        if token is not None:
+            await client.kill_token(token)
+            print("LOXONE_TOKEN_REVOCATION=pass")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run the interactive Gen. 1 Phase-0 test without putting secrets on argv."
+    )
+    parser.add_argument("--endpoint", required=True, help="Canonical private HTTP origin")
+    parser.add_argument("--username", required=True, help="Dedicated restricted Loxone user")
+    parser.add_argument("--visible-control", required=True, help="Control UUID visible to the user")
+    parser.add_argument("--hidden-control", required=True, help="Control UUID hidden from the user")
+    parser.add_argument("--expected-firmware", default="17.1.7.27")
+    parser.add_argument("--observe-seconds", type=float, default=60.0)
+    args = parser.parse_args()
+    asyncio.run(_run(args))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_loxone_target.py
+++ b/tools/test_loxone_target.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import argparse
 import asyncio
 import getpass
-import hashlib
 import sys
 from collections.abc import Iterable
 from uuid import uuid4
@@ -147,9 +146,7 @@ async def _run(args: argparse.Namespace) -> None:
         if cache.get(subject, observed).freshness is not Freshness.STALE:
             raise RuntimeError("Reconnected state was not marked stale after the second close")
 
-        serial_fingerprint = hashlib.sha256(probe.serial.encode()).hexdigest()[:12]
         print(f"LOXONE_FIRMWARE={probe.firmware}")
-        print(f"LOXONE_SERIAL_FINGERPRINT={serial_fingerprint}")
         print("LOXONE_WEBSOCKET_SNAPSHOT=pass", flush=True)
         print("LOXONE_WEBSOCKET_RECONNECT=pass", flush=True)
     except BaseException as exc:

--- a/tools/test_loxone_target.py
+++ b/tools/test_loxone_target.py
@@ -6,12 +6,24 @@ import argparse
 import asyncio
 import getpass
 import hashlib
+import sys
 from collections.abc import Iterable
 from uuid import uuid4
 
 from mcpserver.loxone.cache import UserStateCache
 from mcpserver.loxone.client import LoxoneClient, LoxoneToken, MiniserverEndpoint
 from mcpserver.loxone.models import Control, Freshness
+
+
+def _read_password(*, from_stdin: bool) -> str:
+    password = (
+        sys.stdin.readline().rstrip("\r\n")
+        if from_stdin
+        else getpass.getpass("Dedicated Loxone test-user password: ")
+    )
+    if not password:
+        raise RuntimeError("Dedicated Loxone test-user password is empty")
+    return password
 
 
 def _control_uuids(controls: Iterable[Control]) -> set[str]:
@@ -83,7 +95,7 @@ async def _observe_snapshot_and_delta(
 
 
 async def _run(args: argparse.Namespace) -> None:
-    password = getpass.getpass("Dedicated Loxone test-user password: ")
+    password = _read_password(from_stdin=args.password_stdin)
     endpoint = MiniserverEndpoint.parse_gen1(args.endpoint)
     client = LoxoneClient(endpoint, client_uuid=uuid4(), client_name="LoxBerry MCP Phase-0 Test")
     token = None
@@ -157,6 +169,11 @@ def main() -> int:
     parser.add_argument("--expected-firmware", default="17.1.7.27")
     parser.add_argument("--observe-seconds", type=float, default=60.0)
     parser.add_argument("--operation-timeout", type=float, default=20.0)
+    parser.add_argument(
+        "--password-stdin",
+        action="store_true",
+        help="Read one password line from redirected stdin; never from argv or environment",
+    )
     args = parser.parse_args()
     asyncio.run(_run(args))
     return 0

--- a/tools/test_loxone_target.py
+++ b/tools/test_loxone_target.py
@@ -55,7 +55,7 @@ async def _observe_once(
     try:
         async with asyncio.timeout(timeout):
             async for events in session.state_events():
-                cache.apply(token_subject, events)
+                cache.apply(token_subject, events, allowed_uuids=visible_states)
                 matching = next(
                     (event.uuid for event in events if event.uuid in visible_states), None
                 )
@@ -81,7 +81,7 @@ async def _observe_snapshot_and_delta(
     try:
         async with asyncio.timeout(timeout):
             async for events in session.state_events():
-                cache.apply(token_subject, events)
+                cache.apply(token_subject, events, allowed_uuids=visible_states)
                 for event in events:
                     if event.uuid not in visible_states:
                         continue

--- a/tools/test_loxone_target.py
+++ b/tools/test_loxone_target.py
@@ -88,17 +88,24 @@ async def _run(args: argparse.Namespace) -> None:
     client = LoxoneClient(endpoint, client_uuid=uuid4(), client_name="LoxBerry MCP Phase-0 Test")
     token = None
     try:
-        probe = await client.probe()
+        probe = await asyncio.wait_for(client.probe(), timeout=args.operation_timeout)
         if probe.firmware != args.expected_firmware:
             raise RuntimeError("Miniserver firmware does not match the expected target")
-        token = await client.acquire_token(args.username, password)
+        print("LOXONE_PROBE=pass", flush=True)
+        token = await asyncio.wait_for(
+            client.acquire_token(args.username, password), timeout=args.operation_timeout
+        )
         password = ""
+        print("LOXONE_TOKEN_ACQUISITION=pass", flush=True)
 
-        session = await client.open_session(token)
+        session = await asyncio.wait_for(client.open_session(token), timeout=args.operation_timeout)
         try:
-            structure = await session.load_structure()
+            structure = await asyncio.wait_for(
+                session.load_structure(), timeout=args.operation_timeout
+            )
         finally:
-            await session.close()
+            await asyncio.wait_for(session.close(), timeout=args.operation_timeout)
+        print("LOXONE_STRUCTURE_FETCH=pass", flush=True)
 
         controls = _control_uuids(structure.controls)
         if args.visible_control not in controls:
@@ -108,10 +115,14 @@ async def _run(args: argparse.Namespace) -> None:
         visible_states = _state_uuids(structure.controls)
         if not visible_states:
             raise RuntimeError("Restricted structure does not contain a state UUID")
+        print("LOXONE_RESTRICTED_STRUCTURE=pass", flush=True)
 
         subject = f"{probe.serial}:{args.username}"
         cache = UserStateCache()
-        print("Operate one visible test control through its normal UI now; waiting for a delta.")
+        print(
+            "Operate one visible test control through its normal UI now; waiting for a delta.",
+            flush=True,
+        )
         observed = await _observe_snapshot_and_delta(
             client, subject, token, cache, visible_states, args.observe_seconds
         )
@@ -126,14 +137,13 @@ async def _run(args: argparse.Namespace) -> None:
         serial_fingerprint = hashlib.sha256(probe.serial.encode()).hexdigest()[:12]
         print(f"LOXONE_FIRMWARE={probe.firmware}")
         print(f"LOXONE_SERIAL_FINGERPRINT={serial_fingerprint}")
-        print("LOXONE_RESTRICTED_STRUCTURE=pass")
-        print("LOXONE_WEBSOCKET_SNAPSHOT=pass")
-        print("LOXONE_WEBSOCKET_RECONNECT=pass")
+        print("LOXONE_WEBSOCKET_SNAPSHOT=pass", flush=True)
+        print("LOXONE_WEBSOCKET_RECONNECT=pass", flush=True)
     finally:
         password = ""
         if token is not None:
-            await client.kill_token(token)
-            print("LOXONE_TOKEN_REVOCATION=pass")
+            await asyncio.wait_for(client.kill_token(token), timeout=args.operation_timeout)
+            print("LOXONE_TOKEN_REVOCATION=pass", flush=True)
 
 
 def main() -> int:
@@ -146,6 +156,7 @@ def main() -> int:
     parser.add_argument("--hidden-control", required=True, help="Control UUID hidden from the user")
     parser.add_argument("--expected-firmware", default="17.1.7.27")
     parser.add_argument("--observe-seconds", type=float, default=60.0)
+    parser.add_argument("--operation-timeout", type=float, default=20.0)
     args = parser.parse_args()
     asyncio.run(_run(args))
     return 0

--- a/tools/test_loxone_target.py
+++ b/tools/test_loxone_target.py
@@ -99,6 +99,7 @@ async def _run(args: argparse.Namespace) -> None:
     endpoint = MiniserverEndpoint.parse_gen1(args.endpoint)
     client = LoxoneClient(endpoint, client_uuid=uuid4(), client_name="LoxBerry MCP Phase-0 Test")
     token = None
+    primary_error: BaseException | None = None
     try:
         probe = await asyncio.wait_for(client.probe(), timeout=args.operation_timeout)
         if probe.firmware != args.expected_firmware:
@@ -151,11 +152,20 @@ async def _run(args: argparse.Namespace) -> None:
         print(f"LOXONE_SERIAL_FINGERPRINT={serial_fingerprint}")
         print("LOXONE_WEBSOCKET_SNAPSHOT=pass", flush=True)
         print("LOXONE_WEBSOCKET_RECONNECT=pass", flush=True)
+    except BaseException as exc:
+        primary_error = exc
+        raise
     finally:
         password = ""
         if token is not None:
-            await asyncio.wait_for(client.kill_token(token), timeout=args.operation_timeout)
-            print("LOXONE_TOKEN_REVOCATION=pass", flush=True)
+            try:
+                await asyncio.wait_for(client.kill_token(token), timeout=args.operation_timeout)
+            except Exception:
+                print("LOXONE_TOKEN_REVOCATION=fail", flush=True)
+                if primary_error is None:
+                    raise
+            else:
+                print("LOXONE_TOKEN_REVOCATION=pass", flush=True)
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary

- add a strict local-only Gen. 1 Loxone adapter with Command Encryption and dynamic SHA1/SHA256 token hashing
- normalize the user-specific LoxAPP3 structure and decode documented WebSocket event tables
- enforce Gen. 1 visualization restrictions before exposing controls, rooms, categories, or cached states
- add isolated bounded state caches, in-memory JWT refresh, a target test, and the exact Python 3.13 arm64 WebSocket dependency

## Security boundaries

- rejects credentials in URLs, hostnames, public addresses, redirects, TLS-capable targets, and unsupported hash algorithms
- keeps passwords, hashing keys, JWTs, raw structures, state values, and encrypted request URLs out of logs and exception chains
- keeps test JWTs in memory and revokes them with authenticated `killtoken`; a normal WebSocket close after revocation is accepted as success
- validates the real Gen. 1 certificate chain and RSA leaf key against the pinned Loxone root
- serializes client and event identifiers using Loxone's required UUID representation (`8-4-4-16`)
- filters top-level controls marked `referenced only (internal)`, retains referenced subcontrols under allowed parents, and drops all state events outside the filtered structure
- marks cached values stale immediately on disconnect and requires fresh events after reconnect

## Validation

- local compatibility run with `PYTHONPATH=src`: **92 passed** plus format, lint, and strict mypy
- real LoxBerry `4.0.0.14`, Debian 13/aarch64, Python `3.13.5`, Apache `2.4.68`: **verified**
- 31-wheel offline install: **verified** (`websockets 17.0.1`, 9,360 KiB wheelhouse, 53,836 KiB venv)
- isolated service start/health/RSS gate: **verified** (4,178 ms; 54,796 KiB initial; 54,808 KiB after 30 s)
- real Miniserver Gen. 1 firmware `17.1.7.27`: encrypted probe/login, user-specific structure, visible/denied control filtering, initial snapshot, real temperature delta, disconnect-to-stale, reconnect, and token revocation: **verified**
- target-specific finding: visualisation denial is represented as `restrictions = 17`, while raw metadata and states are still delivered by the Gen. 1 App WebSocket; adapter-side filtering and cache allowlisting are therefore required
- secret and local-test-data scan of the diff and target output: **passed**
- GitHub Actions for head `58ed1f0`: **passed**

All implementation, validation, CI, and normal security-review gates completed successfully before merge.