### PR TITLE
Complete Phase 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,20 @@ Für jeden Assistenten sollte ein eigener Loxone-Benutzer mit den minimal erford
 
 ## Projektstatus
 
-Das Plugin befindet sich im Aufbau. Installations-, Konfigurations- und Nutzungsanleitungen werden zusammen mit der ersten lauffähigen Version ergänzt.
+Phase 0 ist abgeschlossen. Runtime, Apache-Transport, OAuth-Server sowie die
+Gen.-1-Loxone-/WebSocket-Anbindung sind auf der dokumentierten Referenzplattform
+bestätigt. Der nächste Meilenstein ist Phase 1, die lokale Read-only Alpha mit
+Pluginlayout, Dienst, Admin-UI und den ersten stabilen lesenden Tools.
+
+Es gibt noch kein installierbares Testpaket. Die bestätigten Kombinationen und
+bekannten Clientgrenzen stehen in der [Support-Matrix](docs/development/support-matrix.md).
 
 ## Entwicklung
 
 - [Implementierungsrichtlinien](docs/development/implementation-guidelines.md)
 - [Plugin-Konzept](docs/development/plugin-concept.md)
 - [Änderungsgetriebene Teststrategie](docs/development/test-strategy.md)
+- [Support-Matrix](docs/development/support-matrix.md)
 - [Recherche-Ergebnisse](docs/research/research-results.md)
 - [Beitragen und Git-Workflow](CONTRIBUTING.md)
 

--- a/docs/development/adr/0001-phase-0-foundation.md
+++ b/docs/development/adr/0001-phase-0-foundation.md
@@ -1,7 +1,8 @@
 # ADR 0001: Phase-0-Grundarchitektur
 
-- **Status:** Angenommen
+- **Status:** Angenommen; Phase 0 abgeschlossen
 - **Datum:** 2026-08-01
+- **Abschluss:** 2026-08-03
 - **Geltung:** Runtime, Transport, Authentifizierung, Persistenz und erster
   ausführbarer Stand
 
@@ -120,8 +121,8 @@ Implementierungsdetails ersetzen.
 - Phase 1 bleibt read-only. Das erste spätere Schreibziel ist der Loxone-
   Control-Typ `Switch` mit ausschließlich explizitem `on` und `off`.
 - `loxberry:read` folgt erst in Phase 3 mit einer eigenen lokalen Freigabe.
-- Phase-0-Probe-Tools sind keine veröffentlichten MCP-Verträge und werden vor
-  dem ersten Paket entfernt.
+- Phase-0-Probe-Tools sind keine veröffentlichten MCP-Verträge. Das temporäre
+  Identitäts-Probe-Tool wurde mit Abschluss der Phase entfernt.
 
 ### Qualität und Lieferung
 
@@ -161,13 +162,26 @@ zwischen 64.364 und 64.384 KiB und blieb nach 30 Sekunden bei 64.368 KiB.
 Die isolierte Apache-2.4.68-Instanz bestätigte die exakten MCP-, OAuth- und
 Well-known-Pfade, Host-/Origin-Abweisung, DCR, geschützte MCP-Ressource und
 fehlende Alias- beziehungsweise Trailing-Slash-Weiterleitungen. Die
-deterministische Negativmatrix und der Browserablauf sind automatisiert; die
-beiden realen Clientnachweise bleiben vor dem Merge dieses Spikes Pflicht.
+deterministische Negativmatrix und der Browserablauf sind automatisiert.
+
+Claude Desktop `1.24012.9` mit `mcp-remote 0.1.38` bestätigte Anmeldung,
+MCP-Initialisierung, authentifizierten Aufruf, Refresh und Widerruf. Codex CLI
+`0.146.0` bestätigte Anmeldung, MCP-Initialisierung und authentifizierten Aufruf.
+Sein Refresh lässt den nach RFC 8707 verpflichtenden Parameter `resource` weg;
+sein Logout entfernt nur lokale Credentials und ruft den Widerrufsendpunkt nicht
+auf.
+
+Diese beiden Codex-Grenzen wurden für Phase 0 ausdrücklich als externe
+Client-Limitierung akzeptiert. Die Ausnahme ändert den Serververtrag nicht:
+Audience-Bindung und Widerrufsregeln bleiben strikt, und es gibt keinen
+clientspezifischen Fallback. Die konkrete Einstufung steht in der
+[Support-Matrix](../support-matrix.md).
 
 ## Folgen
 
 Python, Apache-Transport, Gen.-1-Loxone und WebSocket sind für die
 Referenzplattform bestätigt; ein vorsorglicher paralleler Go-Build entfällt.
