### PR TITLE
Add Phase 0 OAuth and client interoperability spike

### DIFF
--- a/config/apache/mcpserver.conf
+++ b/config/apache/mcpserver.conf
@@ -5,6 +5,18 @@ ProxyPassMatch "^/plugins/mcpserver/(mcp)$" "http://127.0.0.1:8765/$1" nocanon r
 ProxyPassReverse "/plugins/mcpserver/mcp" "http://127.0.0.1:8765/mcp"
 
 # OAuth routes are deliberately exact. No issuer-wide or generic proxy is used.
+<Location "/plugins/mcpserver/oauth/authorize">
+    LimitRequestBody 16384
+</Location>
+<Location "/plugins/mcpserver/oauth/token">
+    LimitRequestBody 16384
+</Location>
+<Location "/plugins/mcpserver/oauth/register">
+    LimitRequestBody 32768
+</Location>
+<Location "/plugins/mcpserver/oauth/revoke">
+    LimitRequestBody 16384
+</Location>
 ProxyPassMatch "^/plugins/mcpserver/oauth/(authorize)$" "http://127.0.0.1:8765/$1" nocanon
 ProxyPassReverse "/plugins/mcpserver/oauth/authorize" "http://127.0.0.1:8765/authorize"
 ProxyPassMatch "^/plugins/mcpserver/oauth/(token)$" "http://127.0.0.1:8765/$1" nocanon

--- a/config/apache/mcpserver.conf
+++ b/config/apache/mcpserver.conf
@@ -1,5 +1,19 @@
 # Installed as an Apache conf fragment by the LoxBerry root lifecycle hook.
 # The backend remains loopback-only; public host and Origin validation is also
 # enforced by the MCP process.
-ProxyPass "/plugins/mcpserver/mcp" "http://127.0.0.1:8765/mcp" nocanon retry=0 timeout=300
+ProxyPassMatch "^/plugins/mcpserver/(mcp)$" "http://127.0.0.1:8765/$1" nocanon retry=0 timeout=300
 ProxyPassReverse "/plugins/mcpserver/mcp" "http://127.0.0.1:8765/mcp"
+
+# OAuth routes are deliberately exact. No issuer-wide or generic proxy is used.
+ProxyPassMatch "^/plugins/mcpserver/oauth/(authorize)$" "http://127.0.0.1:8765/$1" nocanon
+ProxyPassReverse "/plugins/mcpserver/oauth/authorize" "http://127.0.0.1:8765/authorize"
+ProxyPassMatch "^/plugins/mcpserver/oauth/(token)$" "http://127.0.0.1:8765/$1" nocanon
+ProxyPassReverse "/plugins/mcpserver/oauth/token" "http://127.0.0.1:8765/token"
+ProxyPassMatch "^/plugins/mcpserver/oauth/(register)$" "http://127.0.0.1:8765/$1" nocanon
+ProxyPassReverse "/plugins/mcpserver/oauth/register" "http://127.0.0.1:8765/register"
+ProxyPassMatch "^/plugins/mcpserver/oauth/(revoke)$" "http://127.0.0.1:8765/$1" nocanon
+ProxyPassReverse "/plugins/mcpserver/oauth/revoke" "http://127.0.0.1:8765/revoke"
+ProxyPassMatch "^(/.well-known/oauth-protected-resource/plugins/mcpserver/mcp)$" "http://127.0.0.1:8765$1" nocanon
+ProxyPassReverse "/.well-known/oauth-protected-resource/plugins/mcpserver/mcp" "http://127.0.0.1:8765/.well-known/oauth-protected-resource/plugins/mcpserver/mcp"
+ProxyPassMatch "^(/.well-known/oauth-authorization-server/plugins/mcpserver/oauth)$" "http://127.0.0.1:8765$1" nocanon
+ProxyPassReverse "/.well-known/oauth-authorization-server/plugins/mcpserver/oauth" "http://127.0.0.1:8765/.well-known/oauth-authorization-server/plugins/mcpserver/oauth"

--- a/docs/development/adr/0001-phase-0-foundation.md
+++ b/docs/development/adr/0001-phase-0-foundation.md
@@ -30,9 +30,11 @@ Implementierungsdetails ersetzen.
 
 - Ein einzelner unprivilegierter Dienst läuft als `loxberry`, bindet nur an
   `127.0.0.1` und stellt Streamable HTTP bereit.
-- Der durch den realen Apache-Transport-Spike bestätigte öffentliche MCP-Pfad ist
-  `/plugins/mcpserver/mcp`. Die separat weitergeleiteten OAuth-Discovery-Pfade
-  unter `/.well-known/` werden im OAuth-Spike festgelegt.
+- Der öffentliche MCP-Pfad ist `/plugins/mcpserver/mcp`; der OAuth-Issuer ist
+  `/plugins/mcpserver/oauth`. Apache leitet ausschließlich die vier exakten
+  Issuer-Endpunkte `/authorize`, `/token`, `/register` und `/revoke` sowie die
+  RFC-konformen Protected-Resource- und Authorization-Server-Metadaten unter
+  `/.well-known/` weiter.
 - Externer HTTPS-Zugriff bleibt im ersten öffentlichen Test deaktiviert.
 - Proxy-Header werden nur vom lokalen Apache akzeptiert. Host und Origin werden
   gegen explizite Allowlisten geprüft.
@@ -46,6 +48,10 @@ Implementierungsdetails ersetzen.
 - Access- und Refresh Tokens werden serverseitig nur gehasht gespeichert.
   Client- und Sessionzustand liegt in einer atomar ersetzten Datei mit Modus
   `0600`; eine Datenbank ist für den MVP nicht erforderlich.
+- Authorization Codes sind einmalig und fünf Minuten gültig. Opaque Access
+  Tokens gelten zehn Minuten. Refresh Tokens rotieren bei jeder Verwendung;
+  ihre Familie endet spätestens nach 30 Tagen. Die Wiederverwendung eines
+  rotierten Refresh Tokens widerruft die gesamte Familie.
 - Codex CLI und Claude Desktop sind die beiden Phase-0-Interoperabilitätsclients.
   Nicht standardkonformes Clientverhalten führt nicht zu einem unsicheren
   Server-Sonderweg.
@@ -75,9 +81,11 @@ Implementierungsdetails ersetzen.
 - Gen. 1 wird ausschließlich im lokalen Netz über HTTP/WS angebunden. Anmeldung,
   Tokenanforderung und spätere Steuerkommandos verwenden Loxone-JWT und Command
   Encryption; HTTP Basic Authentication wird nicht implementiert.
-- Das Loxone-Passwort lebt nur während der Tokenanforderung im Speicher. Das
-  erneuerbare Loxone-Token wird getrennt von normaler Konfiguration
-  AES-GCM-verschlüsselt gespeichert.
+- Das Loxone-Passwort lebt nur während der Tokenanforderung im Speicher. Im
+  Phase-0-Browser-Spike bleibt auch das Loxone-Token ausschließlich in der
+  einmaligen RAM-Transaktion und wird vor Ausgabe oder Ablehnung des
+  Authorization Codes mit `killtoken` widerrufen. Erst Phase 1 führt den
+  getrennten AES-GCM-geschützten Loxone-Token-Speicher ein.
 - Der Installationsschlüssel wird durch einen Root-Hook erzeugt, ist nicht Teil
   von Konfiguration, Diagnose oder Backup und unterstützt atomare Rotation mit
   Erhalt des letzten gültigen Secret-Stands.
@@ -103,6 +111,9 @@ Implementierungsdetails ersetzen.
   Wiederherstellung ohne Schlüssel werden vorhandene Sessions und Loxone-Tokens
   verworfen und neu autorisiert, statt unentschlüsselbar weiterverwendet zu
   werden.
+- Für Phase 0 wird der Pfad der Sessiondatei ausdrücklich injiziert. Der Spike
+  beweist Dateisperre, atomaren Austausch sowie Modus `0700` für das Verzeichnis
+  und `0600` für Datei und Lock, ohne das spätere Pluginlayout vorwegzunehmen.
 
 ### Produktabgrenzung
 
@@ -141,9 +152,22 @@ syntaktisch gültig, MCP-Initialisierung über `/plugins/mcpserver/mcp` gelang,
 eine fremde Origin wurde abgewiesen und die SSE-Verbindung blieb 120 Sekunden
 offen. Die produktive System-Apache-Konfiguration wurde dabei nicht verändert.
 
+Der OAuth-Spike wurde am 2026-08-03 mit demselben Python-3.13-/arm64-Ziel erneut
+aus einem Offline-Wheelhouse installiert. Einschließlich Projekt-Wheel waren 31
+Wheels mit 9.372 KiB erforderlich; das Laufzeit-`venv` belegte 53.932 KiB. Fünf
+Starts mit aktiviertem OAuth waren nach 4.604 bis 4.772 ms gesund. Der RSS lag
+zwischen 64.364 und 64.384 KiB und blieb nach 30 Sekunden bei 64.368 KiB.
+
+Die isolierte Apache-2.4.68-Instanz bestätigte die exakten MCP-, OAuth- und
+Well-known-Pfade, Host-/Origin-Abweisung, DCR, geschützte MCP-Ressource und
+fehlende Alias- beziehungsweise Trailing-Slash-Weiterleitungen. Die
+deterministische Negativmatrix und der Browserablauf sind automatisiert; die
+beiden realen Clientnachweise bleiben vor dem Merge dieses Spikes Pflicht.
+
 ## Folgen
 
-Python und der Apache-Transport sind für die Referenzplattform bestätigt; ein
-vorsorglicher paralleler Go-Build entfällt. Loxone-, WebSocket- und OAuth-
-Aussagen bleiben bis zu den jeweiligen reproduzierbaren Spikes als noch nicht
-real bestätigt gekennzeichnet.
+Python, Apache-Transport, Gen.-1-Loxone und WebSocket sind für die
+Referenzplattform bestätigt; ein vorsorglicher paralleler Go-Build entfällt.
+OAuth ist automatisiert und hinter einer isolierten realen Apache-Instanz
+bestätigt. Die Interoperabilitätsaussage folgt erst nach den dokumentierten
+Codex-CLI- und Claude-Desktop-Tests.

--- a/docs/development/phase-0-oauth-test.md
+++ b/docs/development/phase-0-oauth-test.md
@@ -25,10 +25,15 @@ Testabschluss bestmöglich mit `killtoken` widerrufen.
 
 ## Automatisierte und Zielsystem-Nachweise
 
-Am 2026-08-03 liefen Formatprüfung, Ruff, striktes mypy und 121 Pytests lokal
+Am 2026-08-03 liefen Formatprüfung, Ruff, striktes mypy und 132 Pytests lokal
 erfolgreich. Die Tests umfassen DCR, Redirect-Grenzen, Scope, Audience, PKCE,
 CSRF, Ablauf, Code-Replay, Refresh-Rotation, Familien-Replay, Widerruf,
 pseudonymisierte Identität und das Fehlen roher Credentials im Store.
+
+Ein unabhängiger Sicherheitsreview ergänzte Regressionen für begrenzte
+Streaming-Request-Bodies, DCR-Kapazität und -Drosselung, transaktionsübergreifende
+Loginbegrenzung, parallele Einmaltransaktionen, Store-Bereinigung sowie
+Dateirechte bereits vorhandener Stores.
 
 Auf LoxBerry `4.0.0.14`, Debian 13, `aarch64`, Python `3.13.5` und Apache
 `2.4.68` wurden zusätzlich bestätigt:

--- a/docs/development/phase-0-oauth-test.md
+++ b/docs/development/phase-0-oauth-test.md
@@ -1,0 +1,89 @@
+# Phase-0-Test: OAuth und Clientinteroperabilität
+
+Dieser Nachweis prüft den unveröffentlichten OAuth-Spike über die lokale
+HTTPS-Adresse des LoxBerry. Er veröffentlicht noch keinen dauerhaften
+MCP-Toolvertrag. Zugangsdaten, Tokens, interne Adressen, Callback-Parameter und
+lokale Testpfade werden nicht in diesen Bericht übernommen.
+
+## Vertrag
+
+- MCP: `/plugins/mcpserver/mcp`
+- Issuer: `/plugins/mcpserver/oauth`
+- Endpunkte: `/authorize`, `/token`, `/register`, `/revoke`
+- Protected Resource Metadata und Authorization Server Metadata ausschließlich
+  unter den dokumentierten `/.well-known/`-Pfaden
+- Authorization Code mit PKCE S256; öffentliche Clients ohne Client Secret
+- ausschließlich Scope `loxone:read` und exakt die MCP-URL als `resource`
+- Code fünf Minuten, Access Token zehn Minuten, rotierende Refresh-Token-Familie
+  höchstens 30 Tage
+
+Die Browsertransaktion lebt einmalig für höchstens fünf Minuten im RAM, ist mit
+CSRF-Token und sicherem Cookie gebunden und erlaubt höchstens fünf
+Anmeldeversuche. Das Loxone-Passwort wird nur unmittelbar für Command Encryption
+verwendet. Das dabei erzeugte Loxone-JWT wird vor Freigabe, Ablehnung oder
+Testabschluss bestmöglich mit `killtoken` widerrufen.
+
+## Automatisierte und Zielsystem-Nachweise
+
+Am 2026-08-03 liefen Formatprüfung, Ruff, striktes mypy und 121 Pytests lokal
+erfolgreich. Die Tests umfassen DCR, Redirect-Grenzen, Scope, Audience, PKCE,
+CSRF, Ablauf, Code-Replay, Refresh-Rotation, Familien-Replay, Widerruf,
+pseudonymisierte Identität und das Fehlen roher Credentials im Store.
+
+Auf LoxBerry `4.0.0.14`, Debian 13, `aarch64`, Python `3.13.5` und Apache
+`2.4.68` wurden zusätzlich bestätigt:
+
+- 31 Wheels, 9.372 KiB Wheelhouse und erfolgreiche Offline-Installation
+- Laufzeit-`venv` 53.932 KiB
+- fünf OAuth-Kaltstarts zwischen 4.604 und 4.772 ms
+- RSS 64.364 bis 64.384 KiB; nach 30 Sekunden Idle 64.368 KiB
+- Apache-Syntax sowie exakte MCP-, OAuth- und beide Well-known-Pfade
+- DCR, geschützte MCP-Ressource, Host-/Origin-Abweisung und keine
+  Trailing-Slash- oder Prefix-Aliase
+
+Die produktive Apache-Konfiguration wurde für diese Nachweise nicht verändert.
+
+## Verbleibende reale Abnahme vor Merge
+
+| Client | Version | Callback | Login | Probe | Refresh | Revoke |
+| --- | --- | --- | --- | --- | --- | --- |
+| Codex CLI | `0.146.0` | dynamischer IPv4-Loopback mit pfadgebundener Callback-ID | erfolgreich | erfolgreich | extern blockiert | lokal abgemeldet; Client sendet keinen Widerruf |
+| Claude Desktop mit `mcp-remote@0.1.38` | `1.24012.9` | `localhost`-Loopback; Port anonymisiert | erfolgreich | erfolgreich | erfolgreich | erfolgreich |
+
+Für Node-basierte Clients wird die Windows-System-CA mit
+`NODE_USE_SYSTEM_CA=1` verwendet. Zertifikatsprüfung, Hostnamenprüfung und TLS
+werden nicht deaktiviert. Nach beiden Läufen werden OAuth-Widerruf,
+Loxone-`killtoken`, Dateirechte und ein Secret-Scan der maskierten Logs geprüft.
+
+Der reale Codex-Lauf bestätigte außerdem zwei Interoperabilitätsgrenzen: Aktuelle
+Codex-Versionen registrieren öffentliche native Clients mit dem Standardfeld
+`application_type`, das die fixierte Python-SDK-Version noch nicht modelliert. Der
+Provider validiert deshalb ausschließlich `native` oder `web` und normalisiert
+weiterhin strikt auf `token_endpoint_auth_method=none`. Browser-Formulare verwenden
+`Referrer-Policy: strict-origin`; ihre CSP erlaubt neben dem eigenen Issuer nur die
+exakt registrierte Callback-Origin. Pfad, OAuth-Code und Query werden nicht in CSP-
+oder Referrer-Header übernommen.
+
+Nach natürlichem Ablauf des zehnminütigen Access Tokens versuchte Codex CLI
+`0.146.0` zweimal eine Aktualisierung. Der Client ließ dabei den für alle
+Tokenrequests verpflichtenden RFC-8707-Parameter `resource` weg; der Server wies
+beide Requests daher erwartungsgemäß mit `invalid_request` ab. Dieser bekannte
+Clientfehler darf nicht durch eine Lockerung der Audience-Bindung auf Serverseite
+umgangen werden. `codex mcp logout` entfernte anschließend lediglich die lokalen
+OAuth-Credentials und rief den veröffentlichten Widerrufsendpunkt nicht auf. Die
+betroffene, nur für diesen Nachweis angelegte serverseitige Testablage wird beim
+Abbau der isolierten Testinstanz vollständig entfernt.
+
+Der reale Claude-Desktop-Lauf verwendete die lokale stdio-Bridge aus dem exakt
+installierten npm-Paket `mcp-remote@0.1.38` mit der Transportstrategie
+`http-only`. Nach DCR, Browseranmeldung und Einwilligung stellte die Bridge eine
+Streamable-HTTP-Verbindung her. Claude initialisierte MCP, listete die Werkzeuge
+und rief `phase0_identity_probe` erfolgreich auf; die Antwort enthielt genau die
+vier vorgesehenen pseudonymisierten Felder und den Scope `loxone:read`. Ein
+zuvor verwaister Bridge-Prozess belegte den registrierten Loopback-Port und wurde
+anhand des Client-`stderr` als `EADDRINUSE` identifiziert und gezielt beendet.
+Nach natürlichem Ablauf des Access Tokens baute Claude die Verbindung neu auf.
+Der Token-Endpunkt akzeptierte den Refresh, der Store markierte die alte
+Refresh-Generation als verbraucht und legte eine neue aktive Generation an.
+Der abschließende RFC-7009-Widerruf markierte die gesamte Testfamilie sowie alle
+zugehörigen Access- und Refresh-Tokens als widerrufen.

--- a/docs/development/plugin-concept.md
+++ b/docs/development/plugin-concept.md
@@ -709,6 +709,10 @@ Support-Matrix.
 
 - Pluginlayout, Dienst und Admin-UI-Grundgerüst
 - OAuth und Sessionwiderruf
+- OAuth-Store-Lifecycle mit harten Gesamt-/Pro-Client-Grenzen, administrativer
+  Wiederherstellung und belastbarer Größenüberwachung
+- feinere, installationsweite Quoten für erfolgreiche Autorisierungen und
+  langfristige DCR-Bereinigung
 - Struktur, Suche, Beschreibung und Zustände
 - nur `loxone:read`
 - lokale/LAN-Nutzung