-OAuth ist automatisiert und hinter einer isolierten realen Apache-Instanz
-bestätigt. Die Interoperabilitätsaussage folgt erst nach den dokumentierten
-Codex-CLI- und Claude-Desktop-Tests.
+OAuth ist automatisiert, hinter einer isolierten realen Apache-Instanz und mit
+zwei dokumentierten Clients bestätigt. Phase 0 ist abgeschlossen. Phase 1
+liefert als nächsten Meilenstein die lokale Read-only Alpha mit Pluginlayout,
+Lifecycle, Admin-UI und stabilen lesenden MCP-Tools.

--- a/docs/development/phase-0-oauth-test.md
+++ b/docs/development/phase-0-oauth-test.md
@@ -1,9 +1,10 @@
 # Phase-0-Test: OAuth und Clientinteroperabilität
 
-Dieser Nachweis prüft den unveröffentlichten OAuth-Spike über die lokale
-HTTPS-Adresse des LoxBerry. Er veröffentlicht noch keinen dauerhaften
-MCP-Toolvertrag. Zugangsdaten, Tokens, interne Adressen, Callback-Parameter und
-lokale Testpfade werden nicht in diesen Bericht übernommen.
+Dieser Nachweis prüfte den OAuth-Spike über die lokale HTTPS-Adresse des
+LoxBerry. Das dabei verwendete Identitäts-Probe-Tool war kein dauerhafter
+MCP-Toolvertrag und wurde mit dem Abschluss von Phase 0 entfernt. Zugangsdaten,
+Tokens, interne Adressen, Callback-Parameter und lokale Testpfade werden nicht in
+diesen Bericht übernommen.
 
 ## Vertrag
 
@@ -48,11 +49,11 @@ Auf LoxBerry `4.0.0.14`, Debian 13, `aarch64`, Python `3.13.5` und Apache
 
 Die produktive Apache-Konfiguration wurde für diese Nachweise nicht verändert.
 
-## Verbleibende reale Abnahme vor Merge
+## Reale Clientabnahme
 
-| Client | Version | Callback | Login | Probe | Refresh | Revoke |
+| Client | Version | Callback | Login | authentifizierter Aufruf | Refresh | Revoke |
 | --- | --- | --- | --- | --- | --- | --- |
-| Codex CLI | `0.146.0` | dynamischer IPv4-Loopback mit pfadgebundener Callback-ID | erfolgreich | erfolgreich | extern blockiert | lokal abgemeldet; Client sendet keinen Widerruf |
+| Codex CLI | `0.146.0` | dynamischer IPv4-Loopback mit pfadgebundener Callback-ID | erfolgreich | erfolgreich | fehlgeschlagen; `resource` fehlt | lokal abgemeldet; Client sendet keinen Widerruf |
 | Claude Desktop mit `mcp-remote@0.1.38` | `1.24012.9` | `localhost`-Loopback; Port anonymisiert | erfolgreich | erfolgreich | erfolgreich | erfolgreich |
 
 Für Node-basierte Clients wird die Windows-System-CA mit
@@ -92,3 +93,17 @@ Der Token-Endpunkt akzeptierte den Refresh, der Store markierte die alte
 Refresh-Generation als verbraucht und legte eine neue aktive Generation an.
 Der abschließende RFC-7009-Widerruf markierte die gesamte Testfamilie sowie alle
 zugehörigen Access- und Refresh-Tokens als widerrufen.
+
+## Abschlussentscheidung
+
+Phase 0 wurde am 2026-08-03 mit einer ausdrücklichen Ausnahme für die beiden
+bestätigten Codex-CLI-Grenzen abgeschlossen. Die Interoperabilitätsabnahme
+verlangt für beide ausgewählten Clients erfolgreiche Anmeldung,
+MCP-Initialisierung und einen authentifizierten Aufruf. Refresh und Widerruf sind
+serverseitig automatisiert sowie mit Claude Desktop real bestätigt.
+
+Der fehlende RFC-8707-Parameter beim Codex-Refresh und der rein lokale
+Codex-Logout werden als Client-Limitierungen dokumentiert. Sie werden weder durch
+eine gelockerte Audience-Prüfung noch durch einen serverseitigen Sonderpfad
+umgangen. Das temporäre `phase0_identity_probe` wurde nach dieser Entscheidung
+entfernt; Phase 1 führt die ersten dauerhaften Read-only-Tools ein.