--- a/docs/development/plugin-concept.md
+++ b/docs/development/plugin-concept.md
@@ -180,9 +180,14 @@ https://<loxberry>/plugins/mcpserver/mcp
 ```
 
 Dieser MCP-Pfad ist durch den realen Apache-Transport-Spike bestätigt und muss
-GET und POST unterstützen. Die separat weitergeleiteten OAuth-Discovery-Pfade
-unter `/.well-known/` werden im OAuth-Spike festgelegt. Reverse-Proxy-Header
-werden nur von einem explizit vertrauten lokalen Proxy akzeptiert.
+GET und POST unterstützen. Der OAuth-Issuer liegt unter
+`/plugins/mcpserver/oauth`; nur `/authorize`, `/token`, `/register` und
+`/revoke` werden darunter weitergeleitet. Die Metadaten liegen ausschließlich
+unter `/.well-known/oauth-protected-resource/plugins/mcpserver/mcp` und
+`/.well-known/oauth-authorization-server/plugins/mcpserver/oauth`.
+Prefix-Aliase und Trailing-Slash-Weiterleitungen sind nicht Teil des Vertrags.
+Reverse-Proxy-Header werden nur von einem explizit vertrauten lokalen Proxy
+akzeptiert.
 
 Für externe Nutzung gilt:
 
@@ -214,6 +219,9 @@ Der HTTP-Endpunkt implementiert die MCP-Autorisierung mit OAuth 2.1:
 - kurzlebige Access Tokens
 - rotierende, widerrufbare Refresh Tokens
 - sichere Registrierung unterstützter öffentlicher Clients
+- ausschließlich `token_endpoint_auth_method=none` und Scope `loxone:read`
+- einmalige Codes mit fünf Minuten, Access Tokens mit zehn Minuten und
+  rotierende Refresh-Token-Familien mit höchstens 30 Tagen Laufzeit
 
 MCP-Tokens sind ausschließlich für das Plugin gültig. Sie werden nie an Loxone
 oder andere Dienste weitergereicht.
@@ -473,6 +481,9 @@ und sind kein Ersatz für die Admin-UI:
 | `MCPSERVER_PORT` | `8765` | ausschließlich exakt dieser interne Port; Dienst und Apache teilen diesen Vertrag |
 | `MCPSERVER_ALLOWED_HOSTS` | `127.0.0.1:<Port>,localhost:<Port>` | kommaseparierte exakte Host-/Port-Werte oder ein Host mit `:*`; mindestens ein Eintrag |
 | `MCPSERVER_ALLOWED_ORIGINS` | leer | kommaseparierte kanonische `http`-/`https`-Origins ohne Pfad, Zugangsdaten, Query oder Fragment; Standardports und Unicode-Hostnamen werden nicht als alternative Schreibweise akzeptiert |
+| `MCPSERVER_PUBLIC_ORIGIN` | leer | kanonische lokale HTTPS-Origin; aktiviert zusammen mit den beiden folgenden Werten den Phase-0-OAuth-Spike |
+| `MCPSERVER_AUTH_STORE` | leer | absoluter injizierter Pfad einer JSON-Datei; Phase 1 setzt dafür `LBPDATADIR/auth/sessions.json` ein |
+| `MCPSERVER_LOXONE_ENDPOINT` | leer | kanonischer privater Gen.-1-HTTP-Origin ohne Zugangsdaten oder Pfad |
 
 Für einen später erzeugten lokalen Apache-Vertrag lautet ein schematisches
 Beispiel:
@@ -481,7 +492,10 @@ Beispiel:
 MCPSERVER_HOST=127.0.0.1
 MCPSERVER_PORT=8765
 MCPSERVER_ALLOWED_HOSTS=127.0.0.1:8765,loxberry.local
-MCPSERVER_ALLOWED_ORIGINS=https://assistant.example
+MCPSERVER_ALLOWED_ORIGINS=https://loxberry.local
+MCPSERVER_PUBLIC_ORIGIN=https://loxberry.local
+MCPSERVER_AUTH_STORE=/absolute/private/test/path/sessions.json
+MCPSERVER_LOXONE_ENDPOINT=http://PRIVATE-IP
 ```
 
 Origins mit internationalisierten Domains werden in der vom Browser gesendeten
@@ -499,6 +513,8 @@ erfordert eine synchronisierte Migration beider Komponenten.
 - atomare Schreibvorgänge
 - Signing-/Encryption-Key bei Installation kryptografisch erzeugt
 - Refresh Tokens serverseitig nur gehasht, soweit das Verfahren dies erlaubt
+- Codes, Access Tokens und Refresh Tokens ausschließlich als SHA-256-Digests
+- Rotation mit familienweitem Widerruf bei Refresh-Token-Replay
 - keine Secrets in Backups/Diagnosen ohne ausdrückliche, dokumentierte Regel
 - Widerruf einzelner Clients und aller Sessions über die Admin-UI
 
@@ -747,8 +763,8 @@ Support-Matrix.
 | 1 | Plugin-ID und Ordner | festgelegt: `NAME=mcpserver`, `FOLDER=mcpserver`, `TITLE=LoxBerry MCP Server` |
 | 2 | erste CPU-Architektur | festgelegt: LoxBerry 4 auf Debian 13, `arm64` |
 | 3 | Runtime | festgelegt: Python 3.13 und MCP-SDK 1.28.1; Wheel-, Start- und RAM-Gates erfolgreich |
-| 4 | öffentlicher Pluginpfad/Apache | `/plugins/mcpserver/mcp` mit Apache 2.4.68 real bestätigt; Root-Discovery folgt mit dem OAuth-Spike |
-| 5 | MCP-OAuth-Clientregistrierung und Sessionpersistenz | festgelegt: öffentliche Registrierung, PKCE S256, opaque Tokens und atomare dateibasierte Persistenz; Clientprüfung ausstehend |
+| 4 | öffentlicher Pluginpfad/Apache | exakte MCP-, OAuth- und Well-known-Pfade mit Apache 2.4.68 real bestätigt |
+| 5 | MCP-OAuth-Clientregistrierung und Sessionpersistenz | implementiert und automatisiert bestätigt: öffentliche Registrierung, PKCE S256, audience-gebundene opaque Tokens, Replay-Widerruf und atomare dateibasierte Persistenz; beide Clientprüfungen vor Merge ausstehend |
 | 6 | Miniserver-Firmware | Gen. 1 mindestens `17.1.7.27`; Gen.-2-Stände werden durch die öffentliche Beta bestätigt |
 | 7 | erste unterstützte Control-Typen | festgelegt für Phase 2: `Switch` mit explizitem `on` und `off` |
 | 8 | Zeitpunkt und Umfang von `loxberry:read` | festgelegt: erst Phase 3 mit eigener lokaler Freigabe |

--- a/src/mcpserver/auth/__init__.py
+++ b/src/mcpserver/auth/__init__.py
@@ -1,0 +1,1 @@
+"""Phase-0 OAuth components."""

--- a/src/mcpserver/auth/provider.py
+++ b/src/mcpserver/auth/provider.py
@@ -1,0 +1,447 @@
+"""OAuth 2.1 provider with opaque, hashed, family-bound credentials."""
+
+from __future__ import annotations
+
+import secrets
+import time
+from collections.abc import Callable
+from typing import Any, Final
+from urllib.parse import parse_qs, urlsplit
+
+from mcp.server.auth.provider import (
+    AccessToken,
+    AuthorizationCode,
+    AuthorizationParams,
+    OAuthAuthorizationServerProvider,
+    RefreshToken,
+    TokenError,
+)
+from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+from pydantic import AnyUrl
+
+from mcpserver.auth.store import AtomicJsonAuthStore, token_digest
+
+SCOPE: Final = "loxone:read"
+AUTHORIZATION_CODE_TTL: Final = 5 * 60
+ACCESS_TOKEN_TTL: Final = 10 * 60
+REFRESH_FAMILY_TTL: Final = 30 * 24 * 60 * 60
+_MAX_REGISTERED_CLIENTS: Final = 256
+
+
+class StoredAuthorizationCode(AuthorizationCode):
+    family_id: str
+    identity_id: str
+    miniserver_id: str
+
+
+class StoredRefreshToken(RefreshToken):
+    family_id: str
+    resource: str
+    identity_id: str
+    miniserver_id: str
+
+
+class StoredAccessToken(AccessToken):
+    family_id: str
+    identity_id: str
+    miniserver_id: str
+
+
+def _opaque_token() -> str:
+    return secrets.token_urlsafe(32)
+
+
+def redirect_uri_is_allowed(value: str) -> bool:
+    """Allow HTTPS callbacks and registered HTTP loopback callbacks only."""
+    parsed = urlsplit(value)
+    if (
+        parsed.hostname is None
+        or parsed.fragment
+        or parsed.username is not None
+        or parsed.password is not None
+        or "\\" in parsed.netloc
+        or set(parse_qs(parsed.query, keep_blank_values=True)) & {"code", "error", "iss", "state"}
+    ):
+        return False
+    if parsed.scheme == "https":
+        return True
+    if parsed.scheme != "http":
+        return False
+    try:
+        host = parsed.hostname.lower()
+        return host == "localhost" or host == "127.0.0.1" or host == "::1"
+    except ValueError:
+        return False
+
+
+class Phase0OAuthProvider(
+    OAuthAuthorizationServerProvider[
+        StoredAuthorizationCode,
+        StoredRefreshToken,
+        StoredAccessToken,
+    ]
+):
+    """MCP SDK provider with exact audience and refresh-family semantics."""
+
+    def __init__(
+        self,
+        store: AtomicJsonAuthStore,
+        *,
+        issuer: str,
+        resource: str,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        self.store = store
+        self.issuer = issuer
+        self.resource = resource
+        self._clock = clock
+
+    def now(self) -> int:
+        return int(self._clock())
+
+    async def get_client(self, client_id: str) -> OAuthClientInformationFull | None:
+        record = self.store.snapshot()["clients"].get(client_id)
+        return OAuthClientInformationFull.model_validate(record) if record is not None else None
+
+    async def register_client(self, client_info: OAuthClientInformationFull) -> None:
+        if (
+            not client_info.client_id
+            or client_info.client_secret is not None
+            or client_info.token_endpoint_auth_method != "none"
+            or client_info.redirect_uris is None
+            or not client_info.redirect_uris
+            or any(not redirect_uri_is_allowed(str(uri)) for uri in client_info.redirect_uris)
+            or any(
+                grant not in {"authorization_code", "refresh_token"}
+                for grant in client_info.grant_types
+            )
+            or client_info.response_types != ["code"]
+            or client_info.scope != SCOPE
+        ):
+            from mcp.server.auth.provider import RegistrationError
+
+            raise RegistrationError("invalid_client_metadata", "Unsupported public client metadata")
+
+        record = client_info.model_dump(mode="json", exclude_none=True)
+
+        def insert(document: dict[str, Any]) -> None:
+            if client_info.client_id in document["clients"]:
+                from mcp.server.auth.provider import RegistrationError
+
+                raise RegistrationError(
+                    "invalid_client_metadata", "Client identifier already exists"
+                )
+            if len(document["clients"]) >= _MAX_REGISTERED_CLIENTS:
+                raise RegistrationError(
+                    "invalid_client_metadata", "Client registration capacity reached"
+                )
+            document["clients"][client_info.client_id] = record
+
+        self.store.mutate(insert)
+
+    async def authorize(
+        self, client: OAuthClientInformationFull, params: AuthorizationParams
+    ) -> str:
+        raise NotImplementedError("The browser authorization route owns this flow")
+
+    def issue_authorization_code(
+        self,
+        *,
+        client_id: str,
+        redirect_uri: str,
+        code_challenge: str,
+        resource: str,
+        identity_id: str,
+        miniserver_id: str,
+    ) -> str:
+        if resource != self.resource:
+            raise TokenError("invalid_grant", "Resource mismatch")
+        raw_code = _opaque_token()
+        digest = token_digest(raw_code)
+        now = self.now()
+        family_id = secrets.token_hex(16)
+        record = {
+            "client_id": client_id,
+            "redirect_uri": redirect_uri,
+            "code_challenge": code_challenge,
+            "resource": resource,
+            "scopes": [SCOPE],
+            "expires_at": now + AUTHORIZATION_CODE_TTL,
+            "family_id": family_id,
+            "identity_id": identity_id,
+            "miniserver_id": miniserver_id,
+            "status": "active",
+        }
+
+        def insert(document: dict[str, Any]) -> None:
+            document["codes"][digest] = record
+            document["families"][family_id] = {
+                "client_id": client_id,
+                "identity_id": identity_id,
+                "miniserver_id": miniserver_id,
+                "scope": SCOPE,
+                "resource": resource,
+                "expires_at": now + REFRESH_FAMILY_TTL,
+                "revoked": False,
+            }
+
+        self.store.mutate(insert)
+        return raw_code
+
+    @staticmethod
+    def _code_model(raw_code: str, record: dict[str, Any]) -> StoredAuthorizationCode:
+        return StoredAuthorizationCode(
+            code=raw_code,
+            scopes=record["scopes"],
+            expires_at=record["expires_at"],
+            client_id=record["client_id"],
+            code_challenge=record["code_challenge"],
+            redirect_uri=AnyUrl(record["redirect_uri"]),
+            redirect_uri_provided_explicitly=True,
+            resource=record["resource"],
+            family_id=record["family_id"],
+            identity_id=record["identity_id"],
+            miniserver_id=record["miniserver_id"],
+            subject=record["identity_id"],
+        )
+
+    async def load_authorization_code(
+        self, client: OAuthClientInformationFull, authorization_code: str
+    ) -> StoredAuthorizationCode | None:
+        record = self.store.snapshot()["codes"].get(token_digest(authorization_code))
+        if (
+            record is None
+            or record.get("status") != "active"
+            or record.get("client_id") != client.client_id
+            or record.get("expires_at", 0) <= self.now()
+        ):
+            return None
+        return self._code_model(authorization_code, record)
+
+    def _new_token_records(
+        self,
+        *,
+        family_id: str,
+        client_id: str,
+        identity_id: str,
+        miniserver_id: str,
+        resource: str,
+        family_expires_at: int,
+    ) -> tuple[str, str, dict[str, Any], dict[str, Any]]:
+        now = self.now()
+        raw_access = _opaque_token()
+        raw_refresh = _opaque_token()
+        access_record = {
+            "client_id": client_id,
+            "scopes": [SCOPE],
+            "expires_at": min(now + ACCESS_TOKEN_TTL, family_expires_at),
+            "resource": resource,
+            "family_id": family_id,
+            "identity_id": identity_id,
+            "miniserver_id": miniserver_id,
+            "status": "active",
+        }
+        refresh_record = {
+            "client_id": client_id,
+            "scopes": [SCOPE],
+            "expires_at": family_expires_at,
+            "resource": resource,
+            "family_id": family_id,
+            "identity_id": identity_id,
+            "miniserver_id": miniserver_id,
+            "status": "active",
+        }
+        return raw_access, raw_refresh, access_record, refresh_record
+
+    async def exchange_authorization_code(
+        self,
+        client: OAuthClientInformationFull,
+        authorization_code: StoredAuthorizationCode,
+    ) -> OAuthToken:
+        raw_access = ""
+        raw_refresh = ""
+        access_expires_at = 0
+
+        def exchange(document: dict[str, Any]) -> None:
+            nonlocal access_expires_at, raw_access, raw_refresh
+            digest = token_digest(authorization_code.code)
+            record = document["codes"].get(digest)
+            if (
+                record is None
+                or record.get("status") != "active"
+                or record.get("client_id") != client.client_id
+                or record.get("expires_at", 0) <= self.now()
+            ):
+                raise TokenError("invalid_grant", "Authorization code is invalid")
+            family = document["families"].get(record["family_id"])
+            if family is None or family["revoked"] or family["expires_at"] <= self.now():
+                raise TokenError("invalid_grant", "Authorization session is invalid")
+            record["status"] = "consumed"
+            raw_access, raw_refresh, access, refresh = self._new_token_records(
+                family_id=record["family_id"],
+                client_id=record["client_id"],
+                identity_id=record["identity_id"],
+                miniserver_id=record["miniserver_id"],
+                resource=record["resource"],
+                family_expires_at=family["expires_at"],
+            )
+            document["access_tokens"][token_digest(raw_access)] = access
+            document["refresh_tokens"][token_digest(raw_refresh)] = refresh
+            access_expires_at = access["expires_at"]
+
+        self.store.mutate(exchange)
+        return OAuthToken(
+            access_token=raw_access,
+            token_type="Bearer",
+            expires_in=max(0, access_expires_at - self.now()),
+            scope=SCOPE,
+            refresh_token=raw_refresh,
+        )
+
+    @staticmethod
+    def _revoke_family(document: dict[str, Any], family_id: str) -> None:
+        family = document["families"].get(family_id)
+        if family is not None:
+            family["revoked"] = True
+        for collection in ("access_tokens", "refresh_tokens"):
+            for record in document[collection].values():
+                if record.get("family_id") == family_id:
+                    record["status"] = "revoked"
+
+    @staticmethod
+    def _refresh_model(raw_token: str, record: dict[str, Any]) -> StoredRefreshToken:
+        return StoredRefreshToken(
+            token=raw_token,
+            client_id=record["client_id"],
+            scopes=record["scopes"],
+            expires_at=record["expires_at"],
+            subject=record["identity_id"],
+            family_id=record["family_id"],
+            resource=record["resource"],
+            identity_id=record["identity_id"],
+            miniserver_id=record["miniserver_id"],
+        )
+
+    async def load_refresh_token(
+        self, client: OAuthClientInformationFull, refresh_token: str
+    ) -> StoredRefreshToken | None:
+        result: StoredRefreshToken | None = None
+
+        def load(document: dict[str, Any]) -> None:
+            nonlocal result
+            record = document["refresh_tokens"].get(token_digest(refresh_token))
+            if record is None or record.get("client_id") != client.client_id:
+                return
+            family = document["families"].get(record["family_id"])
+            if record.get("status") == "consumed":
+                self._revoke_family(document, record["family_id"])
+                return
+            if (
+                record.get("status") != "active"
+                or family is None
+                or family["revoked"]
+                or record["expires_at"] <= self.now()
+                or family["expires_at"] <= self.now()
+            ):
+                return
+            result = self._refresh_model(refresh_token, record)
+
+        self.store.mutate(load)
+        return result
+
+    async def exchange_refresh_token(
+        self,
+        client: OAuthClientInformationFull,
+        refresh_token: StoredRefreshToken,
+        scopes: list[str],
+    ) -> OAuthToken:
+        if scopes != [SCOPE]:
+            raise TokenError("invalid_scope", "Only loxone:read is supported")
+        raw_access = ""
+        raw_refresh = ""
+        access_expires_at = 0
+        failure: str | None = None
+
+        def exchange(document: dict[str, Any]) -> None:
+            nonlocal access_expires_at, failure, raw_access, raw_refresh
+            record = document["refresh_tokens"].get(token_digest(refresh_token.token))
+            if record is None or record.get("client_id") != client.client_id:
+                failure = "Refresh token is invalid"
+                return
+            family = document["families"].get(record["family_id"])
+            if record.get("status") != "active":
+                self._revoke_family(document, record["family_id"])
+                failure = "Refresh token is invalid"
+                return
+            if family is None or family["revoked"] or family["expires_at"] <= self.now():
+                failure = "Refresh session is invalid"
+                return
+            record["status"] = "consumed"
+            raw_access, raw_refresh, access, refresh = self._new_token_records(
+                family_id=record["family_id"],
+                client_id=record["client_id"],
+                identity_id=record["identity_id"],
+                miniserver_id=record["miniserver_id"],
+                resource=record["resource"],
+                family_expires_at=family["expires_at"],
+            )
+            document["access_tokens"][token_digest(raw_access)] = access
+            document["refresh_tokens"][token_digest(raw_refresh)] = refresh
+            access_expires_at = access["expires_at"]
+
+        self.store.mutate(exchange)
+        if failure is not None:
+            raise TokenError("invalid_grant", failure)
+        return OAuthToken(
+            access_token=raw_access,
+            token_type="Bearer",
+            expires_in=max(0, access_expires_at - self.now()),
+            scope=SCOPE,
+            refresh_token=raw_refresh,
+        )
+
+    async def load_access_token(self, token: str) -> StoredAccessToken | None:
+        document = self.store.snapshot()
+        record = document["access_tokens"].get(token_digest(token))
+        if record is None or record.get("status") != "active" or record["expires_at"] <= self.now():
+            return None
+        family = document["families"].get(record["family_id"])
+        if (
+            family is None
+            or family["revoked"]
+            or family["expires_at"] <= self.now()
+            or record["resource"] != self.resource
+        ):
+            return None
+        return StoredAccessToken(
+            token=token,
+            client_id=record["client_id"],
+            scopes=record["scopes"],
+            expires_at=record["expires_at"],
+            resource=record["resource"],
+            subject=record["identity_id"],
+            claims={
+                "iss": self.issuer,
+                "identity": record["identity_id"],
+                "miniserver": record["miniserver_id"],
+                "audience": record["resource"],
+            },
+            family_id=record["family_id"],
+            identity_id=record["identity_id"],
+            miniserver_id=record["miniserver_id"],
+        )
+
+    async def revoke_token(self, token: StoredAccessToken | StoredRefreshToken) -> None:
+        self.store.mutate(lambda document: self._revoke_family(document, token.family_id))
+
+    async def revoke_raw_token(self, raw_token: str, client_id: str) -> None:
+        digest = token_digest(raw_token)
+
+        def revoke(document: dict[str, Any]) -> None:
+            for collection in ("access_tokens", "refresh_tokens"):
+                record = document[collection].get(digest)
+                if record is not None and record.get("client_id") == client_id:
+                    self._revoke_family(document, record["family_id"])
+                    return
+
+        self.store.mutate(revoke)

--- a/src/mcpserver/auth/provider.py
+++ b/src/mcpserver/auth/provider.py
@@ -14,6 +14,7 @@ from mcp.server.auth.provider import (
     AuthorizationParams,
     OAuthAuthorizationServerProvider,
     RefreshToken,
+    RegistrationError,
     TokenError,
 )
 from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
@@ -26,6 +27,7 @@ AUTHORIZATION_CODE_TTL: Final = 5 * 60
 ACCESS_TOKEN_TTL: Final = 10 * 60
 REFRESH_FAMILY_TTL: Final = 30 * 24 * 60 * 60
 _MAX_REGISTERED_CLIENTS: Final = 256
+_UNUSED_CLIENT_TTL: Final = 24 * 60 * 60
 
 
 class StoredAuthorizationCode(AuthorizationCode):
@@ -100,7 +102,14 @@ class Phase0OAuthProvider(
         return int(self._clock())
 
     async def get_client(self, client_id: str) -> OAuthClientInformationFull | None:
-        record = self.store.snapshot()["clients"].get(client_id)
+        record: dict[str, Any] | None = None
+
+        def load(document: dict[str, Any]) -> None:
+            nonlocal record
+            self._garbage_collect(document)
+            record = document["clients"].get(client_id)
+
+        self.store.mutate(load)
         return OAuthClientInformationFull.model_validate(record) if record is not None else None
 
     async def register_client(self, client_info: OAuthClientInformationFull) -> None:
@@ -111,23 +120,18 @@ class Phase0OAuthProvider(
             or client_info.redirect_uris is None
             or not client_info.redirect_uris
             or any(not redirect_uri_is_allowed(str(uri)) for uri in client_info.redirect_uris)
-            or any(
-                grant not in {"authorization_code", "refresh_token"}
-                for grant in client_info.grant_types
-            )
+            or set(client_info.grant_types) != {"authorization_code", "refresh_token"}
+            or len(client_info.grant_types) != 2
             or client_info.response_types != ["code"]
             or client_info.scope != SCOPE
         ):
-            from mcp.server.auth.provider import RegistrationError
-
             raise RegistrationError("invalid_client_metadata", "Unsupported public client metadata")
 
         record = client_info.model_dump(mode="json", exclude_none=True)
 
         def insert(document: dict[str, Any]) -> None:
+            self._garbage_collect(document)
             if client_info.client_id in document["clients"]:
-                from mcp.server.auth.provider import RegistrationError
-
                 raise RegistrationError(
                     "invalid_client_metadata", "Client identifier already exists"
                 )
@@ -138,6 +142,43 @@ class Phase0OAuthProvider(
             document["clients"][client_info.client_id] = record
 
         self.store.mutate(insert)
+
+    def _garbage_collect(self, document: dict[str, Any]) -> None:
+        now = self.now()
+        expired_families = {
+            family_id
+            for family_id, record in document["families"].items()
+            if record.get("expires_at", 0) <= now
+        }
+        for family_id in expired_families:
+            document["families"].pop(family_id, None)
+        document["codes"] = {
+            digest: record
+            for digest, record in document["codes"].items()
+            if record.get("expires_at", 0) > now and record.get("family_id") not in expired_families
+        }
+        document["access_tokens"] = {
+            digest: record
+            for digest, record in document["access_tokens"].items()
+            if record.get("expires_at", 0) > now and record.get("family_id") not in expired_families
+        }
+        document["refresh_tokens"] = {
+            digest: record
+            for digest, record in document["refresh_tokens"].items()
+            if record.get("family_id") not in expired_families
+        }
+        referenced_clients = {
+            str(record.get("client_id"))
+            for collection in ("codes", "families", "access_tokens", "refresh_tokens")
+            for record in document[collection].values()
+            if record.get("client_id")
+        }
+        document["clients"] = {
+            client_id: record
+            for client_id, record in document["clients"].items()
+            if client_id in referenced_clients
+            or int(record.get("client_id_issued_at", now)) + _UNUSED_CLIENT_TTL > now
+        }
 
     async def authorize(
         self, client: OAuthClientInformationFull, params: AuthorizationParams
@@ -174,6 +215,8 @@ class Phase0OAuthProvider(
         }
 
         def insert(document: dict[str, Any]) -> None:
+            if client_id not in document["clients"]:
+                raise TokenError("invalid_client", "Client registration is unavailable")
             document["codes"][digest] = record
             document["families"][family_id] = {
                 "client_id": client_id,
@@ -264,6 +307,7 @@ class Phase0OAuthProvider(
 
         def exchange(document: dict[str, Any]) -> None:
             nonlocal access_expires_at, raw_access, raw_refresh
+            self._garbage_collect(document)
             digest = token_digest(authorization_code.code)
             record = document["codes"].get(digest)
             if (
@@ -329,6 +373,7 @@ class Phase0OAuthProvider(
 
         def load(document: dict[str, Any]) -> None:
             nonlocal result
+            self._garbage_collect(document)
             record = document["refresh_tokens"].get(token_digest(refresh_token))
             if record is None or record.get("client_id") != client.client_id:
                 return
@@ -364,6 +409,7 @@ class Phase0OAuthProvider(
 
         def exchange(document: dict[str, Any]) -> None:
             nonlocal access_expires_at, failure, raw_access, raw_refresh
+            self._garbage_collect(document)
             record = document["refresh_tokens"].get(token_digest(refresh_token.token))
             if record is None or record.get("client_id") != client.client_id:
                 failure = "Refresh token is invalid"
@@ -401,7 +447,14 @@ class Phase0OAuthProvider(
         )
 
     async def load_access_token(self, token: str) -> StoredAccessToken | None:
-        document = self.store.snapshot()
+        document: dict[str, Any] = {}
+
+        def load(current: dict[str, Any]) -> None:
+            nonlocal document
+            self._garbage_collect(current)
+            document = current
+
+        self.store.mutate(load)
         record = document["access_tokens"].get(token_digest(token))
         if record is None or record.get("status") != "active" or record["expires_at"] <= self.now():
             return None

--- a/src/mcpserver/auth/store.py
+++ b/src/mcpserver/auth/store.py
@@ -1,0 +1,184 @@
+"""Small atomic JSON store for opaque OAuth credentials."""
+
+from __future__ import annotations
+
+import base64
+import copy
+import hashlib
+import hmac
+import json
+import os
+import secrets
+import sys
+import threading
+from collections.abc import Callable
+from contextlib import contextmanager, suppress
+from pathlib import Path
+from typing import Any, BinaryIO, Final, TypeVar
+
+_SCHEMA_VERSION: Final = 1
+_COLLECTIONS: Final = ("clients", "codes", "access_tokens", "refresh_tokens", "families")
+T = TypeVar("T")
+
+
+class AuthStoreError(RuntimeError):
+    """The protected auth store cannot be used safely."""
+
+
+def token_digest(value: str) -> str:
+    """Return the only token representation that may be persisted."""
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _lock_file(handle: BinaryIO) -> None:
+    if sys.platform == "win32":  # pragma: win32 cover
+        import msvcrt
+
+        handle.seek(0)
+        if handle.read(1) == b"":
+            handle.seek(0)
+            handle.write(b"0")
+            handle.flush()
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+    else:  # pragma: posix cover
+        import fcntl
+
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+
+
+def _unlock_file(handle: BinaryIO) -> None:
+    if sys.platform == "win32":  # pragma: win32 cover
+        import msvcrt
+
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+    else:  # pragma: posix cover
+        import fcntl
+
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+class AtomicJsonAuthStore:
+    """Serialize auth updates under a process and platform file lock."""
+
+    def __init__(self, path: Path) -> None:
+        if not path.is_absolute():
+            raise ValueError("Auth store path must be absolute")
+        self.path = path
+        self.lock_path = path.with_name(f".{path.name}.lock")
+        self._thread_lock = threading.RLock()
+        self._prepare_directory()
+        with self._locked():
+            if not self.path.exists():
+                self._write_unlocked(self._new_document())
+            else:
+                self._read_unlocked()
+
+    def _prepare_directory(self) -> None:
+        try:
+            self.path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+            os.chmod(self.path.parent, 0o700)
+        except OSError as exc:
+            raise AuthStoreError("Auth store directory cannot be secured") from exc
+
+    @staticmethod
+    def _new_document() -> dict[str, Any]:
+        return {
+            "schema_version": _SCHEMA_VERSION,
+            "subject_key": base64.urlsafe_b64encode(secrets.token_bytes(32)).decode("ascii"),
+            **{name: {} for name in _COLLECTIONS},
+        }
+
+    @contextmanager
+    def _locked(self):  # type: ignore[no-untyped-def]
+        with self._thread_lock:
+            try:
+                with self.lock_path.open("a+b") as handle:
+                    os.chmod(self.lock_path, 0o600)
+                    _lock_file(handle)
+                    try:
+                        yield
+                    finally:
+                        _unlock_file(handle)
+            except AuthStoreError:
+                raise
+            except OSError as exc:
+                raise AuthStoreError("Auth store lock failed") from exc
+
+    @staticmethod
+    def _validate(document: object) -> dict[str, Any]:
+        if not isinstance(document, dict) or document.get("schema_version") != _SCHEMA_VERSION:
+            raise AuthStoreError("Auth store schema is invalid")
+        expected = {"schema_version", "subject_key", *_COLLECTIONS}
+        if set(document) != expected:
+            raise AuthStoreError("Auth store schema is invalid")
+        subject_key = document.get("subject_key")
+        if not isinstance(subject_key, str):
+            raise AuthStoreError("Auth store schema is invalid")
+        try:
+            decoded = base64.urlsafe_b64decode(subject_key.encode("ascii"))
+        except (ValueError, UnicodeEncodeError) as exc:
+            raise AuthStoreError("Auth store schema is invalid") from exc
+        if len(decoded) != 32 or any(not isinstance(document[name], dict) for name in _COLLECTIONS):
+            raise AuthStoreError("Auth store schema is invalid")
+        return document
+
+    def _read_unlocked(self) -> dict[str, Any]:
+        try:
+            raw = self.path.read_text(encoding="utf-8")
+            return self._validate(json.loads(raw))
+        except AuthStoreError:
+            raise
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            raise AuthStoreError("Auth store is unreadable or corrupt") from exc
+
+    def _write_unlocked(self, document: dict[str, Any]) -> None:
+        self._validate(document)
+        temporary = self.path.with_name(f".{self.path.name}.{secrets.token_hex(8)}.tmp")
+        try:
+            descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as handle:
+                json.dump(
+                    document,
+                    handle,
+                    ensure_ascii=True,
+                    separators=(",", ":"),
+                    sort_keys=True,
+                )
+                handle.write("\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.chmod(temporary, 0o600)
+            os.replace(temporary, self.path)
+            os.chmod(self.path, 0o600)
+            if hasattr(os, "O_DIRECTORY"):
+                directory = os.open(self.path.parent, os.O_RDONLY | os.O_DIRECTORY)
+                try:
+                    os.fsync(directory)
+                finally:
+                    os.close(directory)
+        except OSError as exc:
+            with suppress(OSError):
+                temporary.unlink(missing_ok=True)
+            raise AuthStoreError("Auth store update failed") from exc
+
+    def snapshot(self) -> dict[str, Any]:
+        """Return an isolated validated snapshot."""
+        with self._locked():
+            return copy.deepcopy(self._read_unlocked())
+
+    def mutate(self, operation: Callable[[dict[str, Any]], T]) -> T:
+        """Apply and durably commit one operation while holding both locks."""
+        with self._locked():
+            document = self._read_unlocked()
+            result = operation(document)
+            self._write_unlocked(document)
+            return result
+
+    def pseudonym(self, *parts: str) -> str:
+        """Create a stable store-local identifier without retaining source values."""
+        document = self.snapshot()
+        key = base64.urlsafe_b64decode(document["subject_key"].encode("ascii"))
+        canonical = "\0".join(parts).encode("utf-8")
+        return hmac.new(key, canonical, hashlib.sha256).hexdigest()

--- a/src/mcpserver/auth/store.py
+++ b/src/mcpserver/auth/store.py
@@ -9,16 +9,21 @@ import hmac
 import json
 import os
 import secrets
+import stat
 import sys
 import threading
 from collections.abc import Callable
 from contextlib import contextmanager, suppress
 from pathlib import Path
-from typing import Any, BinaryIO, Final, TypeVar
+from typing import Any, BinaryIO, Final, Protocol, TypeVar, cast
 
 _SCHEMA_VERSION: Final = 1
 _COLLECTIONS: Final = ("clients", "codes", "access_tokens", "refresh_tokens", "families")
 T = TypeVar("T")
+
+
+class _UidProvider(Protocol):
+    def geteuid(self) -> int: ...
 
 
 class AuthStoreError(RuntimeError):
@@ -73,6 +78,7 @@ class AtomicJsonAuthStore:
             if not self.path.exists():
                 self._write_unlocked(self._new_document())
             else:
+                self._secure_existing_file()
                 self._read_unlocked()
 
     def _prepare_directory(self) -> None:
@@ -89,6 +95,23 @@ class AtomicJsonAuthStore:
             "subject_key": base64.urlsafe_b64encode(secrets.token_bytes(32)).decode("ascii"),
             **{name: {} for name in _COLLECTIONS},
         }
+
+    def _secure_existing_file(self) -> None:
+        try:
+            metadata = self.path.lstat()
+            if not stat.S_ISREG(metadata.st_mode) or self.path.is_symlink():
+                raise AuthStoreError("Auth store path is not a regular file")
+            if os.name != "nt":
+                import posix
+
+                current_uid = cast(_UidProvider, posix).geteuid()
+                if metadata.st_uid != current_uid:
+                    raise AuthStoreError("Auth store owner is invalid")
+            os.chmod(self.path, 0o600)
+        except AuthStoreError:
+            raise
+        except OSError as exc:
+            raise AuthStoreError("Auth store file cannot be secured") from exc
 
     @contextmanager
     def _locked(self):  # type: ignore[no-untyped-def]
@@ -170,11 +193,20 @@ class AtomicJsonAuthStore:
 
     def mutate(self, operation: Callable[[dict[str, Any]], T]) -> T:
         """Apply and durably commit one operation while holding both locks."""
+        result: T | None = None
+        failure: BaseException | None = None
         with self._locked():
-            document = self._read_unlocked()
-            result = operation(document)
-            self._write_unlocked(document)
-            return result
+            try:
+                document = self._read_unlocked()
+                original = copy.deepcopy(document)
+                result = operation(document)
+                if document != original:
+                    self._write_unlocked(document)
+            except BaseException as exc:
+                failure = exc
+        if failure is not None:
+            raise failure
+        return result  # type: ignore[return-value]
 
     def pseudonym(self, *parts: str) -> str:
         """Create a stable store-local identifier without retaining source values."""

--- a/src/mcpserver/auth/web.py
+++ b/src/mcpserver/auth/web.py
@@ -14,9 +14,10 @@ import json
 import re
 import secrets
 import time
+from collections import deque
 from collections.abc import Mapping
 from contextlib import suppress
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Final
 from urllib.parse import urlencode, urlsplit
 from uuid import NAMESPACE_URL, uuid5
@@ -40,6 +41,12 @@ _MAX_JSON_BYTES: Final = 32 * 1024
 _TRANSACTION_TTL: Final = 5 * 60
 _MAX_LOGIN_ATTEMPTS: Final = 5
 _MAX_LOGIN_TRANSACTIONS: Final = 16
+_LOGIN_RATE_WINDOW: Final = 5 * 60
+_MAX_CLIENT_LOGIN_FAILURES: Final = 10
+_MAX_GLOBAL_LOGIN_FAILURES: Final = 20
+_MAX_RATE_KEYS: Final = 512
+_REGISTRATION_RATE_WINDOW: Final = 5 * 60
+_MAX_REGISTRATIONS_PER_WINDOW: Final = 16
 _COOKIE_NAME: Final = "phase0_oauth_tx"
 _PKCE_CHALLENGE = re.compile(r"^[A-Za-z0-9_-]{43}$")
 _PKCE_VERIFIER = re.compile(r"^[A-Za-z0-9._~-]{43,128}$")
@@ -62,6 +69,8 @@ class LoginTransaction:
     identity_id: str | None = None
     miniserver_id: str | None = None
     miniserver_name: str | None = None
+    phase: str = "login"
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock, repr=False)
 
 
 def _callback_csp_source(uri: str) -> str:
@@ -125,16 +134,29 @@ label{{display:block;margin:.9rem 0 .25rem}}input{{box-sizing:border-box;width:1
     )
 
 
+async def _limited_body(request: Request, limit: int) -> bytes | None:
+    length_header = request.headers.get("content-length")
+    if length_header is not None:
+        try:
+            length = int(length_header)
+        except ValueError:
+            return None
+        if length < 0 or length > limit:
+            return None
+    body = bytearray()
+    async for chunk in request.stream():
+        if len(body) + len(chunk) > limit:
+            return None
+        body.extend(chunk)
+    return bytes(body)
+
+
 async def _form(request: Request, *, allowed: set[str]) -> dict[str, str] | None:
     content_type = request.headers.get("content-type", "").split(";", 1)[0].strip().lower()
-    try:
-        length = int(request.headers.get("content-length", "0"))
-    except ValueError:
+    if content_type != "application/x-www-form-urlencoded":
         return None
-    if content_type != "application/x-www-form-urlencoded" or length > _MAX_FORM_BYTES:
-        return None
-    body = await request.body()
-    if len(body) > _MAX_FORM_BYTES:
+    body = await _limited_body(request, _MAX_FORM_BYTES)
+    if body is None:
         return None
     from urllib.parse import parse_qsl
 
@@ -165,6 +187,9 @@ class Phase0OAuthWeb:
         self.transactions: dict[str, LoginTransaction] = {}
         self._client_uuid = uuid5(NAMESPACE_URL, issuer)
         self._login_slots = asyncio.Semaphore(2)
+        self._login_failures: dict[str, deque[int]] = {}
+        self._global_login_failures: deque[int] = deque()
+        self._registration_attempts: dict[str, deque[int]] = {}
 
     async def _kill(self, transaction: LoginTransaction) -> bool:
         token = transaction.loxone_token
@@ -185,8 +210,76 @@ class Phase0OAuthWeb:
             if value.created_at + _TRANSACTION_TTL <= now
         ]
         for key in expired:
-            transaction = self.transactions.pop(key)
-            await self._kill(transaction)
+            transaction = self.transactions.get(key)
+            if transaction is None:
+                continue
+            async with transaction.lock:
+                if self.transactions.get(key) is transaction and await self._kill(transaction):
+                    self.transactions.pop(key, None)
+
+    @staticmethod
+    def _prune_times(values: deque[int], *, now: int, window: int) -> None:
+        while values and values[0] + window <= now:
+            values.popleft()
+
+    def _login_rate_keys(self, transaction: LoginTransaction, username: str) -> tuple[str, str]:
+        normalized = username.casefold()
+        identity_key = self.provider.store.pseudonym(
+            "login-identity", self.endpoint.origin, normalized
+        )
+        return f"identity:{identity_key}", f"client:{transaction.client_id}"
+
+    def _login_is_limited(self, keys: tuple[str, str], now: int) -> bool:
+        self._prune_times(self._global_login_failures, now=now, window=_LOGIN_RATE_WINDOW)
+        if len(self._global_login_failures) >= _MAX_GLOBAL_LOGIN_FAILURES:
+            return True
+        limits = (_MAX_LOGIN_ATTEMPTS, _MAX_CLIENT_LOGIN_FAILURES)
+        for key, limit in zip(keys, limits, strict=True):
+            values = self._login_failures.setdefault(key, deque())
+            self._prune_times(values, now=now, window=_LOGIN_RATE_WINDOW)
+            if len(values) >= limit:
+                return True
+        return False
+
+    def _record_login_failure(self, keys: tuple[str, str], now: int) -> None:
+        self._global_login_failures.append(now)
+        for key in keys:
+            self._login_failures.setdefault(key, deque()).append(now)
+        empty = [key for key, values in self._login_failures.items() if not values]
+        for key in empty:
+            self._login_failures.pop(key, None)
+        if len(self._login_failures) > _MAX_RATE_KEYS:
+            oldest = sorted(
+                self._login_failures,
+                key=lambda key: self._login_failures[key][-1],
+            )
+            for key in oldest[: len(self._login_failures) - _MAX_RATE_KEYS]:
+                self._login_failures.pop(key, None)
+
+    def _clear_identity_failures(self, keys: tuple[str, str]) -> None:
+        self._login_failures.pop(keys[0], None)
+
+    def _registration_key(self, request: Request) -> str:
+        source = request.client.host if request.client is not None else "unknown"
+        return self.provider.store.pseudonym("registration-source", source)
+
+    def _registration_is_limited(self, key: str) -> bool:
+        now = int(time.time())
+        values = self._registration_attempts.setdefault(key, deque())
+        self._prune_times(values, now=now, window=_REGISTRATION_RATE_WINDOW)
+        return len(values) >= _MAX_REGISTRATIONS_PER_WINDOW
+
+    def _record_registration(self, key: str) -> None:
+        self._registration_attempts.setdefault(key, deque()).append(int(time.time()))
+        self._bound_rate_map(self._registration_attempts)
+
+    @staticmethod
+    def _bound_rate_map(values: dict[str, deque[int]]) -> None:
+        if len(values) <= _MAX_RATE_KEYS:
+            return
+        oldest = sorted(values, key=lambda key: values[key][-1] if values[key] else 0)
+        for key in oldest[: len(values) - _MAX_RATE_KEYS]:
+            values.pop(key, None)
 
     @staticmethod
     def _single_query(request: Request) -> dict[str, str] | None:
@@ -317,40 +410,69 @@ class Phase0OAuthWeb:
         ):
             return _html_page("Authorization expired", "<h1>Authorization expired</h1>", status=400)
         action = form.get("action")
-        if action == "login" and transaction.identity_id is None:
-            return await self._login(transaction, form)
-        if action == "approve" and transaction.identity_id and transaction.miniserver_id:
-            if not await self._kill(transaction):
+        async with transaction.lock:
+            if self.transactions.get(transaction_id) is not transaction:
                 return _html_page(
-                    "Authorization unavailable", "<h1>Authorization unavailable</h1>", status=503
+                    "Authorization expired", "<h1>Authorization expired</h1>", status=400
                 )
-            code = self.provider.issue_authorization_code(
-                client_id=transaction.client_id,
-                redirect_uri=transaction.redirect_uri,
-                code_challenge=transaction.code_challenge,
-                resource=transaction.resource,
-                identity_id=transaction.identity_id,
-                miniserver_id=transaction.miniserver_id,
-            )
-            self.transactions.pop(transaction_id, None)
-            response = _redirect(
-                transaction.redirect_uri,
-                {"code": code, "state": transaction.state, "iss": self.issuer},
-            )
-            response.delete_cookie(_COOKIE_NAME, path="/plugins/mcpserver/oauth/authorize")
-            return response
-        if action == "deny":
-            if not await self._kill(transaction):
-                return _html_page(
-                    "Authorization unavailable", "<h1>Authorization unavailable</h1>", status=503
+            if action == "login" and transaction.phase == "login":
+                transaction.phase = "login_pending"
+                return await self._login(transaction, form)
+            if (
+                action == "approve"
+                and transaction.phase == "consent"
+                and transaction.identity_id
+                and transaction.miniserver_id
+            ):
+                transaction.phase = "approving"
+                if not await self._kill(transaction):
+                    transaction.phase = "consent"
+                    return _html_page(
+                        "Authorization unavailable",
+                        "<h1>Authorization unavailable</h1>",
+                        status=503,
+                    )
+                try:
+                    code = self.provider.issue_authorization_code(
+                        client_id=transaction.client_id,
+                        redirect_uri=transaction.redirect_uri,
+                        code_challenge=transaction.code_challenge,
+                        resource=transaction.resource,
+                        identity_id=transaction.identity_id,
+                        miniserver_id=transaction.miniserver_id,
+                    )
+                except TokenError:
+                    transaction.phase = "consent"
+                    return _html_page(
+                        "Authorization unavailable",
+                        "<h1>Authorization unavailable</h1>",
+                        status=503,
+                    )
+                transaction.phase = "finished"
+                self.transactions.pop(transaction_id, None)
+                response = _redirect(
+                    transaction.redirect_uri,
+                    {"code": code, "state": transaction.state, "iss": self.issuer},
                 )
-            self.transactions.pop(transaction_id, None)
-            response = _redirect(
-                transaction.redirect_uri,
-                {"error": "access_denied", "state": transaction.state, "iss": self.issuer},
-            )
-            response.delete_cookie(_COOKIE_NAME, path="/plugins/mcpserver/oauth/authorize")
-            return response
+                response.delete_cookie(_COOKIE_NAME, path="/plugins/mcpserver/oauth/authorize")
+                return response
+            if action == "deny" and transaction.phase in {"login", "consent"}:
+                transaction.phase = "denying"
+                if not await self._kill(transaction):
+                    transaction.phase = "consent" if transaction.identity_id else "login"
+                    return _html_page(
+                        "Authorization unavailable",
+                        "<h1>Authorization unavailable</h1>",
+                        status=503,
+                    )
+                transaction.phase = "finished"
+                self.transactions.pop(transaction_id, None)
+                response = _redirect(
+                    transaction.redirect_uri,
+                    {"error": "access_denied", "state": transaction.state, "iss": self.issuer},
+                )
+                response.delete_cookie(_COOKIE_NAME, path="/plugins/mcpserver/oauth/authorize")
+                return response
         return _html_page(
             "Invalid authorization request", "<h1>Invalid authorization request</h1>", status=400
         )
@@ -359,10 +481,22 @@ class Phase0OAuthWeb:
         transaction.attempts += 1
         if transaction.attempts > _MAX_LOGIN_ATTEMPTS:
             self.transactions.pop(transaction.transaction_id, None)
+            transaction.phase = "finished"
             return _html_page("Authorization expired", "<h1>Authorization expired</h1>", status=429)
         username = form.get("username", "")
         password = form.get("password", "")
+        now = int(time.time())
+        rate_keys = self._login_rate_keys(transaction, username)
+        if self._login_is_limited(rate_keys, now):
+            transaction.phase = "login"
+            return _html_page(
+                "Sign-in temporarily unavailable",
+                "<h1>Sign-in temporarily unavailable / Anmeldung vorübergehend nicht verfügbar</h1>",
+                status=429,
+            )
         if not username or len(username) > 128 or not password or len(password) > 1024:
+            self._record_login_failure(rate_keys, now)
+            transaction.phase = "login"
             return self._login_page(transaction, "Sign-in failed. / Anmeldung fehlgeschlagen.")
         client = LoxoneClient(self.endpoint, client_uuid=self._client_uuid)
         token: LoxoneToken | None = None
@@ -379,18 +513,22 @@ class Phase0OAuthWeb:
             if token is not None:
                 with suppress(LoxoneConnectionError):
                     await client.kill_token(token)
+            self._record_login_failure(rate_keys, now)
+            transaction.phase = "login"
             return self._login_page(transaction, "Sign-in failed. / Anmeldung fehlgeschlagen.")
-        transaction.loxone_token = token
-        transaction.identity_name = structure.identity.username
-        transaction.miniserver_name = probe.serial
-        transaction.miniserver_id = self.provider.store.pseudonym(
-            self.endpoint.origin, probe.serial
-        )
-        transaction.identity_id = self.provider.store.pseudonym(
+        miniserver_id = self.provider.store.pseudonym(self.endpoint.origin, probe.serial)
+        identity_id = self.provider.store.pseudonym(
             self.endpoint.origin,
             probe.serial,
             structure.identity.username,
         )
+        transaction.loxone_token = token
+        transaction.identity_name = structure.identity.username
+        transaction.miniserver_name = probe.serial
+        transaction.miniserver_id = miniserver_id
+        transaction.identity_id = identity_id
+        self._clear_identity_failures(rate_keys)
+        transaction.phase = "consent"
         return self._consent_page(transaction)
 
     async def token(self, request: Request) -> Response:
@@ -461,15 +599,11 @@ class Phase0OAuthWeb:
     async def register(self, request: Request) -> Response:
         if request.headers.get("authorization"):
             return _oauth_error("invalid_client_metadata")
-        try:
-            length = int(request.headers.get("content-length", "0"))
-        except ValueError:
-            return _oauth_error("invalid_client_metadata")
         media_type = request.headers.get("content-type", "").split(";", 1)[0].strip().lower()
-        if media_type != "application/json" or length > _MAX_JSON_BYTES:
+        if media_type != "application/json":
             return _oauth_error("invalid_client_metadata")
-        raw = await request.body()
-        if len(raw) > _MAX_JSON_BYTES:
+        raw = await _limited_body(request, _MAX_JSON_BYTES)
+        if raw is None:
             return _oauth_error("invalid_client_metadata")
         reason = "Malformed client metadata"
         try:
@@ -499,10 +633,16 @@ class Phase0OAuthWeb:
             normalized["scope"] = SCOPE
             normalized["token_endpoint_auth_method"] = "none"
             normalized["client_id"] = _opaque()
-            normalized["client_id_issued_at"] = int(time.time())
+            normalized["client_id_issued_at"] = self.provider.now()
             full = OAuthClientInformationFull.model_validate(normalized)
+            registration_key = self._registration_key(request)
+            if self._registration_is_limited(registration_key):
+                response = _oauth_error("temporarily_unavailable", status=429)
+                response.headers["Retry-After"] = str(_REGISTRATION_RATE_WINDOW)
+                return response
             reason = "Client registration was rejected"
             await self.provider.register_client(full)
+            self._record_registration(registration_key)
         except (ValueError, ValidationError, TypeError, RegistrationError):
             return _json(
                 {"error": "invalid_client_metadata", "error_description": reason}, status=400

--- a/src/mcpserver/auth/web.py
+++ b/src/mcpserver/auth/web.py
@@ -1,0 +1,543 @@
+"""Strict public OAuth and browser-consent endpoints for Phase 0."""
+
+# Embedded responsive HTML is kept close to this temporary browser flow.
+# ruff: noqa: E501
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import hmac
+import html
+import json
+import re
+import secrets
+import time
+from collections.abc import Mapping
+from contextlib import suppress
+from dataclasses import dataclass
+from typing import Final
+from urllib.parse import urlencode, urlsplit
+from uuid import NAMESPACE_URL, uuid5
+
+from mcp.server.auth.provider import RegistrationError, TokenError
+from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata
+from pydantic import ValidationError
+from starlette.requests import Request
+from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
+
+from mcpserver.auth.provider import SCOPE, Phase0OAuthProvider
+from mcpserver.loxone.client import (
+    LoxoneClient,
+    LoxoneConnectionError,
+    LoxoneToken,
+    MiniserverEndpoint,
+)
+
+_MAX_FORM_BYTES: Final = 16 * 1024
+_MAX_JSON_BYTES: Final = 32 * 1024
+_TRANSACTION_TTL: Final = 5 * 60
+_MAX_LOGIN_ATTEMPTS: Final = 5
+_MAX_LOGIN_TRANSACTIONS: Final = 16
+_COOKIE_NAME: Final = "phase0_oauth_tx"
+_PKCE_CHALLENGE = re.compile(r"^[A-Za-z0-9_-]{43}$")
+_PKCE_VERIFIER = re.compile(r"^[A-Za-z0-9._~-]{43,128}$")
+
+
+@dataclass(slots=True)
+class LoginTransaction:
+    transaction_id: str
+    csrf_token: str
+    client_id: str
+    client_name: str
+    redirect_uri: str
+    state: str
+    code_challenge: str
+    resource: str
+    created_at: int
+    attempts: int = 0
+    loxone_token: LoxoneToken | None = None
+    identity_name: str | None = None
+    identity_id: str | None = None
+    miniserver_id: str | None = None
+    miniserver_name: str | None = None
+
+
+def _callback_csp_source(uri: str) -> str:
+    parsed = urlsplit(uri)
+    host = parsed.hostname or ""
+    if ":" in host:
+        host = f"[{host}]"
+    authority = host if parsed.port is None else f"{host}:{parsed.port}"
+    return f"{parsed.scheme}://{authority}"
+
+
+def _security_headers(*, callback_uri: str | None = None) -> dict[str, str]:
+    form_action = "'self'"
+    if callback_uri is not None:
+        form_action = f"{form_action} {_callback_csp_source(callback_uri)}"
+    return {
+        "Cache-Control": "no-store",
+        "Pragma": "no-cache",
+        "Content-Security-Policy": (
+            f"default-src 'none'; style-src 'unsafe-inline'; form-action {form_action}; "
+            "frame-ancestors 'none'; base-uri 'none'"
+        ),
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "DENY",
+        "Referrer-Policy": "strict-origin",
+    }
+
+
+def _json(payload: Mapping[str, object], status: int = 200) -> JSONResponse:
+    return JSONResponse(payload, status_code=status, headers=_security_headers())
+
+
+def _oauth_error(error: str, *, status: int = 400) -> JSONResponse:
+    return _json({"error": error}, status)
+
+
+def _redirect(uri: str, parameters: Mapping[str, str]) -> RedirectResponse:
+    separator = "&" if "?" in uri else "?"
+    return RedirectResponse(
+        f"{uri}{separator}{urlencode(parameters)}",
+        status_code=302,
+        headers=_security_headers(callback_uri=uri),
+    )
+
+
+def _html_page(
+    title: str, body: str, *, status: int = 200, callback_uri: str | None = None
+) -> HTMLResponse:
+    document = f"""<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>{html.escape(title)}</title><style>
+:root{{font-family:system-ui,sans-serif;color-scheme:light dark}}body{{margin:0;padding:1rem;background:#18222d}}
+main{{box-sizing:border-box;max-width:34rem;margin:4vh auto;padding:1.4rem;border-radius:.8rem;background:#fff;color:#17202a}}
+label{{display:block;margin:.9rem 0 .25rem}}input{{box-sizing:border-box;width:100%;padding:.75rem;font:inherit}}
+.actions{{display:flex;gap:.7rem;flex-wrap:wrap;margin-top:1.2rem}}button{{padding:.7rem 1rem;font:inherit}}
+.error{{color:#a00000}}dl{{display:grid;grid-template-columns:max-content 1fr;gap:.4rem .8rem}}dt{{font-weight:700}}
+@media(max-width:430px){{main{{margin:0 auto;padding:1rem}}dl{{display:block}}dd{{margin:0 0 .7rem}}button{{flex:1}}}}
+</style></head><body><main>{body}</main></body></html>"""
+    return HTMLResponse(
+        document, status_code=status, headers=_security_headers(callback_uri=callback_uri)
+    )
+
+
+async def _form(request: Request, *, allowed: set[str]) -> dict[str, str] | None:
+    content_type = request.headers.get("content-type", "").split(";", 1)[0].strip().lower()
+    try:
+        length = int(request.headers.get("content-length", "0"))
+    except ValueError:
+        return None
+    if content_type != "application/x-www-form-urlencoded" or length > _MAX_FORM_BYTES:
+        return None
+    body = await request.body()
+    if len(body) > _MAX_FORM_BYTES:
+        return None
+    from urllib.parse import parse_qsl
+
+    try:
+        pairs = parse_qsl(body.decode("utf-8"), keep_blank_values=True, strict_parsing=True)
+    except (UnicodeError, ValueError):
+        return None
+    if any(key not in allowed for key, _ in pairs) or len({key for key, _ in pairs}) != len(pairs):
+        return None
+    return dict(pairs)
+
+
+class Phase0OAuthWeb:
+    """Own exact endpoint behavior while using MCP SDK data interfaces."""
+
+    def __init__(
+        self,
+        provider: Phase0OAuthProvider,
+        *,
+        endpoint: MiniserverEndpoint,
+        issuer: str,
+        resource: str,
+    ) -> None:
+        self.provider = provider
+        self.endpoint = endpoint
+        self.issuer = issuer
+        self.resource = resource
+        self.transactions: dict[str, LoginTransaction] = {}
+        self._client_uuid = uuid5(NAMESPACE_URL, issuer)
+        self._login_slots = asyncio.Semaphore(2)
+
+    async def _kill(self, transaction: LoginTransaction) -> bool:
+        token = transaction.loxone_token
+        if token is None:
+            return True
+        try:
+            await LoxoneClient(self.endpoint, client_uuid=self._client_uuid).kill_token(token)
+        except LoxoneConnectionError:
+            return False
+        transaction.loxone_token = None
+        return True
+
+    async def _cleanup(self) -> None:
+        now = int(time.time())
+        expired = [
+            key
+            for key, value in self.transactions.items()
+            if value.created_at + _TRANSACTION_TTL <= now
+        ]
+        for key in expired:
+            transaction = self.transactions.pop(key)
+            await self._kill(transaction)
+
+    @staticmethod
+    def _single_query(request: Request) -> dict[str, str] | None:
+        if len(request.url.query.encode("utf-8")) > _MAX_FORM_BYTES:
+            return None
+        pairs = request.query_params.multi_items()
+        allowed = {
+            "response_type",
+            "client_id",
+            "redirect_uri",
+            "scope",
+            "resource",
+            "code_challenge",
+            "code_challenge_method",
+            "state",
+        }
+        if any(key not in allowed for key, _ in pairs) or len({key for key, _ in pairs}) != len(
+            pairs
+        ):
+            return None
+        return dict(pairs)
+
+    async def authorize(self, request: Request) -> Response:
+        await self._cleanup()
+        if request.method == "GET":
+            return await self._authorize_start(request)
+        return await self._authorize_post(request)
+
+    async def _authorize_start(self, request: Request) -> Response:
+        query = self._single_query(request)
+        if query is None:
+            return _html_page(
+                "Invalid authorization request",
+                "<h1>Invalid authorization request</h1>",
+                status=400,
+            )
+        client_id = query.get("client_id", "")
+        client = await self.provider.get_client(client_id)
+        redirect_uri = query.get("redirect_uri", "")
+        if (
+            client is None
+            or client.redirect_uris is None
+            or redirect_uri not in {str(value) for value in client.redirect_uris}
+        ):
+            return _html_page(
+                "Invalid authorization request",
+                "<h1>Invalid authorization request</h1>",
+                status=400,
+            )
+        if (
+            query.get("response_type") != "code"
+            or query.get("scope") != SCOPE
+            or query.get("resource") != self.resource
+            or query.get("code_challenge_method") != "S256"
+            or not _PKCE_CHALLENGE.fullmatch(query.get("code_challenge", ""))
+            or not query.get("state")
+        ):
+            return _redirect(
+                redirect_uri,
+                {"error": "invalid_request", "state": query.get("state", ""), "iss": self.issuer},
+            )
+        if len(self.transactions) >= _MAX_LOGIN_TRANSACTIONS:
+            return _html_page(
+                "Authorization unavailable",
+                "<h1>Authorization unavailable / Autorisierung nicht verfügbar</h1>",
+                status=503,
+            )
+        transaction = LoginTransaction(
+            transaction_id=_opaque(),
+            csrf_token=_opaque(),
+            client_id=client_id,
+            client_name=client.client_name or client_id,
+            redirect_uri=redirect_uri,
+            state=query["state"],
+            code_challenge=query["code_challenge"],
+            resource=query["resource"],
+            created_at=int(time.time()),
+        )
+        self.transactions[transaction.transaction_id] = transaction
+        response = self._login_page(transaction)
+        response.set_cookie(
+            _COOKIE_NAME,
+            transaction.transaction_id,
+            max_age=_TRANSACTION_TTL,
+            secure=True,
+            httponly=True,
+            samesite="lax",
+            path="/plugins/mcpserver/oauth/authorize",
+        )
+        return response
+
+    def _hidden(self, transaction: LoginTransaction, action: str) -> str:
+        return (
+            f'<input type="hidden" name="csrf" value="{html.escape(transaction.csrf_token)}">'
+            f'<input type="hidden" name="action" value="{action}">'
+        )
+
+    def _login_page(self, transaction: LoginTransaction, error: str = "") -> HTMLResponse:
+        error_html = f'<p class="error">{html.escape(error)}</p>' if error else ""
+        body = f"""<h1>Connect Loxone / Loxone verbinden</h1><p>Sign in with the dedicated Loxone user for <strong>{html.escape(transaction.client_name)}</strong>. / Melden Sie sich mit dem dedizierten Loxone-Benutzer an.</p>
+{error_html}<form method="post" action="{html.escape(self.issuer)}/authorize">{self._hidden(transaction, "login")}
+<label for="username">Loxone user / Loxone-Benutzer</label><input id="username" name="username" autocomplete="username" maxlength="128" required>
+<label for="password">Password / Passwort</label><input id="password" type="password" name="password" autocomplete="current-password" maxlength="1024" required>
+<div class="actions"><button type="submit">Continue / Weiter</button></div></form>"""
+        return _html_page("Connect Loxone", body, callback_uri=transaction.redirect_uri)
+
+    def _consent_page(self, transaction: LoginTransaction) -> HTMLResponse:
+        body = f"""<h1>Allow read-only access? / Lesezugriff erlauben?</h1><dl>
+<dt>Client</dt><dd>{html.escape(transaction.client_name)}</dd>
+<dt>Miniserver</dt><dd>{html.escape(transaction.miniserver_name or "")}</dd>
+<dt>Loxone identity / Loxone-Identität</dt><dd>{html.escape(transaction.identity_name or "")}</dd>
+<dt>Scope / Berechtigung</dt><dd>{SCOPE}</dd></dl>
+<form method="post" action="{html.escape(self.issuer)}/authorize">{self._hidden(transaction, "approve")}
+<div class="actions"><button type="submit">Allow / Erlauben</button></div></form>
+<form method="post" action="{html.escape(self.issuer)}/authorize">{self._hidden(transaction, "deny")}
+<div class="actions"><button type="submit">Deny / Ablehnen</button></div></form>"""
+        return _html_page("Authorize client", body, callback_uri=transaction.redirect_uri)
+
+    async def _authorize_post(self, request: Request) -> Response:
+        form = await _form(request, allowed={"csrf", "action", "username", "password"})
+        transaction_id = request.cookies.get(_COOKIE_NAME, "")
+        transaction = self.transactions.get(transaction_id)
+        if (
+            form is None
+            or transaction is None
+            or not hmac.compare_digest(form.get("csrf", ""), transaction.csrf_token)
+            or transaction.created_at + _TRANSACTION_TTL <= int(time.time())
+        ):
+            return _html_page("Authorization expired", "<h1>Authorization expired</h1>", status=400)
+        action = form.get("action")
+        if action == "login" and transaction.identity_id is None:
+            return await self._login(transaction, form)
+        if action == "approve" and transaction.identity_id and transaction.miniserver_id:
+            if not await self._kill(transaction):
+                return _html_page(
+                    "Authorization unavailable", "<h1>Authorization unavailable</h1>", status=503
+                )
+            code = self.provider.issue_authorization_code(
+                client_id=transaction.client_id,
+                redirect_uri=transaction.redirect_uri,
+                code_challenge=transaction.code_challenge,
+                resource=transaction.resource,
+                identity_id=transaction.identity_id,
+                miniserver_id=transaction.miniserver_id,
+            )
+            self.transactions.pop(transaction_id, None)
+            response = _redirect(
+                transaction.redirect_uri,
+                {"code": code, "state": transaction.state, "iss": self.issuer},
+            )
+            response.delete_cookie(_COOKIE_NAME, path="/plugins/mcpserver/oauth/authorize")
+            return response
+        if action == "deny":
+            if not await self._kill(transaction):
+                return _html_page(
+                    "Authorization unavailable", "<h1>Authorization unavailable</h1>", status=503
+                )
+            self.transactions.pop(transaction_id, None)
+            response = _redirect(
+                transaction.redirect_uri,
+                {"error": "access_denied", "state": transaction.state, "iss": self.issuer},
+            )
+            response.delete_cookie(_COOKIE_NAME, path="/plugins/mcpserver/oauth/authorize")
+            return response
+        return _html_page(
+            "Invalid authorization request", "<h1>Invalid authorization request</h1>", status=400
+        )
+
+    async def _login(self, transaction: LoginTransaction, form: Mapping[str, str]) -> Response:
+        transaction.attempts += 1
+        if transaction.attempts > _MAX_LOGIN_ATTEMPTS:
+            self.transactions.pop(transaction.transaction_id, None)
+            return _html_page("Authorization expired", "<h1>Authorization expired</h1>", status=429)
+        username = form.get("username", "")
+        password = form.get("password", "")
+        if not username or len(username) > 128 or not password or len(password) > 1024:
+            return self._login_page(transaction, "Sign-in failed. / Anmeldung fehlgeschlagen.")
+        client = LoxoneClient(self.endpoint, client_uuid=self._client_uuid)
+        token: LoxoneToken | None = None
+        try:
+            async with self._login_slots:
+                probe = await client.probe()
+                token = await client.acquire_token(username, password)
+                session = await client.open_session(token)
+                try:
+                    structure = await session.load_structure()
+                finally:
+                    await session.close()
+        except Exception:
+            if token is not None:
+                with suppress(LoxoneConnectionError):
+                    await client.kill_token(token)
+            return self._login_page(transaction, "Sign-in failed. / Anmeldung fehlgeschlagen.")
+        transaction.loxone_token = token
+        transaction.identity_name = structure.identity.username
+        transaction.miniserver_name = probe.serial
+        transaction.miniserver_id = self.provider.store.pseudonym(
+            self.endpoint.origin, probe.serial
+        )
+        transaction.identity_id = self.provider.store.pseudonym(
+            self.endpoint.origin,
+            probe.serial,
+            structure.identity.username,
+        )
+        return self._consent_page(transaction)
+
+    async def token(self, request: Request) -> Response:
+        if request.headers.get("authorization"):
+            return _oauth_error("invalid_client", status=401)
+        form = await _form(
+            request,
+            allowed={
+                "grant_type",
+                "client_id",
+                "code",
+                "redirect_uri",
+                "code_verifier",
+                "refresh_token",
+                "scope",
+                "resource",
+            },
+        )
+        if form is None or form.get("resource") != self.resource:
+            return _oauth_error("invalid_request")
+        client = await self.provider.get_client(form.get("client_id", ""))
+        if client is None or client.token_endpoint_auth_method != "none":
+            return _oauth_error("invalid_client", status=401)
+        try:
+            if form.get("grant_type") == "authorization_code":
+                return await self._authorization_code_token(client, form)
+            if form.get("grant_type") == "refresh_token":
+                return await self._refresh_token(client, form)
+            return _oauth_error("unsupported_grant_type")
+        except TokenError as exc:
+            return _oauth_error(exc.error)
+
+    async def _authorization_code_token(
+        self, client: OAuthClientInformationFull, form: Mapping[str, str]
+    ) -> Response:
+        raw_code = form.get("code", "")
+        verifier = form.get("code_verifier", "")
+        code = await self.provider.load_authorization_code(client, raw_code)
+        if (
+            code is None
+            or form.get("redirect_uri") != str(code.redirect_uri)
+            or form.get("resource") != code.resource
+            or not _PKCE_VERIFIER.fullmatch(verifier)
+        ):
+            return _oauth_error("invalid_grant")
+        challenge = (
+            base64.urlsafe_b64encode(hashlib.sha256(verifier.encode("ascii")).digest())
+            .rstrip(b"=")
+            .decode("ascii")
+        )
+        if not hmac.compare_digest(challenge, code.code_challenge):
+            return _oauth_error("invalid_grant")
+        token = await self.provider.exchange_authorization_code(client, code)
+        return _json(token.model_dump(mode="json", exclude_none=True))
+
+    async def _refresh_token(
+        self, client: OAuthClientInformationFull, form: Mapping[str, str]
+    ) -> Response:
+        refresh = await self.provider.load_refresh_token(client, form.get("refresh_token", ""))
+        if refresh is None or refresh.resource != form.get("resource"):
+            return _oauth_error("invalid_grant")
+        scope = form.get("scope", SCOPE)
+        if scope != SCOPE:
+            return _oauth_error("invalid_scope")
+        token = await self.provider.exchange_refresh_token(client, refresh, [SCOPE])
+        return _json(token.model_dump(mode="json", exclude_none=True))
+
+    async def register(self, request: Request) -> Response:
+        if request.headers.get("authorization"):
+            return _oauth_error("invalid_client_metadata")
+        try:
+            length = int(request.headers.get("content-length", "0"))
+        except ValueError:
+            return _oauth_error("invalid_client_metadata")
+        media_type = request.headers.get("content-type", "").split(";", 1)[0].strip().lower()
+        if media_type != "application/json" or length > _MAX_JSON_BYTES:
+            return _oauth_error("invalid_client_metadata")
+        raw = await request.body()
+        if len(raw) > _MAX_JSON_BYTES:
+            return _oauth_error("invalid_client_metadata")
+        reason = "Malformed client metadata"
+        try:
+            payload = json.loads(raw)
+            if not isinstance(payload, dict):
+                raise ValueError
+            allowed = set(OAuthClientMetadata.model_fields) | {"application_type"}
+            unsupported = sorted(key for key in payload if key not in allowed)
+            reason = f"Unsupported client metadata field: {', '.join(unsupported)}"
+            if unsupported:
+                raise ValueError
+            reason = "Unsupported application type"
+            if payload.get("application_type") not in {None, "native", "web"}:
+                raise ValueError
+            reason = "Only public clients are supported"
+            if payload.get("token_endpoint_auth_method") not in {None, "none"}:
+                raise ValueError
+            reason = "Only loxone:read is supported"
+            if payload.get("scope") not in {None, SCOPE}:
+                raise ValueError
+            reason = "Client metadata schema is invalid"
+            sdk_payload = {
+                key: value for key, value in payload.items() if key != "application_type"
+            }
+            metadata = OAuthClientMetadata.model_validate(sdk_payload)
+            normalized = metadata.model_dump()
+            normalized["scope"] = SCOPE
+            normalized["token_endpoint_auth_method"] = "none"
+            normalized["client_id"] = _opaque()
+            normalized["client_id_issued_at"] = int(time.time())
+            full = OAuthClientInformationFull.model_validate(normalized)
+            reason = "Client registration was rejected"
+            await self.provider.register_client(full)
+        except (ValueError, ValidationError, TypeError, RegistrationError):
+            return _json(
+                {"error": "invalid_client_metadata", "error_description": reason}, status=400
+            )
+        return _json(full.model_dump(mode="json", exclude_none=True), status=201)
+
+    async def revoke(self, request: Request) -> Response:
+        if request.headers.get("authorization"):
+            return _oauth_error("invalid_client", status=401)
+        form = await _form(request, allowed={"token", "token_type_hint", "client_id"})
+        if form is None:
+            return _oauth_error("invalid_request")
+        client = await self.provider.get_client(form.get("client_id", ""))
+        if client is None or client.token_endpoint_auth_method != "none":
+            return _oauth_error("invalid_client", status=401)
+        await self.provider.revoke_raw_token(form.get("token", ""), client.client_id or "")
+        return Response(status_code=200, headers=_security_headers())
+
+    async def authorization_metadata(self, request: Request) -> Response:
+        return _json(
+            {
+                "issuer": self.issuer,
+                "authorization_endpoint": f"{self.issuer}/authorize",
+                "token_endpoint": f"{self.issuer}/token",
+                "registration_endpoint": f"{self.issuer}/register",
+                "revocation_endpoint": f"{self.issuer}/revoke",
+                "scopes_supported": [SCOPE],
+                "response_types_supported": ["code"],
+                "grant_types_supported": ["authorization_code", "refresh_token"],
+                "token_endpoint_auth_methods_supported": ["none"],
+                "revocation_endpoint_auth_methods_supported": ["none"],
+                "code_challenge_methods_supported": ["S256"],
+            }
+        )
+
+
+def _opaque() -> str:
+    return secrets.token_urlsafe(32)

--- a/src/mcpserver/server.py
+++ b/src/mcpserver/server.py
@@ -5,8 +5,13 @@ from __future__ import annotations
 import logging
 from typing import Final
 
+from mcp.server.auth.middleware.auth_context import get_access_token
+from mcp.server.auth.provider import AccessToken, TokenVerifier
+from mcp.server.auth.settings import AuthSettings
 from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecurityMiddleware, TransportSecuritySettings
+from mcp.types import ToolAnnotations
+from pydantic import AnyHttpUrl
 from starlette.applications import Starlette
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.requests import Request
@@ -14,6 +19,9 @@ from starlette.responses import JSONResponse, Response
 from starlette.types import ASGIApp
 
 from mcpserver import __version__
+from mcpserver.auth.provider import SCOPE, Phase0OAuthProvider
+from mcpserver.auth.store import AtomicJsonAuthStore
+from mcpserver.auth.web import Phase0OAuthWeb
 from mcpserver.settings import ServerSettings
 
 SERVER_NAME: Final = "LoxBerry MCP Server"
@@ -70,18 +78,46 @@ class _ForwardedHostValidationMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
 
 
+class _TransportValidationMiddleware(BaseHTTPMiddleware):
+    """Apply Host and Origin validation to OAuth and metadata routes too."""
+
+    def __init__(self, app: ASGIApp, *, guard: TransportSecurityMiddleware) -> None:
+        super().__init__(app)
+        self._guard = guard
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        rejection = await self._guard.validate_request(request)
+        if rejection is not None:
+            return rejection
+        return await call_next(request)
+
+
 class _ForwardedHostFastMCP(FastMCP):
     """FastMCP application that also validates Apache's original Host header."""
 
     forwarded_allowed_hosts: tuple[str, ...] = ()
+    transport_guard: TransportSecurityMiddleware | None = None
 
     def streamable_http_app(self) -> Starlette:
         app = super().streamable_http_app()
+        app.router.redirect_slashes = False
         app.add_middleware(
             _ForwardedHostValidationMiddleware,
             allowed_hosts=self.forwarded_allowed_hosts,
         )
+        if self.transport_guard is not None:
+            app.add_middleware(_TransportValidationMiddleware, guard=self.transport_guard)
         return app
+
+
+class _Phase0TokenVerifier(TokenVerifier):
+    """Expose the concrete provider through the SDK verifier contract."""
+
+    def __init__(self, provider: Phase0OAuthProvider) -> None:
+        self._provider = provider
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        return await self._provider.load_access_token(token)
 
 
 def create_server(settings: ServerSettings) -> FastMCP:
@@ -92,24 +128,83 @@ def create_server(settings: ServerSettings) -> FastMCP:
         allowed_origins=list(settings.allowed_origins),
     )
     transport_guard = TransportSecurityMiddleware(transport_security)
+    oauth_web: Phase0OAuthWeb | None = None
+    oauth_auth: AuthSettings | None = None
+    token_verifier: _Phase0TokenVerifier | None = None
+    if settings.phase0_auth is not None:
+        auth_store = AtomicJsonAuthStore(settings.phase0_auth.store_path)
+        provider = Phase0OAuthProvider(
+            auth_store,
+            issuer=settings.phase0_auth.issuer_url,
+            resource=settings.phase0_auth.resource_url,
+        )
+        oauth_web = Phase0OAuthWeb(
+            provider,
+            endpoint=settings.phase0_auth.loxone_endpoint,
+            issuer=settings.phase0_auth.issuer_url,
+            resource=settings.phase0_auth.resource_url,
+        )
+        oauth_auth = AuthSettings(
+            issuer_url=AnyHttpUrl(settings.phase0_auth.issuer_url),
+            resource_server_url=AnyHttpUrl(settings.phase0_auth.resource_url),
+            required_scopes=[SCOPE],
+        )
+        token_verifier = _Phase0TokenVerifier(provider)
+
     server = _ForwardedHostFastMCP(
         SERVER_NAME,
+        token_verifier=token_verifier,
         host=settings.host,
         port=settings.port,
         streamable_http_path="/mcp",
         json_response=True,
         stateless_http=True,
+        auth=oauth_auth,
         transport_security=transport_security,
     )
     server.forwarded_allowed_hosts = settings.allowed_hosts
+    server.transport_guard = transport_guard
+
+    if oauth_web is not None:
+        server.custom_route("/authorize", methods=["GET", "POST"], include_in_schema=False)(
+            oauth_web.authorize
+        )
+        server.custom_route("/token", methods=["POST"], include_in_schema=False)(oauth_web.token)
+        server.custom_route("/register", methods=["POST"], include_in_schema=False)(
+            oauth_web.register
+        )
+        server.custom_route("/revoke", methods=["POST"], include_in_schema=False)(oauth_web.revoke)
+        server.custom_route(
+            "/.well-known/oauth-authorization-server/plugins/mcpserver/oauth",
+            methods=["GET"],
+            include_in_schema=False,
+        )(oauth_web.authorization_metadata)
+
+        @server.tool(
+            name="phase0_identity_probe",
+            description="Unpublished Phase-0 OAuth identity interoperability probe.",
+            annotations=ToolAnnotations(
+                readOnlyHint=True,
+                destructiveHint=False,
+                idempotentHint=True,
+                openWorldHint=False,
+            ),
+        )
+        async def phase0_identity_probe() -> dict[str, object]:
+            token = get_access_token()
+            if token is None or token.claims is None:
+                raise RuntimeError("Authenticated identity is unavailable")
+            return {
+                "identity": token.claims["identity"],
+                "client_id": token.client_id,
+                "audience": token.claims["audience"],
+                "scope": token.scopes,
+            }
 
     @server.custom_route(  # type: ignore[misc]
         "/healthz", methods=["GET"], include_in_schema=False
     )
     async def health(request: Request) -> Response:
-        rejection = await transport_guard.validate_request(request)
-        if rejection is not None:
-            return rejection
         return JSONResponse(
             {
                 "ok": True,

--- a/src/mcpserver/settings.py
+++ b/src/mcpserver/settings.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 import ipaddress
 import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Final
 from urllib.parse import urlsplit
 
 import idna
+
+from mcpserver.loxone.client import MiniserverEndpoint
 
 SERVER_PORT: Final = 8765
 
@@ -156,6 +159,52 @@ def _validate_origins(origins: tuple[str, ...]) -> tuple[str, ...]:
 
 
 @dataclass(frozen=True, slots=True)
+class Phase0AuthSettings:
+    """Injected Phase-0 OAuth settings; no Loxone credentials are persisted."""
+
+    public_origin: str
+    store_path: Path
+    loxone_endpoint: MiniserverEndpoint
+
+    @property
+    def resource_url(self) -> str:
+        return f"{self.public_origin}/plugins/mcpserver/mcp"
+
+    @property
+    def issuer_url(self) -> str:
+        return f"{self.public_origin}/plugins/mcpserver/oauth"
+
+
+def _phase0_auth_from_environment() -> Phase0AuthSettings | None:
+    names = (
+        "MCPSERVER_PUBLIC_ORIGIN",
+        "MCPSERVER_AUTH_STORE",
+        "MCPSERVER_LOXONE_ENDPOINT",
+    )
+    values = tuple(os.getenv(name, "").strip() for name in names)
+    if not any(values):
+        return None
+    if not all(values):
+        raise ValueError(f"{', '.join(names)} must be configured together")
+
+    public_origin = _validate_origins((values[0],))[0]
+    if not public_origin.startswith("https://"):
+        raise ValueError("MCPSERVER_PUBLIC_ORIGIN must use HTTPS")
+
+    store_path = Path(values[1])
+    if not store_path.is_absolute() or store_path.name in {"", ".", ".."}:
+        raise ValueError("MCPSERVER_AUTH_STORE must be an absolute JSON file path")
+    if store_path.suffix.lower() != ".json":
+        raise ValueError("MCPSERVER_AUTH_STORE must name a JSON file")
+
+    return Phase0AuthSettings(
+        public_origin=public_origin,
+        store_path=store_path,
+        loxone_endpoint=MiniserverEndpoint.parse_gen1(values[2]),
+    )
+
+
+@dataclass(frozen=True, slots=True)
 class ServerSettings:
     """Runtime settings for the local MCP process."""
 
@@ -163,6 +212,7 @@ class ServerSettings:
     port: int
     allowed_hosts: tuple[str, ...]
     allowed_origins: tuple[str, ...]
+    phase0_auth: Phase0AuthSettings | None = None
 
     @classmethod
     def from_environment(cls) -> ServerSettings:
@@ -192,4 +242,5 @@ class ServerSettings:
             port=port,
             allowed_hosts=allowed_hosts,
             allowed_origins=allowed_origins,
+            phase0_auth=_phase0_auth_from_environment(),
         )

--- a/tests/integration/test_apache_transport.sh
+++ b/tests/integration/test_apache_transport.sh
@@ -131,7 +131,99 @@ stream_status=$?
 set -e
 test "$stream_status" = "124"
 
+# Restart the same loopback service with Phase-0 OAuth enabled so every exact
+# public Apache route is exercised without contacting a real Miniserver.
+kill "$server_pid"
+wait "$server_pid" 2>/dev/null || true
+server_pid=""
+mkdir "$work_dir/auth"
+MCPSERVER_ALLOWED_HOSTS="127.0.0.1:8765,127.0.0.1:18888" \
+	MCPSERVER_ALLOWED_ORIGINS="http://127.0.0.1:18888" \
+	MCPSERVER_PUBLIC_ORIGIN="https://localhost:18888" \
+	MCPSERVER_AUTH_STORE="$work_dir/auth/sessions.json" \
+	MCPSERVER_LOXONE_ENDPOINT="http://192.168.255.254" \
+	PYTHONPATH="$repository_root/src" \
+	"$python" -m mcpserver.server >"$work_dir/oauth-server.log" 2>&1 &
+server_pid=$!
+
+attempt=0
+while [ "$attempt" -lt 100 ]; do
+	require_running "OAuth MCP server" "$server_pid" "$work_dir/oauth-server.log"
+	if curl -fsS http://127.0.0.1:8765/healthz >/dev/null 2>&1; then
+		break
+	fi
+	attempt=$((attempt + 1))
+	sleep 0.05
+done
+test "$attempt" -lt 100
+
+authorization_metadata=$(curl -fsS \
+	http://127.0.0.1:18888/.well-known/oauth-authorization-server/plugins/mcpserver/oauth)
+printf '%s' "$authorization_metadata" | "$python" -c \
+	'import json,sys; body=json.load(sys.stdin); assert body["issuer"] == "https://localhost:18888/plugins/mcpserver/oauth"; assert body["token_endpoint_auth_methods_supported"] == ["none"]'
+
+resource_metadata=$(curl -fsS \
+	http://127.0.0.1:18888/.well-known/oauth-protected-resource/plugins/mcpserver/mcp)
+printf '%s' "$resource_metadata" | "$python" -c \
+	'import json,sys; body=json.load(sys.stdin); assert body["resource"] == "https://localhost:18888/plugins/mcpserver/mcp"'
+
+registration=$(curl -fsS \
+	-H 'Content-Type: application/json' \
+	--data '{"redirect_uris":["http://127.0.0.1:48999/callback"],"token_endpoint_auth_method":"none","grant_types":["authorization_code","refresh_token"],"response_types":["code"],"client_name":"Apache integration"}' \
+	http://127.0.0.1:18888/plugins/mcpserver/oauth/register)
+client_id=$(printf '%s' "$registration" | "$python" -c \
+	'import json,sys; body=json.load(sys.stdin); assert body["scope"] == "loxone:read"; assert "client_secret" not in body; print(body["client_id"])')
+
+authorize_status=$(curl -sS -o "$work_dir/authorize.html" -w '%{http_code}' -G \
+	--data-urlencode 'response_type=code' \
+	--data-urlencode "client_id=$client_id" \
+	--data-urlencode 'redirect_uri=http://127.0.0.1:48999/callback' \
+	--data-urlencode 'scope=loxone:read' \
+	--data-urlencode 'resource=https://localhost:18888/plugins/mcpserver/mcp' \
+	--data-urlencode 'code_challenge=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' \
+	--data-urlencode 'code_challenge_method=S256' \
+	--data-urlencode 'state=apache-integration' \
+	http://127.0.0.1:18888/plugins/mcpserver/oauth/authorize)
+test "$authorize_status" = "200"
+grep -q 'Loxone-Benutzer' "$work_dir/authorize.html"
+
+token_status=$(curl -sS -o /dev/null -w '%{http_code}' \
+	-H 'Content-Type: application/x-www-form-urlencoded' \
+	--data-urlencode 'grant_type=authorization_code' \
+	--data-urlencode "client_id=$client_id" \
+	http://127.0.0.1:18888/plugins/mcpserver/oauth/token)
+test "$token_status" = "400"
+
+revoke_status=$(curl -sS -o /dev/null -w '%{http_code}' \
+	-H 'Content-Type: application/x-www-form-urlencoded' \
+	--data-urlencode "client_id=$client_id" \
+	--data-urlencode 'token=unknown' \
+	http://127.0.0.1:18888/plugins/mcpserver/oauth/revoke)
+test "$revoke_status" = "200"
+
+protected_status=$(curl -sS -o /dev/null -w '%{http_code}' \
+	-H 'Accept: application/json, text/event-stream' \
+	-H 'Content-Type: application/json' \
+	--data "$request" \
+	http://127.0.0.1:18888/plugins/mcpserver/mcp)
+test "$protected_status" = "401"
+
+for unmatched in \
+	/plugins/mcpserver/oauth/authorize/ \
+	/plugins/mcpserver/oauth/token/ \
+	/.well-known/oauth-authorization-server; do
+	unmatched_status=$(curl -sS -o /dev/null -w '%{http_code}' "http://127.0.0.1:18888$unmatched")
+	test "$unmatched_status" != "200"
+	test "$unmatched_status" != "301"
+	test "$unmatched_status" != "302"
+	test "$unmatched_status" != "307"
+	test "$unmatched_status" != "308"
+done
+
 printf 'APACHE_STREAMABLE_HTTP=pass\n'
 printf 'APACHE_HOST_REJECTION=pass\n'
 printf 'APACHE_ORIGIN_REJECTION=pass\n'
 printf 'APACHE_SSE_%s_SECONDS=pass\n' "$stream_seconds"
+printf 'APACHE_OAUTH_EXACT_ROUTES=pass\n'
+printf 'APACHE_OAUTH_DISCOVERY=pass\n'
+printf 'APACHE_OAUTH_PROTECTED_RESOURCE=pass\n'

--- a/tests/test_apache_config.py
+++ b/tests/test_apache_config.py
@@ -40,3 +40,16 @@ def test_apache_exposes_only_exact_oauth_and_metadata_paths() -> None:
         assert f'ProxyPassReverse "{path}" ' in config
     assert 'ProxyPassMatch "^/plugins/mcpserver/oauth$" ' not in config
     assert 'ProxyPassMatch "^/.well-known/$" ' not in config
+
+
+def test_apache_caps_oauth_request_bodies_on_exact_routes() -> None:
+    config = Path("config/apache/mcpserver.conf").read_text(encoding="utf-8")
+    expected_limits = {
+        "/plugins/mcpserver/oauth/authorize": 16384,
+        "/plugins/mcpserver/oauth/token": 16384,
+        "/plugins/mcpserver/oauth/register": 32768,
+        "/plugins/mcpserver/oauth/revoke": 16384,
+    }
+
+    for path, limit in expected_limits.items():
+        assert f'<Location "{path}">\n    LimitRequestBody {limit}\n</Location>' in config

--- a/tests/test_apache_config.py
+++ b/tests/test_apache_config.py
@@ -8,10 +8,35 @@ from mcpserver.settings import SERVER_PORT
 def test_apache_proxy_is_narrow_and_loopback_only() -> None:
     config = Path("config/apache/mcpserver.conf").read_text(encoding="utf-8")
 
-    assert f'ProxyPass "/plugins/mcpserver/mcp" "http://127.0.0.1:{SERVER_PORT}/mcp"' in config
+    assert (
+        f'ProxyPassMatch "^/plugins/mcpserver/(mcp)$" "http://127.0.0.1:{SERVER_PORT}/$1"' in config
+    )
     assert "ProxyRequests" not in config
     assert "ProxyPreserveHost" not in config
     assert "\nProxyTimeout " not in config
     assert "timeout=300" in config
     assert "0.0.0.0" not in config
     assert "ProxyPass / " not in config
+
+
+def test_apache_exposes_only_exact_oauth_and_metadata_paths() -> None:
+    config = Path("config/apache/mcpserver.conf").read_text(encoding="utf-8")
+    public_paths = (
+        "/plugins/mcpserver/oauth/authorize",
+        "/plugins/mcpserver/oauth/token",
+        "/plugins/mcpserver/oauth/register",
+        "/plugins/mcpserver/oauth/revoke",
+        "/.well-known/oauth-protected-resource/plugins/mcpserver/mcp",
+        "/.well-known/oauth-authorization-server/plugins/mcpserver/oauth",
+    )
+
+    for path in public_paths:
+        leaf = path.rsplit("/", 1)[-1]
+        if path.startswith("/.well-known/"):
+            assert f'ProxyPassMatch "^({path})$" ' in config
+        else:
+            prefix = path[: -len(leaf)]
+            assert f'ProxyPassMatch "^{prefix}({leaf})$" ' in config
+        assert f'ProxyPassReverse "{path}" ' in config
+    assert 'ProxyPassMatch "^/plugins/mcpserver/oauth$" ' not in config
+    assert 'ProxyPassMatch "^/.well-known/$" ' not in config

--- a/tests/test_auth_store.py
+++ b/tests/test_auth_store.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from mcpserver.auth.store import AtomicJsonAuthStore, AuthStoreError, token_digest
+
+
+def test_store_is_atomic_and_persists_only_supplied_digests(tmp_path: Path) -> None:
+    path = tmp_path / "auth" / "sessions.json"
+    store = AtomicJsonAuthStore(path)
+    raw = "opaque-secret-value"
+
+    store.mutate(lambda document: document["access_tokens"].update({token_digest(raw): {}}))
+
+    serialized = path.read_text(encoding="utf-8")
+    assert raw not in serialized
+    assert token_digest(raw) in serialized
+    assert json.loads(serialized)["schema_version"] == 1
+    assert not list(path.parent.glob("*.tmp"))
+    if os.name != "nt":
+        assert path.stat().st_mode & 0o777 == 0o600
+        assert path.parent.stat().st_mode & 0o777 == 0o700
+
+
+def test_store_fails_closed_on_corruption(tmp_path: Path) -> None:
+    path = tmp_path / "auth" / "sessions.json"
+    store = AtomicJsonAuthStore(path)
+    path.write_text("not-json", encoding="utf-8")
+
+    with pytest.raises(AuthStoreError, match="corrupt"):
+        store.snapshot()
+
+    assert path.read_text(encoding="utf-8") == "not-json"
+
+
+def test_pseudonyms_are_stable_and_store_local(tmp_path: Path) -> None:
+    first = AtomicJsonAuthStore(tmp_path / "one" / "sessions.json")
+    second = AtomicJsonAuthStore(tmp_path / "two" / "sessions.json")
+
+    assert first.pseudonym("server", "user") == first.pseudonym("server", "user")
+    assert first.pseudonym("server", "user") != second.pseudonym("server", "user")

--- a/tests/test_auth_store.py
+++ b/tests/test_auth_store.py
@@ -37,6 +37,26 @@ def test_store_fails_closed_on_corruption(tmp_path: Path) -> None:
     assert path.read_text(encoding="utf-8") == "not-json"
 
 
+def test_existing_store_is_secured_before_it_is_read(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "auth" / "sessions.json"
+    AtomicJsonAuthStore(path)
+    calls: list[tuple[Path, int]] = []
+    real_chmod = os.chmod
+
+    def recording_chmod(
+        target: str | bytes | os.PathLike[str] | os.PathLike[bytes], mode: int
+    ) -> None:
+        calls.append((Path(target), mode))
+        real_chmod(target, mode)
+
+    monkeypatch.setattr("mcpserver.auth.store.os.chmod", recording_chmod)
+    AtomicJsonAuthStore(path)
+
+    assert (path, 0o600) in calls
+
+
 def test_pseudonyms_are_stable_and_store_local(tmp_path: Path) -> None:
     first = AtomicJsonAuthStore(tmp_path / "one" / "sessions.json")
     second = AtomicJsonAuthStore(tmp_path / "two" / "sessions.json")

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1,0 +1,437 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from mcp.shared.auth import OAuthClientInformationFull
+from pydantic import AnyUrl
+from starlette.applications import Starlette
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from mcpserver.auth.provider import SCOPE, Phase0OAuthProvider
+from mcpserver.auth.store import AtomicJsonAuthStore
+from mcpserver.auth.web import Phase0OAuthWeb
+from mcpserver.loxone.client import LoxoneToken, MiniserverEndpoint, ProbeResult
+
+ISSUER = "https://public.example/plugins/mcpserver/oauth"
+RESOURCE = "https://public.example/plugins/mcpserver/mcp"
+REDIRECT = "http://127.0.0.1:48765/callback"
+VERIFIER = "v" * 43
+CHALLENGE = (
+    base64.urlsafe_b64encode(hashlib.sha256(VERIFIER.encode()).digest()).rstrip(b"=").decode()
+)
+
+
+class Clock:
+    def __init__(self) -> None:
+        self.value = 1_800_000_000
+
+    def __call__(self) -> float:
+        return float(self.value)
+
+
+def _provider(tmp_path: Path, clock: Clock | None = None) -> Phase0OAuthProvider:
+    return Phase0OAuthProvider(
+        AtomicJsonAuthStore(tmp_path / "auth" / "sessions.json"),
+        issuer=ISSUER,
+        resource=RESOURCE,
+        clock=clock or Clock(),
+    )
+
+
+async def _client(provider: Phase0OAuthProvider) -> OAuthClientInformationFull:
+    client = OAuthClientInformationFull(
+        client_id="public-client",
+        redirect_uris=[AnyUrl(REDIRECT)],
+        token_endpoint_auth_method="none",
+        grant_types=["authorization_code", "refresh_token"],
+        response_types=["code"],
+        scope=SCOPE,
+    )
+    await provider.register_client(client)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_code_access_and_refresh_values_are_never_persisted(tmp_path: Path) -> None:
+    provider = _provider(tmp_path)
+    client = await _client(provider)
+    raw_code = provider.issue_authorization_code(
+        client_id=client.client_id or "",
+        redirect_uri=REDIRECT,
+        code_challenge=CHALLENGE,
+        resource=RESOURCE,
+        identity_id="identity-pseudonym",
+        miniserver_id="miniserver-pseudonym",
+    )
+    code = await provider.load_authorization_code(client, raw_code)
+    assert code is not None
+
+    token = await provider.exchange_authorization_code(client, code)
+    serialized = provider.store.path.read_text(encoding="utf-8")
+
+    assert raw_code not in serialized
+    assert token.access_token not in serialized
+    assert token.refresh_token is not None
+    assert token.refresh_token not in serialized
+    access = await provider.load_access_token(token.access_token)
+    assert access is not None
+    assert access.resource == RESOURCE
+    assert access.claims == {
+        "iss": ISSUER,
+        "identity": "identity-pseudonym",
+        "miniserver": "miniserver-pseudonym",
+        "audience": RESOURCE,
+    }
+
+
+@pytest.mark.asyncio
+async def test_refresh_replay_revokes_the_entire_family(tmp_path: Path) -> None:
+    provider = _provider(tmp_path)
+    client = await _client(provider)
+    raw_code = provider.issue_authorization_code(
+        client_id=client.client_id or "",
+        redirect_uri=REDIRECT,
+        code_challenge=CHALLENGE,
+        resource=RESOURCE,
+        identity_id="identity",
+        miniserver_id="miniserver",
+    )
+    code = await provider.load_authorization_code(client, raw_code)
+    assert code is not None
+    first = await provider.exchange_authorization_code(client, code)
+    assert first.refresh_token is not None
+    refresh = await provider.load_refresh_token(client, first.refresh_token)
+    assert refresh is not None
+    second = await provider.exchange_refresh_token(client, refresh, [SCOPE])
+
+    assert await provider.load_refresh_token(client, first.refresh_token) is None
+    assert await provider.load_access_token(first.access_token) is None
+    assert await provider.load_access_token(second.access_token) is None
+    assert second.refresh_token is not None
+    assert await provider.load_refresh_token(client, second.refresh_token) is None
+
+
+@pytest.mark.asyncio
+async def test_expired_code_and_access_token_fail_closed(tmp_path: Path) -> None:
+    clock = Clock()
+    provider = _provider(tmp_path, clock)
+    client = await _client(provider)
+    raw_code = provider.issue_authorization_code(
+        client_id=client.client_id or "",
+        redirect_uri=REDIRECT,
+        code_challenge=CHALLENGE,
+        resource=RESOURCE,
+        identity_id="identity",
+        miniserver_id="miniserver",
+    )
+    clock.value += 301
+    assert await provider.load_authorization_code(client, raw_code) is None
+
+
+def _web_app(provider: Phase0OAuthProvider) -> Starlette:
+    web = Phase0OAuthWeb(
+        provider,
+        endpoint=MiniserverEndpoint.parse_gen1("http://192.168.255.254"),
+        issuer=ISSUER,
+        resource=RESOURCE,
+    )
+    return Starlette(
+        routes=[
+            Route("/register", web.register, methods=["POST"]),
+            Route("/authorize", web.authorize, methods=["GET", "POST"]),
+            Route("/token", web.token, methods=["POST"]),
+            Route("/revoke", web.revoke, methods=["POST"]),
+            Route("/metadata", web.authorization_metadata, methods=["GET"]),
+        ]
+    )
+
+
+def _registration_payload() -> dict[str, object]:
+    return {
+        "redirect_uris": [REDIRECT],
+        "token_endpoint_auth_method": "none",
+        "grant_types": ["authorization_code", "refresh_token"],
+        "response_types": ["code"],
+        "client_name": "Phase zero client",
+    }
+
+
+def _authorize_parameters(client_id: str) -> dict[str, str]:
+    return {
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": REDIRECT,
+        "scope": SCOPE,
+        "resource": RESOURCE,
+        "code_challenge": CHALLENGE,
+        "code_challenge_method": "S256",
+        "state": "client-state",
+    }
+
+
+def test_metadata_advertises_only_the_public_contract(tmp_path: Path) -> None:
+    with TestClient(_web_app(_provider(tmp_path))) as client:
+        response = client.get("/metadata")
+
+    assert response.status_code == 200
+    assert response.json()["issuer"] == ISSUER
+    assert response.json()["token_endpoint_auth_methods_supported"] == ["none"]
+    assert response.json()["scopes_supported"] == [SCOPE]
+    assert response.json()["code_challenge_methods_supported"] == ["S256"]
+    assert response.headers["cache-control"] == "no-store"
+    assert response.headers["referrer-policy"] == "strict-origin"
+
+
+@pytest.mark.parametrize(
+    "redirect",
+    [
+        "http://client.example/callback",
+        "ftp://127.0.0.1/callback",
+        "http://user@127.0.0.1/callback",
+        "http://127.0.0.1/callback#fragment",
+        "http://127.0.0.1/callback?state=attacker",
+    ],
+)
+def test_registration_rejects_unsafe_redirects(tmp_path: Path, redirect: str) -> None:
+    payload = {
+        "redirect_uris": [redirect],
+        "token_endpoint_auth_method": "none",
+        "grant_types": ["authorization_code", "refresh_token"],
+        "response_types": ["code"],
+    }
+    with TestClient(_web_app(_provider(tmp_path))) as client:
+        response = client.post("/register", json=payload)
+
+    assert response.status_code == 400
+    assert response.json()["error"] == "invalid_client_metadata"
+
+
+def test_registration_normalizes_public_client_scope(tmp_path: Path) -> None:
+    provider = _provider(tmp_path)
+    with TestClient(_web_app(provider)) as client:
+        response = client.post("/register", json=_registration_payload())
+
+    assert response.status_code == 201
+    assert response.json()["token_endpoint_auth_method"] == "none"
+    assert response.json()["scope"] == SCOPE
+    assert "client_secret" not in response.json()
+
+
+def test_registration_normalizes_omitted_public_auth_method(tmp_path: Path) -> None:
+    payload = _registration_payload()
+    payload.pop("token_endpoint_auth_method")
+    with TestClient(_web_app(_provider(tmp_path))) as client:
+        response = client.post("/register", json=payload)
+
+    assert response.status_code == 201
+    assert response.json()["token_endpoint_auth_method"] == "none"
+    assert "client_secret" not in response.json()
+
+
+@pytest.mark.parametrize("application_type", ["native", "web"])
+def test_registration_accepts_standard_application_type(
+    tmp_path: Path, application_type: str
+) -> None:
+    payload = {**_registration_payload(), "application_type": application_type}
+    with TestClient(_web_app(_provider(tmp_path))) as client:
+        response = client.post("/register", json=payload)
+
+    assert response.status_code == 201
+    assert response.json()["token_endpoint_auth_method"] == "none"
+
+
+def test_registration_rejects_unknown_application_type(tmp_path: Path) -> None:
+    payload = {**_registration_payload(), "application_type": "service"}
+    with TestClient(_web_app(_provider(tmp_path))) as client:
+        response = client.post("/register", json=payload)
+
+    assert response.status_code == 400
+    assert response.json()["error"] == "invalid_client_metadata"
+
+
+def test_registration_rejects_another_scope(tmp_path: Path) -> None:
+    payload = {**_registration_payload(), "scope": "loxone:control"}
+    with TestClient(_web_app(_provider(tmp_path))) as client:
+        response = client.post("/register", json=payload)
+
+    assert response.status_code == 400
+    assert response.json()["error"] == "invalid_client_metadata"
+
+
+def test_authorize_uses_secure_cookie_csrf_and_exact_resource(tmp_path: Path) -> None:
+    provider = _provider(tmp_path)
+    with TestClient(_web_app(provider), follow_redirects=False) as client:
+        registration = client.post("/register", json=_registration_payload())
+        parameters = _authorize_parameters(registration.json()["client_id"])
+        start = client.get("/authorize", params=parameters)
+        wrong_resource = client.get(
+            "/authorize",
+            params={**parameters, "resource": "https://other.example/mcp"},
+        )
+
+    assert start.status_code == 200
+    csp = start.headers["content-security-policy"]
+    assert "form-action 'self' http://127.0.0.1:48765" in csp
+    assert "/callback" not in csp
+    cookie = start.headers["set-cookie"]
+    assert "Secure" in cookie
+    assert "HttpOnly" in cookie
+    assert "SameSite=lax" in cookie
+    assert "Path=/plugins/mcpserver/oauth/authorize" in cookie
+    assert 'name="csrf"' in start.text
+    assert "client-state" not in start.text
+    assert wrong_resource.status_code == 302
+    assert "error=invalid_request" in wrong_resource.headers["location"]
+    assert "state=client-state" in wrong_resource.headers["location"]
+    assert (
+        "iss=https%3A%2F%2Fpublic.example%2Fplugins%2Fmcpserver%2Foauth"
+        in wrong_resource.headers["location"]
+    )
+
+
+def test_authorize_bounds_concurrent_login_transactions(tmp_path: Path) -> None:
+    provider = _provider(tmp_path)
+    with TestClient(_web_app(provider), follow_redirects=False) as client:
+        registration = client.post("/register", json=_registration_payload())
+        parameters = _authorize_parameters(registration.json()["client_id"])
+        accepted = [client.get("/authorize", params=parameters) for _ in range(16)]
+        rejected = client.get("/authorize", params=parameters)
+
+    assert all(response.status_code == 200 for response in accepted)
+    assert rejected.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_browser_login_consent_kills_loxone_token_and_persists_no_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    provider = _provider(tmp_path)
+    web = Phase0OAuthWeb(
+        provider,
+        endpoint=MiniserverEndpoint.parse_gen1("http://192.168.255.254"),
+        issuer=ISSUER,
+        resource=RESOURCE,
+    )
+    app = Starlette(
+        routes=[
+            Route("/register", web.register, methods=["POST"]),
+            Route("/authorize", web.authorize, methods=["GET", "POST"]),
+        ]
+    )
+    killed: list[str] = []
+
+    class FakeSession:
+        async def load_structure(self) -> object:
+            return SimpleNamespace(identity=SimpleNamespace(username="private-test-user"))
+
+        async def close(self) -> None:
+            return None
+
+    class FakeLoxoneClient:
+        def __init__(self, endpoint: object, *, client_uuid: object) -> None:
+            pass
+
+        async def probe(self) -> ProbeResult:
+            return ProbeResult("17.1.7.27", "private-serial", True, True)
+
+        async def acquire_token(self, username: str, password: str) -> LoxoneToken:
+            assert username == "private-test-user"
+            assert password == "private-password"
+            return LoxoneToken("private-jwt", username, "private-key", "SHA256", 1)
+
+        async def open_session(self, token: LoxoneToken) -> FakeSession:
+            return FakeSession()
+
+        async def kill_token(self, token: LoxoneToken) -> None:
+            killed.append(token.value)
+            token.destroy()
+
+    monkeypatch.setattr("mcpserver.auth.web.LoxoneClient", FakeLoxoneClient)
+    with TestClient(app, follow_redirects=False) as client:
+        registration = client.post("/register", json=_registration_payload())
+        start = client.get(
+            "/authorize", params=_authorize_parameters(registration.json()["client_id"])
+        )
+        transaction = next(iter(web.transactions.values()))
+        cookie = f"phase0_oauth_tx={transaction.transaction_id}"
+        login = client.post(
+            "/authorize",
+            headers={"Cookie": cookie},
+            data={
+                "csrf": transaction.csrf_token,
+                "action": "login",
+                "username": "private-test-user",
+                "password": "private-password",
+            },
+        )
+        approved = client.post(
+            "/authorize",
+            headers={"Cookie": cookie},
+            data={"csrf": transaction.csrf_token, "action": "approve"},
+        )
+
+    assert start.status_code == 200
+    assert login.status_code == 200
+    assert "private-test-user" in login.text
+    assert "private-serial" in login.text
+    assert "private-password" not in login.text
+    assert approved.status_code == 302
+    assert "state=client-state" in approved.headers["location"]
+    assert (
+        "iss=https%3A%2F%2Fpublic.example%2Fplugins%2Fmcpserver%2Foauth"
+        in approved.headers["location"]
+    )
+    assert killed == ["private-jwt"]
+    persisted = provider.store.path.read_text(encoding="utf-8")
+    assert "private-test-user" not in persisted
+    assert "private-password" not in persisted
+    assert "private-jwt" not in persisted
+    assert "private-serial" not in persisted
+
+
+@pytest.mark.asyncio
+async def test_token_route_enforces_pkce_resource_replay_and_revoke(tmp_path: Path) -> None:
+    provider = _provider(tmp_path)
+    client_info = await _client(provider)
+    raw_code = provider.issue_authorization_code(
+        client_id=client_info.client_id or "",
+        redirect_uri=REDIRECT,
+        code_challenge=CHALLENGE,
+        resource=RESOURCE,
+        identity_id="identity",
+        miniserver_id="miniserver",
+    )
+    form = {
+        "grant_type": "authorization_code",
+        "client_id": client_info.client_id,
+        "code": raw_code,
+        "redirect_uri": REDIRECT,
+        "code_verifier": VERIFIER,
+        "resource": RESOURCE,
+    }
+    with TestClient(_web_app(provider)) as client:
+        wrong_resource = client.post(
+            "/token", data={**form, "resource": "https://other.example/mcp"}
+        )
+        issued = client.post("/token", data=form)
+        replay = client.post("/token", data=form)
+        revoked = client.post(
+            "/revoke",
+            data={
+                "client_id": client_info.client_id,
+                "token": issued.json()["refresh_token"],
+                "token_type_hint": "refresh_token",
+            },
+        )
+
+    assert wrong_resource.json() == {"error": "invalid_request"}
+    assert issued.status_code == 200
+    assert issued.json()["scope"] == SCOPE
+    assert replay.json() == {"error": "invalid_grant"}
+    assert revoked.status_code == 200
+    assert await provider.load_access_token(issued.json()["access_token"]) is None

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1,20 +1,24 @@
 from __future__ import annotations
 
+import asyncio
 import base64
 import hashlib
 from pathlib import Path
 from types import SimpleNamespace
 
+import httpx
 import pytest
+from mcp.server.auth.provider import RegistrationError, TokenError
 from mcp.shared.auth import OAuthClientInformationFull
 from pydantic import AnyUrl
 from starlette.applications import Starlette
+from starlette.requests import Request
 from starlette.routing import Route
 from starlette.testclient import TestClient
 
 from mcpserver.auth.provider import SCOPE, Phase0OAuthProvider
 from mcpserver.auth.store import AtomicJsonAuthStore
-from mcpserver.auth.web import Phase0OAuthWeb
+from mcpserver.auth.web import Phase0OAuthWeb, _limited_body
 from mcpserver.loxone.client import LoxoneToken, MiniserverEndpoint, ProbeResult
 
 ISSUER = "https://public.example/plugins/mcpserver/oauth"
@@ -54,6 +58,90 @@ async def _client(provider: Phase0OAuthProvider) -> OAuthClientInformationFull:
     )
     await provider.register_client(client)
     return client
+
+
+def _client_info(client_id: str, *, grants: list[str] | None = None) -> OAuthClientInformationFull:
+    return OAuthClientInformationFull(
+        client_id=client_id,
+        client_id_issued_at=1_800_000_000,
+        redirect_uris=[AnyUrl(REDIRECT)],
+        token_endpoint_auth_method="none",
+        grant_types=grants or ["authorization_code", "refresh_token"],
+        response_types=["code"],
+        scope=SCOPE,
+    )
+
+
+@pytest.mark.asyncio
+async def test_limited_body_rejects_negative_and_oversized_streams() -> None:
+    negative = Request(
+        {"type": "http", "method": "POST", "path": "/", "headers": [(b"content-length", b"-1")]}
+    )
+    assert await _limited_body(negative, 4) is None
+
+    messages = iter(
+        [
+            {"type": "http.request", "body": b"abc", "more_body": True},
+            {"type": "http.request", "body": b"def", "more_body": False},
+        ]
+    )
+
+    async def receive() -> dict[str, object]:
+        return next(messages)
+
+    streamed = Request({"type": "http", "method": "POST", "path": "/", "headers": []}, receive)
+    assert await _limited_body(streamed, 4) is None
+
+
+@pytest.mark.asyncio
+async def test_registration_capacity_returns_protocol_error_and_prunes_old_clients(
+    tmp_path: Path,
+) -> None:
+    clock = Clock()
+    provider = _provider(tmp_path, clock)
+    template = _client_info("template").model_dump(mode="json", exclude_none=True)
+
+    def fill(document: dict[str, object]) -> None:
+        clients = document["clients"]
+        assert isinstance(clients, dict)
+        for index in range(256):
+            clients[f"old-{index}"] = {**template, "client_id": f"old-{index}"}
+
+    provider.store.mutate(fill)
+    with pytest.raises(RegistrationError, match="capacity"):
+        await provider.register_client(_client_info("overflow"))
+
+    clock.value += 24 * 60 * 60 + 1
+    await provider.register_client(_client_info("replacement"))
+    assert set(provider.store.snapshot()["clients"]) == {"replacement"}
+
+
+@pytest.mark.asyncio
+async def test_registration_requires_authorization_code_and_refresh_grants(tmp_path: Path) -> None:
+    provider = _provider(tmp_path)
+    with pytest.raises(RegistrationError, match="Unsupported"):
+        await provider.register_client(_client_info("refresh-only", grants=["refresh_token"]))
+
+
+@pytest.mark.asyncio
+async def test_stale_unused_client_is_removed_before_authorization_starts(tmp_path: Path) -> None:
+    clock = Clock()
+    provider = _provider(tmp_path, clock)
+    client = _client_info("stale-client")
+    await provider.register_client(client)
+
+    clock.value += 24 * 60 * 60 + 1
+
+    assert await provider.get_client("stale-client") is None
+    with pytest.raises(TokenError, match="registration"):
+        provider.issue_authorization_code(
+            client_id="stale-client",
+            redirect_uri=REDIRECT,
+            code_challenge=CHALLENGE,
+            resource=RESOURCE,
+            identity_id="identity",
+            miniserver_id="miniserver",
+        )
 
 
 @pytest.mark.asyncio
@@ -263,6 +351,27 @@ def test_registration_rejects_another_scope(tmp_path: Path) -> None:
     assert response.json()["error"] == "invalid_client_metadata"
 
 
+def test_registration_rejects_refresh_only_metadata(tmp_path: Path) -> None:
+    payload = {**_registration_payload(), "grant_types": ["refresh_token"]}
+    with TestClient(_web_app(_provider(tmp_path))) as client:
+        response = client.post("/register", json=payload)
+
+    assert response.status_code == 400
+    assert response.json()["error"] == "invalid_client_metadata"
+
+
+def test_invalid_registration_requests_do_not_consume_valid_client_quota(tmp_path: Path) -> None:
+    with TestClient(_web_app(_provider(tmp_path))) as client:
+        invalid = [
+            client.post("/register", content=b"invalid", headers={"Content-Type": "text/plain"})
+            for _ in range(20)
+        ]
+        valid = client.post("/register", json=_registration_payload())
+
+    assert all(response.status_code == 400 for response in invalid)
+    assert valid.status_code == 201
+
+
 def test_authorize_uses_secure_cookie_csrf_and_exact_resource(tmp_path: Path) -> None:
     provider = _provider(tmp_path)
     with TestClient(_web_app(provider), follow_redirects=False) as client:
@@ -304,6 +413,153 @@ def test_authorize_bounds_concurrent_login_transactions(tmp_path: Path) -> None:
 
     assert all(response.status_code == 200 for response in accepted)
     assert rejected.status_code == 503
+
+
+def test_login_rate_limit_survives_new_authorization_transactions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    provider = _provider(tmp_path)
+    web = Phase0OAuthWeb(
+        provider,
+        endpoint=MiniserverEndpoint.parse_gen1("http://192.168.255.254"),
+        issuer=ISSUER,
+        resource=RESOURCE,
+    )
+
+    class FailingLoxoneClient:
+        def __init__(self, endpoint: object, *, client_uuid: object) -> None:
+            pass
+
+        async def probe(self) -> ProbeResult:
+            raise RuntimeError("unavailable")
+
+    monkeypatch.setattr("mcpserver.auth.web.LoxoneClient", FailingLoxoneClient)
+    app = Starlette(
+        routes=[
+            Route("/register", web.register, methods=["POST"]),
+            Route("/authorize", web.authorize, methods=["GET", "POST"]),
+        ]
+    )
+    with TestClient(app, follow_redirects=False) as client:
+        results = []
+        for _ in range(6):
+            registration = client.post("/register", json=_registration_payload())
+            parameters = _authorize_parameters(registration.json()["client_id"])
+            client.cookies.clear()
+            client.get("/authorize", params=parameters)
+            transaction = next(reversed(web.transactions.values()))
+            results.append(
+                client.post(
+                    "/authorize",
+                    headers={"Cookie": f"phase0_oauth_tx={transaction.transaction_id}"},
+                    data={
+                        "csrf": transaction.csrf_token,
+                        "action": "login",
+                        "username": "same-user",
+                        "password": "wrong-password",
+                    },
+                )
+            )
+
+    assert [response.status_code for response in results] == [200, 200, 200, 200, 200, 429]
+
+
+@pytest.mark.asyncio
+async def test_parallel_login_posts_acquire_only_one_loxone_token(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    provider = _provider(tmp_path)
+    web = Phase0OAuthWeb(
+        provider,
+        endpoint=MiniserverEndpoint.parse_gen1("http://192.168.255.254"),
+        issuer=ISSUER,
+        resource=RESOURCE,
+    )
+    acquired: list[LoxoneToken] = []
+
+    class FakeSession:
+        async def load_structure(self) -> object:
+            await asyncio.sleep(0.01)
+            return SimpleNamespace(identity=SimpleNamespace(username="parallel-user"))
+
+        async def close(self) -> None:
+            return None
+
+    class FakeLoxoneClient:
+        def __init__(self, endpoint: object, *, client_uuid: object) -> None:
+            pass
+
+        async def probe(self) -> ProbeResult:
+            return ProbeResult("17.1.7.27", "serial", True, True)
+
+        async def acquire_token(self, username: str, password: str) -> LoxoneToken:
+            token = LoxoneToken(f"jwt-{len(acquired)}", username, "key", "SHA256", 1)
+            acquired.append(token)
+            return token
+
+        async def open_session(self, token: LoxoneToken) -> FakeSession:
+            return FakeSession()
+
+        async def kill_token(self, token: LoxoneToken) -> None:
+            token.destroy()
+
+    monkeypatch.setattr("mcpserver.auth.web.LoxoneClient", FakeLoxoneClient)
+    app = Starlette(
+        routes=[
+            Route("/register", web.register, methods=["POST"]),
+            Route("/authorize", web.authorize, methods=["GET", "POST"]),
+        ]
+    )
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://public.example", follow_redirects=False
+    ) as client:
+        registration = await client.post("/register", json=_registration_payload())
+        await client.get(
+            "/authorize", params=_authorize_parameters(registration.json()["client_id"])
+        )
+        transaction = next(iter(web.transactions.values()))
+        data = {
+            "csrf": transaction.csrf_token,
+            "action": "login",
+            "username": "parallel-user",
+            "password": "password",
+        }
+        headers = {"Cookie": f"phase0_oauth_tx={transaction.transaction_id}"}
+        responses = await asyncio.gather(
+            client.post("/authorize", headers=headers, data=data),
+            client.post("/authorize", headers=headers, data=data),
+        )
+
+    assert sorted(response.status_code for response in responses) == [200, 400]
+    assert len(acquired) == 1
+    await web._kill(transaction)
+
+
+@pytest.mark.asyncio
+async def test_expired_store_records_are_garbage_collected(tmp_path: Path) -> None:
+    clock = Clock()
+    provider = _provider(tmp_path, clock)
+    client = await _client(provider)
+    raw_code = provider.issue_authorization_code(
+        client_id=client.client_id or "",
+        redirect_uri=REDIRECT,
+        code_challenge=CHALLENGE,
+        resource=RESOURCE,
+        identity_id="identity",
+        miniserver_id="miniserver",
+    )
+    code = await provider.load_authorization_code(client, raw_code)
+    assert code is not None
+    await provider.exchange_authorization_code(client, code)
+
+    clock.value += 30 * 24 * 60 * 60 + 1
+    await provider.register_client(_client_info("new-client"))
+    document = provider.store.snapshot()
+    assert document["codes"] == {}
+    assert document["families"] == {}
+    assert document["access_tokens"] == {}
+    assert document["refresh_tokens"] == {}
 
 
 @pytest.mark.asyncio

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
 import pytest
 from starlette.testclient import TestClient
 
+from mcpserver.loxone.client import MiniserverEndpoint
 from mcpserver.server import create_server
-from mcpserver.settings import ServerSettings
+from mcpserver.settings import Phase0AuthSettings, ServerSettings
 
 
 def _settings() -> ServerSettings:
@@ -133,3 +135,43 @@ def test_mcp_initialize_uses_expected_protocol() -> None:
     assert response.status_code == 200
     assert response.json()["result"]["protocolVersion"] == "2025-11-25"
     assert response.json()["result"]["serverInfo"]["name"] == "LoxBerry MCP Server"
+
+
+def test_oauth_routes_and_protected_resource_metadata_are_exact(tmp_path: Path) -> None:
+    settings = ServerSettings(
+        host="127.0.0.1",
+        port=8765,
+        allowed_hosts=("testserver",),
+        allowed_origins=(),
+        phase0_auth=Phase0AuthSettings(
+            public_origin="https://public.example",
+            store_path=tmp_path / "sessions.json",
+            loxone_endpoint=MiniserverEndpoint.parse_gen1("http://192.168.255.254"),
+        ),
+    )
+    app = create_server(settings).streamable_http_app()
+    with TestClient(app, base_url="http://testserver") as client:
+        authorization = client.get(
+            "/.well-known/oauth-authorization-server/plugins/mcpserver/oauth"
+        )
+        resource = client.get("/.well-known/oauth-protected-resource/plugins/mcpserver/mcp")
+        unauthenticated = client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+            headers={"Accept": "application/json, text/event-stream"},
+        )
+        aliases = [
+            client.get("/.well-known/oauth-authorization-server"),
+            client.get("/plugins/mcpserver/oauth/authorize"),
+            client.get("/authorize/"),
+        ]
+
+    assert authorization.status_code == 200
+    assert authorization.json()["issuer"] == "https://public.example/plugins/mcpserver/oauth"
+    assert resource.status_code == 200
+    assert resource.json()["resource"] == "https://public.example/plugins/mcpserver/mcp"
+    assert resource.json()["authorization_servers"] == [
+        "https://public.example/plugins/mcpserver/oauth"
+    ]
+    assert unauthenticated.status_code == 401
+    assert all(response.status_code == 404 for response in aliases)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -19,6 +19,9 @@ def test_secure_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
         "MCPSERVER_PORT",
         "MCPSERVER_ALLOWED_HOSTS",
         "MCPSERVER_ALLOWED_ORIGINS",
+        "MCPSERVER_PUBLIC_ORIGIN",
+        "MCPSERVER_AUTH_STORE",
+        "MCPSERVER_LOXONE_ENDPOINT",
     ):
         monkeypatch.delenv(key, raising=False)
 
@@ -28,6 +31,48 @@ def test_secure_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     assert settings.port == 8765
     assert settings.allowed_hosts == ("127.0.0.1:8765", "localhost:8765")
     assert settings.allowed_origins == ()
+    assert settings.phase0_auth is None
+
+
+def test_phase0_auth_settings_are_derived_without_credentials(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    store = tmp_path / "auth" / "sessions.json"
+    monkeypatch.setenv("MCPSERVER_PUBLIC_ORIGIN", "https://loxberry.example")
+    monkeypatch.setenv("MCPSERVER_AUTH_STORE", str(store))
+    monkeypatch.setenv("MCPSERVER_LOXONE_ENDPOINT", "http://192.168.255.254:7080")
+
+    settings = ServerSettings.from_environment()
+
+    assert settings.phase0_auth is not None
+    assert settings.phase0_auth.store_path == store
+    assert settings.phase0_auth.resource_url == "https://loxberry.example/plugins/mcpserver/mcp"
+    assert settings.phase0_auth.issuer_url == "https://loxberry.example/plugins/mcpserver/oauth"
+    assert settings.phase0_auth.loxone_endpoint.origin == "http://192.168.255.254:7080"
+
+
+def test_partial_phase0_auth_settings_are_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MCPSERVER_PUBLIC_ORIGIN", "https://loxberry.example")
+    monkeypatch.delenv("MCPSERVER_AUTH_STORE", raising=False)
+    monkeypatch.delenv("MCPSERVER_LOXONE_ENDPOINT", raising=False)
+
+    with pytest.raises(ValueError, match="must be configured together"):
+        ServerSettings.from_environment()
+
+
+@pytest.mark.parametrize(
+    "origin",
+    ["http://loxberry.example", "https://loxberry.example/", "https://user@loxberry.example"],
+)
+def test_invalid_phase0_public_origin_is_rejected(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, origin: str
+) -> None:
+    monkeypatch.setenv("MCPSERVER_PUBLIC_ORIGIN", origin)
+    monkeypatch.setenv("MCPSERVER_AUTH_STORE", str(tmp_path / "sessions.json"))
+    monkeypatch.setenv("MCPSERVER_LOXONE_ENDPOINT", "http://192.168.255.254")
+
+    with pytest.raises(ValueError, match="MCPSERVER_(PUBLIC_ORIGIN|ALLOWED_ORIGINS)"):
+        ServerSettings.from_environment()
 
 
 @pytest.mark.parametrize("host", ["0.0.0.0", "::", "192.0.2.10"])

--- a/tools/test_runtime_gate.sh
+++ b/tools/test_runtime_gate.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -ne 2 ]; then
+	echo "usage: $0 PYTHON TEST_ROOT" >&2
+	exit 2
+fi
+
+python=$1
+test_root=$2
+work_dir=$(mktemp -d /tmp/mcpserver-runtime-gate.XXXXXX)
+server_pid=""
+
+cleanup() {
+	if [ -n "$server_pid" ]; then
+		kill "$server_pid" 2>/dev/null || true
+		wait "$server_pid" 2>/dev/null || true
+	fi
+	rm -rf "$work_dir"
+}
+trap cleanup EXIT INT TERM
+
+start_server() {
+	store_path=$1
+	env \
+		MCPSERVER_ALLOWED_HOSTS=127.0.0.1:8765 \
+		MCPSERVER_PUBLIC_ORIGIN=https://localhost \
+		MCPSERVER_AUTH_STORE="$store_path" \
+		MCPSERVER_LOXONE_ENDPOINT=http://192.168.255.254 \
+		"$python" -m mcpserver.server >"$work_dir/server.log" 2>&1 &
+	server_pid=$!
+}
+
+wait_for_health() {
+	attempt=0
+	while [ "$attempt" -lt 150 ]; do
+		if ! kill -0 "$server_pid" 2>/dev/null; then
+			cat "$work_dir/server.log" >&2
+			exit 1
+		fi
+		if curl -fsS http://127.0.0.1:8765/healthz >/dev/null 2>&1; then
+			return
+		fi
+		attempt=$((attempt + 1))
+		sleep 0.05
+	done
+	echo "runtime gate server did not become healthy" >&2
+	exit 1
+}
+
+stop_server() {
+	kill "$server_pid"
+	wait "$server_pid" 2>/dev/null || true
+	server_pid=""
+}
+
+printf 'WHEELS=%s\n' "$(find "$test_root/wheelhouse" -maxdepth 1 -name '*.whl' | wc -l)"
+printf 'WHEELHOUSE_KIB=%s\n' "$(du -sk "$test_root/wheelhouse" | cut -f1)"
+printf 'RUNTIME_VENV_KIB=%s\n' "$(du -sk "$test_root/runtime-env" | cut -f1)"
+
+index=1
+while [ "$index" -le 5 ]; do
+	started=$(date +%s%3N)
+	start_server "$work_dir/auth-$index/sessions.json"
+	wait_for_health
+	healthy=$(date +%s%3N)
+	rss=$(ps -o rss= -p "$server_pid" | tr -d ' ')
+	printf 'START_%s_MS=%s RSS_%s_KIB=%s\n' \
+		"$index" "$((healthy - started))" "$index" "$rss"
+	stop_server
+	index=$((index + 1))
+done
+
+start_server "$work_dir/auth-idle/sessions.json"
+wait_for_health
+rss_initial=$(ps -o rss= -p "$server_pid" | tr -d ' ')
+sleep 30
+rss_idle=$(ps -o rss= -p "$server_pid" | tr -d ' ')
+printf 'RSS_INITIAL_KIB=%s RSS_IDLE_30S_KIB=%s\n' "$rss_initial" "$rss_idle"
+stop_server


### PR DESCRIPTION
## Summary

- implement OAuth 2.1 Authorization Code with PKCE S256, public-client DCR, exact redirect/resource/scope validation, consent login, revocation, refresh rotation and replay-family revocation
- persist only hashed codes and tokens in an atomic locked JSON store with restrictive permissions
- expose the Phase 0 identity probe and the concrete MCP/OAuth/well-known Apache routes
- add unit, negative-matrix, Apache transport and runtime-gate coverage
- document target-runtime and client interoperability evidence

## Verification

- `python tools/test.py`: 121 passed (Ruff, format, mypy, pytest)
- `git diff --check`: passed
- staged private-data and secret scan: no matches
- target Apache/runtime gate: passed
- Claude Desktop with `mcp-remote@0.1.38`: login, probe, natural refresh and revoke passed
- Codex CLI 0.146.0: login and probe passed

## Known Phase 0 blocker

Codex CLI currently omits the required RFC 8707 `resource` value during refresh. The server intentionally rejects that request rather than weakening audience binding. This matches upstream issue [openai/codex#33403](https://github.com/openai/codex/issues/33403). Codex logout also removes local credentials without invoking the revocation endpoint.

Therefore this PR does **not** mark Phase 0 complete and the temporary probe remains until the Codex refresh/revoke acceptance can be completed.

## Cleanup

The temporary target service, Apache proxy configuration, OAuth store and exact test processes/caches were removed. Apache was configuration-tested and reloaded successfully.