--- a/docs/development/plugin-concept.md
+++ b/docs/development/plugin-concept.md
@@ -241,7 +241,7 @@ Sicherheitsdomänen.
 | Loxone-Anmeldung | JWT mit `getkey2`, HMAC und Loxone Command Encryption | JWT über die TLS-geschützte API |
 | Anwendungskryptografie | RSA-Schlüsselaustausch und AES-256-CBC für Auth-/Steuerkommandos | ab Firmware 11.2 bei geprüftem TLS nicht erforderlich |
 | HTTP Basic Auth | nicht unterstützt | nicht unterstützt |
-| Reale Ausgangsbasis | verfügbares Testgerät mit Firmware `17.1.7.27`; Prüfung noch ausstehend | Firmwarestände erst durch öffentliche Beta bestätigt |
+| Reale Ausgangsbasis | Firmware `17.1.7.27` auf dem verfügbaren Testgerät bestätigt | Firmwarestände erst durch öffentliche Beta bestätigt |
 
 Der Verbindungsaufbau beginnt lokal mit dem nicht sensitiven
 `jdev/cfg/apiKey`-Probe. Der Adapter wertet Firmware und `httpsStatus` aus:
@@ -693,6 +693,9 @@ weiterhin als experimentell ausweisen.
 
 ### Phase 0: Architektur-Spikes
 
+**Status:** abgeschlossen am 2026-08-03. Die bestätigten Kombinationen und
+bekannten Clientgrenzen stehen in der [Support-Matrix](support-matrix.md).
+
 - Python-Version, venv und Wheels auf allen Zielarchitekturen
 - kleiner Go-Vergleichsbuild nur, falls Wheels oder Ressourcenbudget kritisch
   sind
@@ -768,7 +771,7 @@ Support-Matrix.
 | 2 | erste CPU-Architektur | festgelegt: LoxBerry 4 auf Debian 13, `arm64` |
 | 3 | Runtime | festgelegt: Python 3.13 und MCP-SDK 1.28.1; Wheel-, Start- und RAM-Gates erfolgreich |
 | 4 | öffentlicher Pluginpfad/Apache | exakte MCP-, OAuth- und Well-known-Pfade mit Apache 2.4.68 real bestätigt |
-| 5 | MCP-OAuth-Clientregistrierung und Sessionpersistenz | implementiert und automatisiert bestätigt: öffentliche Registrierung, PKCE S256, audience-gebundene opaque Tokens, Replay-Widerruf und atomare dateibasierte Persistenz; beide Clientprüfungen vor Merge ausstehend |
+| 5 | MCP-OAuth-Clientregistrierung und Sessionpersistenz | implementiert und automatisiert bestätigt: öffentliche Registrierung, PKCE S256, audience-gebundene opaque Tokens, Replay-Widerruf und atomare dateibasierte Persistenz; Claude Desktop vollständig real bestätigt; Codex Login und authentifizierter Aufruf bestätigt, Refresh und Revoke als dokumentierte Client-Limitierungen akzeptiert |
 | 6 | Miniserver-Firmware | Gen. 1 mindestens `17.1.7.27`; Gen.-2-Stände werden durch die öffentliche Beta bestätigt |
 | 7 | erste unterstützte Control-Typen | festgelegt für Phase 2: `Switch` mit explizitem `on` und `off` |
 | 8 | Zeitpunkt und Umfang von `loxberry:read` | festgelegt: erst Phase 3 mit eigener lokaler Freigabe |

--- a/docs/development/support-matrix.md
+++ b/docs/development/support-matrix.md
@@ -1,0 +1,44 @@
+# Support-Matrix
+
+- **Stand:** Abschluss Phase 0, 2026-08-03
+- **Nächster Meilenstein:** Phase 1, Read-only Alpha
+
+Diese Matrix unterscheidet reale Nachweise von implementierten, aber noch nicht
+real bestätigten Kombinationen. Sie ist keine Freigabe eines Installationspakets;
+Pluginlayout, Lifecycle und Admin-UI entstehen erst in Phase 1.
+
+## Plattformen und Geräte
+
+| Komponente | Getesteter Stand | Status | Nachweis und Grenze |
+| --- | --- | --- | --- |
+| LoxBerry | `4.0.0.14`, Debian 13, `aarch64` | `maintainer-tested` | [Python-3.13-Runtime, Offline-Wheels, Apache-Transport und Ressourcenbudgets real bestätigt](phase-0-oauth-test.md#automatisierte-und-zielsystem-nachweise) |
+| LoxBerry 3 und ältere Debian-Basen | nicht getestet | `unsupported` | nicht Teil des anfänglichen Umfangs |
+| Miniserver Gen. 1 | Firmware `17.1.7.27` | `maintainer-tested` | [lokale HTTP-/WS-Anbindung, Command Encryption, JWT, Rechtefilterung, Snapshot, Delta und Reconnect real bestätigt](phase-0-loxone-test.md#runtime-nachweis-für-pr-1) |
+| Miniserver Gen. 1 mit älterer Firmware | nicht getestet | `experimental` | keine Kompatibilitätszusage ohne passenden Nachweis |
+| Miniserver Gen. 2/Compact | keine Maintainer-Hardware | `unsupported` | der Phase-0-Adapter weist TLS-fähige Miniservers ab; Phase 1 beginnt die read-only Implementierung und öffentliche Beta |
+
+`maintainer-tested` gilt nur für die exakt dokumentierte Kombination. Weitere
+Architekturen, LoxBerry-Versionen und Firmwarestände werden nicht daraus
+abgeleitet.
+
+## MCP-Clients
+
+| Client | Getesteter Stand | Phase-0-Ergebnis | Bekannte Grenze |
+| --- | --- | --- | --- |
+| Claude Desktop mit `mcp-remote` | Desktop `1.24012.9`, Bridge `0.1.38` | [Login, MCP-Initialisierung, authentifizierter Aufruf, Refresh und RFC-7009-Widerruf erfolgreich](phase-0-oauth-test.md#reale-clientabnahme) | lokale Bridge mit `http-only`; kein Nachweis für den cloudbasierten Connector |
+| Codex CLI | `0.146.0` | [Login, MCP-Initialisierung und authentifizierter Aufruf erfolgreich](phase-0-oauth-test.md#reale-clientabnahme) | Refresh sendet keinen verpflichtenden RFC-8707-Parameter `resource`; Logout löscht nur lokale Credentials und ruft `/revoke` nicht auf |
+
+Die Codex-Grenzen sind bestätigtes Clientverhalten und werden für den Abschluss
+von Phase 0 ausdrücklich akzeptiert. Der Server lockert weder Audience-Bindung
+noch Widerrufsregeln. Codex-Benutzer müssen sich nach Ablauf des Access Tokens
+erneut anmelden; serverseitige Testsitzungen werden administrativ oder durch
+ihren Ablauf beendet. Phase 1 dokumentiert den späteren operativen
+Sessionwiderruf für reguläre Installationen.
+
+## Nicht abgedeckt
+
+- Es gibt noch kein installierbares Alpha-Paket und keine Lifecycle-Abnahme.
+- Es gibt noch keine Admin-UI und daher keine Browser-Supportaussage.
+- Externer oder cloudbasierter MCP-Zugriff ist nicht freigegeben.
+- Es gibt noch keine veröffentlichten Loxone- oder LoxBerry-Domain-Tools.
+- Schreibende MCP-Tools sind nicht Bestandteil von Phase 0 oder Phase 1.

--- a/docs/development/test-strategy.md
+++ b/docs/development/test-strategy.md
@@ -6,8 +6,8 @@
 Tests werden durch tatsächliche Entwicklungsänderungen ausgelöst. Es gibt keine
 täglichen oder wöchentlichen Pflichtläufe. Gewählt wird der kleinste
 reproduzierbare Prüfumfang, der die Wirkung und das Risiko des Diffs abdeckt.
-Die vollständige deterministische Suite wird später zum Gate für Pull Requests
-und `master`, sobald ausführbarer Code vorhanden ist.
+Die vollständige deterministische Suite ist das Gate für Pull Requests und
+`master`, seit ausführbarer Code vorhanden ist.
 
 ## Testebenen
 
@@ -136,10 +136,9 @@ Test, aber die betreffende Kombination bleibt unbestätigt.
 
 ## CI-Aufbau
 
-Solange noch kein ausführbarer Code vorhanden ist, wird kein Platzhalter-Workflow
-benötigt. Der erste ausführbare Commit führt einen einheitlichen lokalen
-Testbefehl und denselben CI-Pfad ein. CI läuft auf Pull Requests und Pushes nach
-`master` und umfasst mindestens Syntax/Lint, Unit- und MCP-Vertragstests.
+Der einheitliche lokale Testbefehl und derselbe CI-Pfad wurden mit dem ersten
+ausführbaren Stand eingeführt. CI läuft auf Pull Requests und Pushes nach
+`master` und umfasst Syntax/Lint, Unit- und MCP-Vertragstests.
 
 Ein GitHub-Pflichtcheck wird erst aktiviert, wenn sein Name und seine Runtime
 stabil sind. Zielgeräte und echte Miniserver werden nicht aus öffentlicher CI

--- a/src/mcpserver/server.py
+++ b/src/mcpserver/server.py
@@ -1,16 +1,14 @@
-"""Minimal Phase-0 MCP transport with no released domain tools."""
+"""MCP transport foundation with no released domain tools."""
 
 from __future__ import annotations
 
 import logging
 from typing import Final
 
-from mcp.server.auth.middleware.auth_context import get_access_token
 from mcp.server.auth.provider import AccessToken, TokenVerifier
 from mcp.server.auth.settings import AuthSettings
 from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecurityMiddleware, TransportSecuritySettings
-from mcp.types import ToolAnnotations
 from pydantic import AnyHttpUrl
 from starlette.applications import Starlette
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
@@ -179,27 +177,6 @@ def create_server(settings: ServerSettings) -> FastMCP:
             methods=["GET"],
             include_in_schema=False,
         )(oauth_web.authorization_metadata)
-
-        @server.tool(
-            name="phase0_identity_probe",
-            description="Unpublished Phase-0 OAuth identity interoperability probe.",
-            annotations=ToolAnnotations(
-                readOnlyHint=True,
-                destructiveHint=False,
-                idempotentHint=True,
-                openWorldHint=False,
-            ),
-        )
-        async def phase0_identity_probe() -> dict[str, object]:
-            token = get_access_token()
-            if token is None or token.claims is None:
-                raise RuntimeError("Authenticated identity is unavailable")
-            return {
-                "identity": token.claims["identity"],
-                "client_id": token.client_id,
-                "audience": token.claims["audience"],
-                "scope": token.scopes,
-            }
 
     @server.custom_route(  # type: ignore[misc]
         "/healthz", methods=["GET"], include_in_schema=False

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -137,6 +137,26 @@ def test_mcp_initialize_uses_expected_protocol() -> None:
     assert response.json()["result"]["serverInfo"]["name"] == "LoxBerry MCP Server"
 
 
+def test_no_unreleased_domain_tools_are_published() -> None:
+    app = create_server(_settings()).streamable_http_app()
+    request = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/list",
+        "params": {},
+    }
+    headers = {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "Origin": "https://client.example",
+    }
+    with TestClient(app, base_url="http://testserver") as client:
+        response = client.post("/mcp", json=request, headers=headers)
+
+    assert response.status_code == 200
+    assert response.json()["result"]["tools"] == []
+
+
 def test_oauth_routes_and_protected_resource_metadata_are_exact(tmp_path: Path) -> None:
     settings = ServerSettings(
         host="127.0.0.1",


### PR DESCRIPTION
## Summary

- accept the verified Codex CLI refresh and logout behavior as documented client limitations without weakening the OAuth server contract
- remove the temporary `phase0_identity_probe` and add a regression that keeps unreleased domain tools out of the tool list
- add the concrete Phase 0 support matrix and synchronize the OAuth evidence, ADR, plugin concept, test strategy, and project status
- mark Phase 0 complete and Phase 1 Read-only Alpha as the next milestone

## Why

Claude Desktop completed login, authenticated MCP access, refresh, and revocation. Codex CLI completed login and authenticated MCP access, but its bundled OAuth client omits RFC 8707 `resource` during refresh and its logout only deletes local credentials. The maintainer explicitly accepts those two client limitations for Phase 0; the server continues to enforce audience binding and revocation strictly.

## Impact

There are no released domain tools yet. The temporary interoperability probe is removed, while the validated runtime, transport, OAuth, and Gen. 1 Loxone foundations remain available for Phase 1.

## Verification

- `python tools/test.py`: format, Ruff, strict mypy, and 133 tests passed
- targeted `tests/test_server.py`: 12 passed
- local Markdown links: passed
- `git diff --check`: passed

The existing Starlette deprecation warning and the sandbox-only pytest cache warning remain non-failing.