### PR TITLE
Implement Phase 1 read-only alpha

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto eol=lf
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.zip binary
+*.whl binary

--- a/.github/ISSUE_TEMPLATE/gen2-beta.yml
+++ b/.github/ISSUE_TEMPLATE/gen2-beta.yml
@@ -1,0 +1,47 @@
+name: Gen. 2 read-only beta report
+description: Report a complete, sanitized experimental Gen. 2 test
+title: "[Gen2 beta] "
+labels: ["gen2-beta"]
+body:
+  - type: markdown
+    attributes:
+      value: Do not include credentials, tokens, private addresses, full structures, or unmasked states.
+  - type: input
+    id: versions
+    attributes:
+      label: Versions
+      description: Plugin, LoxBerry, architecture, Miniserver firmware, MCP client and version
+    validations:
+      required: true
+  - type: checkboxes
+    id: tls
+    attributes:
+      label: TLS negative cases
+      options:
+        - label: Valid HTTPS/WSS hostname and trusted certificate worked
+          required: true
+        - label: Hostname mismatch failed without cleartext fallback
+          required: true
+        - label: Untrusted or expired certificate failed without cleartext fallback
+          required: true
+  - type: textarea
+    id: tools
+    attributes:
+      label: Six read-only tools and permission filtering
+      description: List expected and observed outcomes for every tool, without sensitive values
+    validations:
+      required: true
+  - type: textarea
+    id: lifecycle
+    attributes:
+      label: Snapshot, deltas, reconnect and revocation
+      description: Describe expected and observed results
+    validations:
+      required: true
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Masked diagnostics
+      description: Paste only the plugin-generated masked diagnostic and sanitized log excerpts
+    validations:
+      required: true

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ Thumbs.db
 *.local
 secrets/
 dist/
+build/
 tmp/
 temp/
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ bekannten Clientgrenzen stehen in der [Support-Matrix](docs/development/support-
 - [Implementierungsrichtlinien](docs/development/implementation-guidelines.md)
 - [Plugin-Konzept](docs/development/plugin-concept.md)
 - [Änderungsgetriebene Teststrategie](docs/development/test-strategy.md)
+- [Entwicklungs- und Testautomatisierung](docs/development/automation.md)
 - [Support-Matrix](docs/development/support-matrix.md)
 - [Recherche-Ergebnisse](docs/research/research-results.md)
 - [Beitragen und Git-Workflow](CONTRIBUTING.md)

--- a/bin/healthcheck
+++ b/bin/healthcheck
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -u
+
+failed=0
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P) || exit 1
+actual_folder=$(basename -- "$script_dir")
+plugin_config="${LBPCONFIG:?}/$actual_folder"
+plugin_data="${LBPDATA:?}/$actual_folder"
+check() {
+    if "$@"; then
+        echo "OK: $*"
+    else
+        echo "FAIL: $*"
+        failed=1
+    fi
+}
+
+check systemctl is-active --quiet loxberry-mcpserver.service
+check curl --fail --silent --show-error --max-time 3 http://127.0.0.1:8765/healthz
+check test -r "$plugin_config/mcpserver.json"
+check test -d "$plugin_data/auth"
+check test -w "$plugin_data/auth"
+
+if [ "$failed" -ne 0 ]; then
+    echo "Health check failed. No repair was attempted."
+    exit 1
+fi
+echo "LoxBerry MCP Server health check passed."

--- a/bin/mcpserver-admin
+++ b/bin/mcpserver-admin
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -u
+exec "${LBPDATA:?}/venv/bin/python" -m mcpserver.admin

--- a/config/apache/mcpserver.conf
+++ b/config/apache/mcpserver.conf
@@ -1,3 +1,4 @@
+# Managed by the LoxBerry MCP Server plugin.
 # Installed as an Apache conf fragment by the LoxBerry root lifecycle hook.
 # The backend remains loopback-only; public host and Origin validation is also
 # enforced by the MCP process.

--- a/config/default-config.json
+++ b/config/default-config.json
@@ -1,0 +1,18 @@
+{
+  "limits": {
+    "max_parallel_calls": 4,
+    "requests_per_minute": 60
+  },
+  "loxone": {
+    "connection_timeout": 10,
+    "endpoint": ""
+  },
+  "schema_version": 1,
+  "server": {
+    "enabled": false,
+    "public_origin": ""
+  },
+  "tools": {
+    "loxone_read_enabled": true
+  }
+}

--- a/config/systemd/loxberry-mcpserver.service.in
+++ b/config/systemd/loxberry-mcpserver.service.in
@@ -1,0 +1,38 @@
+# Managed by the LoxBerry MCP Server plugin.
+[Unit]
+Description=LoxBerry MCP Server
+After=network-online.target apache2.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=loxberry
+Group=loxberry
+UMask=0077
+Environment=PYTHONUNBUFFERED=1
+Environment=MCPSERVER_HOST=127.0.0.1
+Environment=MCPSERVER_PORT=8765
+Environment=MCPSERVER_CONFIG=@CONFIG@
+Environment=MCPSERVER_AUTH_STORE=@SESSIONS@
+Environment=MCPSERVER_LOXONE_TOKEN_STORE=@TOKENS@
+Environment=MCPSERVER_INSTALL_KEY=@KEY@
+Environment=MCPSERVER_ALLOWED_HOSTS=127.0.0.1:8765,localhost:8765,@HOST@,@HOST@:*
+Environment=MCPSERVER_ALLOWED_ORIGINS=https://@HOST@
+ExecStart=@VENV@/bin/mcpserver
+StandardOutput=append:@LOG_DIR@/service.log
+StandardError=append:@LOG_DIR@/service.log
+Restart=on-failure
+RestartSec=5s
+TimeoutStartSec=30s
+TimeoutStopSec=20s
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=@CONFIG_DIR@ @DATA_DIR@ @LOG_DIR@
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+LockPersonality=true
+MemoryDenyWriteExecute=true
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/development/adr/0002-phase-1-read-only-alpha.md
+++ b/docs/development/adr/0002-phase-1-read-only-alpha.md
@@ -1,0 +1,109 @@
+# ADR 0002: Phase-1 Read-only Alpha
+
+- **Status:** Accepted
+- **Date:** 2026-08-03
+- **Release:** `0.1.0-alpha.1`
+
+## Context
+
+Phase 0 established the Python 3.13, MCP 2025-11-25, OAuth 2.1, Apache and
+Loxone protocol boundaries. Phase 1 turns that foundation into a native,
+installable LoxBerry 4 plugin without widening the authorization surface.
+
+The implementation follows the LoxBerry documentation for
+[plugin development](https://wiki.loxberry.de/entwickler/plugin_fur_den_loxberry_entwickeln_ab_version_1x/start),
+[Python plugins](https://wiki.loxberry.de/entwickler/python_develop_plugins_with_python/start),
+[web UI development](https://wiki.loxberry.de/entwickler/web_ui_development_in_loxberry/start),
+[developer tips](https://wiki.loxberry.de/entwickler/entwicker_tipps_und_tricks/start)
+and the [V4 sample plugin](https://github.com/mschlenstedt/LoxBerry-Plugin-SamplePlugin-V4).
+
+## Decision
+
+### Identity and layout
+
+The immutable identity is `NAME=mcpserver`, `FOLDER=mcpserver`, title
+`LoxBerry MCP Server`, Plugin Interface 2.0 and minimum LoxBerry 4.0.0. Hooks
+use LoxBerry's `$LBP*` paths and argument `$3`; a suffixed installation folder
+therefore remains valid. Installed text files use LF line endings.
+
+Persistent files are contracts:
+
+- `LBPCONFIG/mcpserver.json`: authoritative `schema_version: 1` configuration;
+- `LBPDATA/auth/sessions.json`: OAuth clients, hashed credentials and families;
+- `LBPDATA/auth/loxone-tokens.json.enc`: AES-GCM protected Loxone JWT records;
+- `LBPDATA/auth/install.key`: root-created 256-bit installation key.
+
+The key is never packaged or exported. Configuration and sessions survive an
+upgrade. Uninstall removes only external files bearing the plugin marker.
+
+### Runtime and service
+
+The package contains a complete arm64 wheelhouse and creates a plugin-owned
+Python 3.13 virtual environment with `--no-index --no-deps`. It does not import
+the LoxBerry Python SDK. The service runs as `loxberry`, applies `UMask=0077`
+and systemd sandboxing, and binds only `127.0.0.1:8765`. Apache publishes only
+the exact MCP, OAuth and metadata paths. Port or foreign-file conflicts abort
+installation rather than overwrite another owner.
+
+The configuration is disabled by default. In that state only the loopback
+health endpoint remains available; MCP, OAuth and metadata routes fail closed
+with HTTP 503. Validation precedes atomic replace; only a successful write is
+followed by a bounded service restart. The last valid file remains after a failed write.
+Runtime caches and connections are
+separated by immutable OAuth family, Miniserver and Loxone identity. Cache
+values have the explicit freshness states `current`, `stale`, `unknown` and
+`unavailable`.
+
+### Authentication and transports
+
+Only scope `loxone:read` exists. OAuth access, refresh and authorization values
+are stored only as SHA-256 digests. The store limits file size, total clients,
+total active families, families per client and age. Refresh replay revokes the
+whole family. Administrative revocation attempts Loxone `killtoken`, then
+removes the encrypted JWT even when the Miniserver is unavailable.
+
+Gen. 1 accepts only canonical private literal HTTP addresses and uses WS plus
+Loxone Command Encryption. Gen. 2 accepts only canonical HTTPS origins and uses
+WSS with the HTTP and WebSocket libraries' hostname and certificate validation.
+A TLS error never selects HTTP/WS as a fallback. Gen. 2 remains experimental
+until an independent complete report exists.
+
+### MCP contracts
+
+The stable read-only inventory is exactly:
+
+1. `loxone_get_system_status`
+2. `loxone_list_rooms`
+3. `loxone_list_categories`
+4. `loxone_find_controls`
+5. `loxone_describe_control`
+6. `loxone_get_states`
+
+All tools declare `readOnlyHint=true` and `destructiveHint=false`. Their common
+envelope contains `ok`, `data`, `warnings`, `observed_at`, `stale` and
+`trace_id`. Lists use signed opaque cursors with limit 50 by default and 100 at
+most. State requests contain 1–100 unique, visible state UUIDs. Normalization
+excludes controls restricted to internal references and only returns rooms and
+categories referenced by visible controls.
+
+### Administration UI
+
+Perl is only the authenticated native LoxBerry integration layer. It uses
+`LoxBerry::System`, `LoxBerry::Web`, `LoxBerry::Log` and `HTML::Template` in
+`nojqm` mode. All validation, storage, probing and revocation run through the
+narrow Python JSON stdin/stdout helper.
+
+The first layer is server rendered and supports save, connection test and
+revocation with POST/Redirect/Get and no JavaScript. Responsive layout, visible
+focus and touch-sized actions are mandatory from this layer. JavaScript then
+progressively enhances status, connection test and revocation using the same
+CGI and Python handlers. There is no SPA, jQuery Mobile, configuration write via
+`ajax-generic.php`, mandatory polling or AJAX-only navigation.
+
+## Consequences and verification boundary
+
+This change requires the complete deterministic gate, package inspection,
+disabled-JavaScript UI checks, the full responsive viewport matrix and native
+LoxBerry lifecycle tests. Gen. 1 needs a real restricted-user run for all six
+tools, reconnect and revocation. Automated tests can prove the Gen. 2 negative
+TLS boundary but cannot promote real hardware compatibility.

--- a/docs/development/automation.md
+++ b/docs/development/automation.md
@@ -1,0 +1,47 @@
+# Development automation
+
+Use repository scripts for deterministic, shareable work. Keep target-specific
+authorization, connection profiles, credentials, and private test fixtures outside Git.
+
+## Local and CI-safe commands
+
+- `python tools/test.py` runs the deterministic formatting, lint, type, and test gate.
+- `python tools/build_release_candidate.py --runtime-wheelhouse <cache>` rebuilds the
+  project wheel, runs the full gate, builds the plugin twice, requires byte-identical
+  ZIPs, writes the checksum, and verifies the final archive. Omit the cache argument to
+  download the pinned Debian 13/arm64 wheels into a temporary directory.
+- `python tools/verify_plugin.py <archive.zip>` verifies checksum, paths, file modes,
+  LF text files, plugin identity, required entries, and the offline wheelhouse without
+  extracting or installing the archive.
+- `pwsh -File tools/test_mcp_client.ps1` starts the configured Claude MCP proxy and
+  exercises all six read-only tools. Use `-VisibilityFixturePath <private-json>` to add
+  a real visible/hidden-control boundary test. The private JSON contains only
+  `visible_control_uuid` and `hidden_control_uuid` and remains outside Git.
+
+`tools/build_plugin.py` and `tools/prepare_wheelhouse.py` remain useful low-level
+building blocks for focused development. Use the release-candidate wrapper for any
+artifact that is intended for target installation or publication.
+
+## Target-system workflow
+
+Automate orchestration, evidence collection, and sanitized checks, but keep explicit
+boundaries around state-changing operations:
+
+1. Verify the exact target profile and strict host key before transfer.
+2. Compare local and remote SHA-256 before installation.
+3. Prefer the native LoxBerry Plugin Manager or its exact installer command for install,
+   upgrade, and uninstall.
+4. Read the SecurePIN only from an approved external file or interactive input. Never
+   place it in arguments, logs, repository files, or generated evidence.
+5. Run health, service, Apache, ownership, configuration-schema, and MCP read-only
+   smokes after the lifecycle action.
+6. Preserve the installed plugin and configured MCP clients unless the requested test
+   explicitly includes removal.
+
+Replacing individual installed files is a diagnostic shortcut, not release evidence.
+Limit it to plugin-owned paths, save a recoverable copy, preserve owner and mode,
+restart only the affected plugin service, and follow it with a normal package upgrade
+before claiming lifecycle acceptance.
+
+Never automate changes to a Loxone Miniserver, access to a production LoxBerry, or the
+publication of private addresses, identities, configuration, or test fixtures.

--- a/docs/development/gen2-beta-test.md
+++ b/docs/development/gen2-beta-test.md
@@ -1,0 +1,31 @@
+# Experimental Gen. 2 read-only beta test
+
+Gen. 2 is not maintainer-tested. Use only the matching prerelease ZIP and its
+`.sha256` file. Verify the checksum before installation and use a dedicated
+read-only Loxone user. Never attach passwords, tokens, full structure files,
+internal addresses or unmasked state values to a report.
+
+## Test sequence
+
+1. Record plugin, LoxBerry, architecture, Miniserver firmware and MCP client
+   versions.
+2. Back up the current plugin configuration and keep the previous ZIP.
+3. Install through Plugin Manager and run `bin/healthcheck`.
+4. Configure a canonical HTTPS hostname with a valid certificate. Confirm that
+   an invalid hostname, untrusted certificate and expired certificate each fail
+   without HTTP/WS fallback.
+5. Complete OAuth with the restricted user in one supported MCP client.
+6. Run all six tools; confirm rooms, categories, controls and states are limited
+   to that user's visible structure.
+7. Leave the connection open long enough to observe snapshot/delta processing,
+   force one network interruption and confirm reconnect with stale/current
+   transitions.
+8. Revoke the session in the UI and confirm subsequent MCP access fails.
+9. Export the masked diagnostic and report each expected and observed result
+   through the Gen. 2 issue form.
+
+## Rollback
+
+Disable the plugin, reinstall the previous ZIP through Plugin Manager and
+restore only the normal configuration if needed. Do not restore encrypted
+tokens without the matching installation key; authorize clients again instead.

--- a/docs/development/phase-1-acceptance.md
+++ b/docs/development/phase-1-acceptance.md
@@ -1,0 +1,76 @@
+# Phase-1-Abnahmenachweis
+
+- **Stand:** 2026-08-04
+- **Releasekandidat:** `0.1.0-alpha.1`
+- **SHA-256:** `fe33a85aa52cae4e1cb4008d028f72b6abdd75fc811424b7d395e60fbd7329b5`
+
+Dieser Nachweis trennt lokale Regressionen, reale Zielsystemtests und weiterhin
+offene Grenzen. Er enthält keine Zugangsdaten, internen Adressen, Identitäten,
+Steuerungsnamen, UUIDs oder Zustandswerte.
+
+## Automatisiertes Gate
+
+`PYTHONPATH=src .venv/Scripts/python.exe tools/test.py` wurde für den finalen
+Quellstand vollständig ausgeführt:
+
+- Ruff-Formatierung und Ruff-Lint erfolgreich
+- mypy für 19 Quelldateien erfolgreich
+- 172 Pytest-Tests erfolgreich
+- bekannte, nicht blockierende Warnungen: Starlette-`httpx`-Deprecation und ein
+  lokal nicht beschreibbarer Pytest-Cache
+
+Die ergänzten Regressionen decken insbesondere ab:
+
+- lokales Aufräumen eines Login-Tokens, wenn das entfernte `killtoken` nicht
+  erreichbar ist
+- Ausblenden bereits widerrufener Familien in der Administration
+- administrativen Widerruf bei einem nicht mehr entschlüsselbaren historischen
+  Tokenstore
+- Erhalt von Konfiguration, Sessions, verschlüsselten Tokens und
+  Installationsschlüssel über den nativen Upgradepfad
+
+## Reales LoxBerry- und Gen.-1-Ergebnis
+
+Getestet wurde LoxBerry `4.0.0.14` auf Debian 13/aarch64 über die native
+Plugin-Verwaltung. Das reproduzierbare ZIP wurde unverändert übertragen; lokale
+und entfernte SHA-256 stimmten überein.
+
+- Offline-Venv wurde vollständig aus dem Paket aufgebaut.
+- Der native Installer beendete das finale Upgrade mit Status 0 und
+  `Everything seems to be OK`.
+- systemd-Dienst und Loopback-Healthcheck waren aktiv.
+- `schema_version: 1`, Aktivierung und Read-only-Toolfreigabe blieben erhalten.
+- Installationsschlüssel, Sessionstore und verschlüsselter Tokenstore behielten
+  ihre restriktiven Eigentümer- und Dateirechte.
+- Eine neue OAuth-Anmeldung mit Claude Desktop und `mcp-remote 0.1.38` erhielt
+  ausschließlich `loxone:read`.
+- Genau die sechs Phase-1-Tools mit `readOnlyHint=true` und
+  `destructiveHint=false` wurden veröffentlicht und real aufgerufen.
+- Eine sichtbare Teststeuerung war auffindbar und beschreibbar; eine für den
+  Testbenutzer unsichtbare Steuerung erschien nicht. Ein sichtbarer Zustand
+  wurde lesend abgefragt.
+- Nach einem weiteren nativen Upgrade desselben Artefakts funktionierten
+  Toolliste und alle sechs Aufrufe ohne erneute Anmeldung. Damit sind der
+  gemeinsame Erhalt von OAuth-Sitzung, Installationsschlüssel und
+  verschlüsseltem Loxone-Token praktisch bestätigt.
+
+Es wurden keine Steuerbefehle ausgeführt und keine Nutzsteuerung verändert.
+Tokenanlage und Tokenlebenszyklus waren für die OAuth-Abnahme ausdrücklich
+freigegeben.
+
+## Reproduzierbarkeit
+
+Das ZIP wurde zweimal aus demselben frisch aufgebauten arm64-Wheelhouse erzeugt.
+Beide Dateien waren bytegleich und hatten die oben genannte SHA-256-Prüfsumme.
+
+## Noch offene Grenzen
+
+- Der vollständige Kernablauf wurde nicht mit browserweit deaktiviertem
+  JavaScript real wiederholt. Die serverseitigen POST/Redirect/GET-Fallbacks
+  sind automatisiert geprüft.
+- Codex CLI wurde in diesem Abschlusslauf wegen der lokalen
+  Windows-Ausführungsstörung nicht erneut abgenommen; dies blockiert den Server-
+  und Claude-Nachweis nicht.
+- Gen. 2 bleibt ohne unabhängigen vollständigen Hardwarebericht
+  `experimental`.
+- Externer oder cloudbasierter MCP-Zugriff ist nicht freigegeben.

--- a/docs/development/support-matrix.md
+++ b/docs/development/support-matrix.md
@@ -1,7 +1,7 @@
 # Support-Matrix
 
-- **Stand:** Implementierungsstand Phase 1, 2026-08-03
-- **Nächster Meilenstein:** vollständige Gen.-1-End-to-End-Abnahme `0.1.0-alpha.1`
+- **Stand:** Abnahmestand Phase 1, 2026-08-04
+- **Nächster Meilenstein:** Review und Prerelease-Veröffentlichung `0.1.0-alpha.1`
 
 Diese Matrix unterscheidet reale Nachweise von implementierten, aber noch nicht
 real bestätigten Kombinationen. Das Alpha-Paket bleibt ein Prerelease, bis alle
@@ -37,6 +37,9 @@ Sessionwiderruf für reguläre Installationen.
 
 ## Phase-1-Paketnachweis
 
+Der vollständige maskierte Nachweis steht im
+[Phase-1-Abnahmebericht](phase-1-acceptance.md).
+
 - Das Plugin wurde auf LoxBerry `4.0.0.14`, Debian 13/aarch64 über die native
   Plugin-Verwaltung installiert und aktualisiert; Offline-Venv, Icon,
   systemd-Start und Admin-UI waren erfolgreich.
@@ -48,14 +51,19 @@ Sessionwiderruf für reguläre Installationen.
   AJAX-Status und sichtbarer Tastaturfokus wurden ebenfalls real bestätigt.
 - Das ZIP wurde zweimal byteidentisch gebaut und durch seine SHA-256-Prüfsumme
   abgesichert.
+- Eine frische Claude-OAuth-Anmeldung mit ausschließlich `loxone:read`, exakt
+  sechs Read-only-Tools, alle sechs realen Toolaufrufe und die reale
+  Sichtbarkeitsgrenze wurden auf dem installierten Alpha-Paket bestätigt.
+- Nach dem nativen Upgrade desselben finalen Artefakts blieb die Sitzung ohne
+  Neuanmeldung nutzbar. Konfiguration, Sessions, verschlüsselte Tokens und der
+  zugehörige Installationsschlüssel wurden gemeinsam erhalten.
 
 ## Noch nicht als vollständige Phase-1-Abnahme bestätigt
 
-- Deinstallation und anschließende saubere Neuinstallation des finalen ZIPs
-  stehen noch aus.
 - Der vollständige Kernablauf mit im Browser deaktiviertem JavaScript steht noch
   aus; die serverseitigen POST/Redirect/GET-Fallbacks sind automatisiert geprüft.
 - Externer oder cloudbasierter MCP-Zugriff ist nicht freigegeben.
-- Die sechs Phase-1-Loxone-Lesetools sind implementiert; ihre erneute reale
-  Gen.-1-Abnahme im installierten Alpha-Paket steht aus.
+- Codex CLI wurde im finalen Abschlusslauf wegen der lokalen
+  Windows-Ausführungsstörung nicht erneut abgenommen; der bekannte Clientfehler
+  ist für den Server- und Claude-Nachweis nicht blockierend.
 - Schreibende MCP-Tools sind nicht Bestandteil von Phase 0 oder Phase 1.

--- a/docs/development/support-matrix.md
+++ b/docs/development/support-matrix.md
@@ -1,11 +1,11 @@
 # Support-Matrix
 
-- **Stand:** Abschluss Phase 0, 2026-08-03
-- **Nächster Meilenstein:** Phase 1, Read-only Alpha
+- **Stand:** Implementierungsstand Phase 1, 2026-08-03
+- **Nächster Meilenstein:** vollständige Gen.-1-End-to-End-Abnahme `0.1.0-alpha.1`
 
 Diese Matrix unterscheidet reale Nachweise von implementierten, aber noch nicht
-real bestätigten Kombinationen. Sie ist keine Freigabe eines Installationspakets;
-Pluginlayout, Lifecycle und Admin-UI entstehen erst in Phase 1.
+real bestätigten Kombinationen. Das Alpha-Paket bleibt ein Prerelease, bis alle
+unten genannten Phase-1-Abnahmepunkte abgeschlossen sind.
 
 ## Plattformen und Geräte
 
@@ -15,7 +15,7 @@ Pluginlayout, Lifecycle und Admin-UI entstehen erst in Phase 1.
 | LoxBerry 3 und ältere Debian-Basen | nicht getestet | `unsupported` | nicht Teil des anfänglichen Umfangs |
 | Miniserver Gen. 1 | Firmware `17.1.7.27` | `maintainer-tested` | [lokale HTTP-/WS-Anbindung, Command Encryption, JWT, Rechtefilterung, Snapshot, Delta und Reconnect real bestätigt](phase-0-loxone-test.md#runtime-nachweis-für-pr-1) |
 | Miniserver Gen. 1 mit älterer Firmware | nicht getestet | `experimental` | keine Kompatibilitätszusage ohne passenden Nachweis |
-| Miniserver Gen. 2/Compact | keine Maintainer-Hardware | `unsupported` | der Phase-0-Adapter weist TLS-fähige Miniservers ab; Phase 1 beginnt die read-only Implementierung und öffentliche Beta |
+| Miniserver Gen. 2/Compact | keine Maintainer-Hardware | `experimental` | HTTPS/WSS ohne Klartext-Fallback ist implementiert und automatisiert negativ prüfbar; reale Bestätigung erfordert den [vollständigen unabhängigen Betabericht](gen2-beta-test.md) |
 
 `maintainer-tested` gilt nur für die exakt dokumentierte Kombination. Weitere
 Architekturen, LoxBerry-Versionen und Firmwarestände werden nicht daraus
@@ -35,10 +35,27 @@ erneut anmelden; serverseitige Testsitzungen werden administrativ oder durch
 ihren Ablauf beendet. Phase 1 dokumentiert den späteren operativen
 Sessionwiderruf für reguläre Installationen.
 
-## Nicht abgedeckt
+## Phase-1-Paketnachweis
 
-- Es gibt noch kein installierbares Alpha-Paket und keine Lifecycle-Abnahme.
-- Es gibt noch keine Admin-UI und daher keine Browser-Supportaussage.
+- Das Plugin wurde auf LoxBerry `4.0.0.14`, Debian 13/aarch64 über die native
+  Plugin-Verwaltung installiert und aktualisiert; Offline-Venv, Icon,
+  systemd-Start und Admin-UI waren erfolgreich.
+- Der Dienst wurde als aktiv bestätigt. Der deaktivierte Defaultzustand lässt
+  nur den Loopback-Healthcheck zu und beantwortet den veröffentlichten MCP-Pfad
+  fail-safe mit HTTP 503.
+- Die responsive deutsche und englische Admin-UI wurde bei `1280x800`,
+  `900x768`, `390x844`, `360x800` und `320x568` ohne Seitenoverflow geprüft.
+  AJAX-Status und sichtbarer Tastaturfokus wurden ebenfalls real bestätigt.
+- Das ZIP wurde zweimal byteidentisch gebaut und durch seine SHA-256-Prüfsumme
+  abgesichert.
+
+## Noch nicht als vollständige Phase-1-Abnahme bestätigt
+
+- Deinstallation und anschließende saubere Neuinstallation des finalen ZIPs
+  stehen noch aus.
+- Der vollständige Kernablauf mit im Browser deaktiviertem JavaScript steht noch
+  aus; die serverseitigen POST/Redirect/GET-Fallbacks sind automatisiert geprüft.
 - Externer oder cloudbasierter MCP-Zugriff ist nicht freigegeben.
-- Es gibt noch keine veröffentlichten Loxone- oder LoxBerry-Domain-Tools.
+- Die sechs Phase-1-Loxone-Lesetools sind implementiert; ihre erneute reale
+  Gen.-1-Abnahme im installierten Alpha-Paket steht aus.
 - Schreibende MCP-Tools sind nicht Bestandteil von Phase 0 oder Phase 1.

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -47,6 +47,8 @@ best effort `killtoken`.
 
 Deaktiviere zuerst den Dienst in der UI. Bei einer fehlerhaften Vorabversion
 kann das vorherige Plugin-ZIP über den Plugin Manager erneut installiert
-werden. Konfiguration und Sitzungen bleiben beim Upgrade erhalten. Eine
-Deinstallation entfernt Dienst, Apache-Regel und die enge sudoers-Regel nur,
-wenn sie eindeutig dem Plugin gehören.
+werden. Konfiguration, Sitzungen, verschlüsselte Loxone-Tokens und der lokale
+Installationsschlüssel bleiben beim Upgrade gemeinsam erhalten, sodass eine
+gültige Sitzung anschließend ohne erneute Anmeldung weiterverwendet werden
+kann. Eine Deinstallation entfernt Dienst, Apache-Regel und die enge
+sudoers-Regel nur, wenn sie eindeutig dem Plugin gehören.

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -1,0 +1,52 @@
+# LoxBerry MCP Server 0.1.0-alpha.1
+
+## Voraussetzungen
+
+- LoxBerry 4.0.0 oder neuer; Referenzsystem ist 4.0.0.14 auf Debian 13/arm64.
+- Ein eigener Loxone-Benutzer mit möglichst kleinen Leserechten.
+- Gen. 1: private lokale HTTP-Adresse. Gen. 2: gültige HTTPS-Adresse mit
+  vertrauenswürdigem Zertifikat; derzeit experimentell.
+- Keine Zugangsdaten in URLs. Basic Auth wird nicht unterstützt.
+
+## Installation und Einrichtung
+
+Installiere das ZIP über den normalen LoxBerry Plugin Manager. Das Paket bringt
+alle Python-Wheels offline mit. Öffne danach **LoxBerry MCP Server**:
+
+1. Trage die lokale HTTPS-Origin des LoxBerry ein, z. B.
+   `https://loxberry.local`.
+2. Trage den kanonischen Miniserver-Endpunkt ein: Gen. 1 beispielsweise
+   `http://192.168.1.20`, Gen. 2 ausschließlich `https://miniserver.example`.
+3. Prüfe die Verbindung, aktiviere den Dienst und speichere.
+4. Verbinde Codex CLI oder Claude Desktop mit
+   `https://loxberry.local/plugins/mcpserver/mcp` und folge dem OAuth-Login.
+
+Speichern, Verbindungstest und Sitzungswiderruf funktionieren auch ohne
+JavaScript. Mit JavaScript werden Status, Test und Widerruf ohne Seitenwechsel
+aktualisiert.
+
+## Umfang und Betrieb
+
+Die Alpha veröffentlicht ausschließlich die sechs dokumentierten
+`loxone_*`-Lesetools. Sie bietet keine Steuerbefehle, Historie, LoxBerry-Tools,
+Basic Auth oder generischen Kommandos. Ergebnisse entsprechen den Sichtrechten
+des angemeldeten Loxone-Benutzers.
+
+Der englische Healthcheck führt keine Reparatur aus:
+
+```bash
+LBPCONFIG=/actual/config/path LBPDATA=/actual/data/path /actual/bin/healthcheck
+```
+
+Logs erscheinen im LoxBerry-Logviewer. Der Diagnoseexport enthält nur Version,
+Dienststatus, Transportart und maskierte Zähler. Sitzungen können einzeln oder
+gemeinsam widerrufen werden; ein erreichbarer Miniserver erhält zusätzlich
+best effort `killtoken`.
+
+## Rücksetzen
+
+Deaktiviere zuerst den Dienst in der UI. Bei einer fehlerhaften Vorabversion
+kann das vorherige Plugin-ZIP über den Plugin Manager erneut installiert
+werden. Konfiguration und Sitzungen bleiben beim Upgrade erhalten. Eine
+Deinstallation entfernt Dienst, Apache-Regel und die enge sudoers-Regel nur,
+wenn sie eindeutig dem Plugin gehören.

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -45,5 +45,7 @@ best-effort `killtoken`.
 
 Disable the service in the UI first. If a prerelease is faulty, reinstall the
 previous plugin ZIP through Plugin Manager. Configuration and sessions survive
-upgrades. Uninstall removes the service, Apache rule and narrow sudoers rule
-only when their plugin ownership marker matches.
+upgrades together with encrypted Loxone tokens and the local installation key,
+so a still-valid session can continue without another login. Uninstall removes
+the service, Apache rule and narrow sudoers rule only when their plugin
+ownership marker matches.

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -1,0 +1,49 @@
+# LoxBerry MCP Server 0.1.0-alpha.1
+
+## Requirements
+
+- LoxBerry 4.0.0 or newer; the reference target is 4.0.0.14 on Debian 13/arm64.
+- A dedicated Loxone user with the smallest practical read permissions.
+- Gen. 1: a private local HTTP address. Gen. 2: a valid HTTPS address with a
+  trusted certificate; currently experimental.
+- Never put credentials in URLs. Basic Auth is unsupported.
+
+## Installation and setup
+
+Install the ZIP through the normal LoxBerry Plugin Manager. The package contains
+all Python wheels for offline installation. Then open **LoxBerry MCP Server**:
+
+1. Enter the LoxBerry's local HTTPS origin, for example
+   `https://loxberry.local`.
+2. Enter the canonical Miniserver endpoint: for example
+   `http://192.168.1.20` for Gen. 1, or HTTPS only for Gen. 2.
+3. Test the connection, enable the service and save.
+4. Connect Codex CLI or Claude Desktop to
+   `https://loxberry.local/plugins/mcpserver/mcp` and complete OAuth login.
+
+Save, connection test and session revocation remain usable without JavaScript.
+With JavaScript, status, test and revocation update without a page navigation.
+
+## Scope and operation
+
+The alpha publishes only the six documented `loxone_*` read tools. It provides
+no controls, history, LoxBerry tools, Basic Auth or generic commands. Results
+are limited to the permissions of the authenticated Loxone user.
+
+The English healthcheck never repairs the system:
+
+```bash
+LBPCONFIG=/actual/config/path LBPDATA=/actual/data/path /actual/bin/healthcheck
+```
+
+Logs appear in the LoxBerry log viewer. Diagnostic export contains only the
+version, service state, transport kind and masked counts. Sessions can be
+revoked individually or together; an available Miniserver also receives a
+best-effort `killtoken`.
+
+## Rollback
+
+Disable the service in the UI first. If a prerelease is faulty, reinstall the
+previous plugin ZIP through Plugin Manager. Configuration and sessions survive
+upgrades. Uninstall removes the service, Apache rule and narrow sudoers rule
+only when their plugin ownership marker matches.

--- a/icons/icon.svg
+++ b/icons/icon.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title">
+  <title id="title">LoxBerry MCP Server</title>
+  <rect width="128" height="128" rx="24" fill="#2f7d32"/>
+  <path d="M37 30v19H25v30h12v19h18V79h18v19h18V79h12V49H91V30H73v19H55V30H37zm6 31h42v6H43v-6z" fill="#fff"/>
+  <circle cx="43" cy="64" r="4" fill="#2f7d32"/>
+  <circle cx="85" cy="64" r="4" fill="#2f7d32"/>
+</svg>

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -1,0 +1,23 @@
+[AUTHOR]
+NAME=Miraculix2050
+EMAIL=198097126+Miraculix2050@users.noreply.github.com
+
+[PLUGIN]
+VERSION=0.1.0-alpha.1
+NAME=mcpserver
+FOLDER=mcpserver
+TITLE=LoxBerry MCP Server
+WEBSITE=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server
+
+[AUTOUPDATE]
+AUTOMATIC_UPDATES=false
+RELEASECFG=https://raw.githubusercontent.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/master/release.cfg
+PRERELEASECFG=https://raw.githubusercontent.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/master/prerelease.cfg
+
+[SYSTEM]
+REBOOT=false
+LB_MINIMUM=4.0.0
+LB_MAXIMUM=false
+ARCHITECTURE="raspberry"
+CUSTOM_LOGLEVELS=false
+INTERFACE=2.0

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -2,7 +2,8 @@
 set -u
 
 actual_folder=$3
-if [ -z "$actual_folder" ] || [ -z "${LBPBIN:-}" ] || [ -z "${LBPCONFIG:-}" ] || [ -z "${LBPDATA:-}" ] || [ -z "${LBPLOG:-}" ]; then
+installer_root=${6:-}
+if [ -z "$actual_folder" ] || [ -z "$installer_root" ] || [ -z "${LBPBIN:-}" ] || [ -z "${LBPCONFIG:-}" ] || [ -z "${LBPDATA:-}" ] || [ -z "${LBPLOG:-}" ]; then
     echo "<ERROR> LoxBerry did not provide the plugin paths or actual folder."
     exit 2
 fi
@@ -12,6 +13,8 @@ plugin_config="$LBPCONFIG/$actual_folder"
 plugin_data="$LBPDATA/$actual_folder"
 plugin_log="$LBPLOG/$actual_folder"
 config_file="$plugin_config/mcpserver.json"
+upgrade_backup_dir="$installer_root/.mcpserver-upgrade"
+upgrade_backup="$upgrade_backup_dir/mcpserver.json"
 venv="$plugin_data/venv"
 new_venv="$plugin_data/.venv.new.$$"
 old_venv="$plugin_data/.venv.previous.$$"
@@ -24,10 +27,23 @@ trap cleanup EXIT
 mkdir -p "$plugin_config" "$plugin_data/auth" "$plugin_log"
 chmod 700 "$plugin_data/auth"
 
-if [ ! -f "$config_file" ]; then
+if [ -f "$upgrade_backup" ] && [ ! -L "$upgrade_backup" ]; then
+    install -m 600 "$upgrade_backup" "$config_file" || exit 2
+    rm -f -- "$upgrade_backup"
+    echo "<INFO> Existing configuration restored after the upgrade."
+elif [ ! -f "$config_file" ]; then
     cp "$plugin_config/default-config.json" "$config_file"
 fi
 chmod 600 "$config_file"
+
+for auth_file in sessions.json loxone-tokens.json.enc install.key; do
+    upgrade_auth="$upgrade_backup_dir/$auth_file"
+    if [ -f "$upgrade_auth" ] && [ ! -L "$upgrade_auth" ]; then
+        install -m 600 "$upgrade_auth" "$plugin_data/auth/$auth_file" || exit 2
+        rm -f -- "$upgrade_auth"
+    fi
+done
+rmdir "$upgrade_backup_dir" 2>/dev/null || true
 
 if [ ! -d "$wheelhouse" ] || ! find "$wheelhouse" -maxdepth 1 -name '*.whl' -print -quit | grep -q .; then
     echo "<ERROR> Offline wheelhouse is missing from the package."

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -u
+
+actual_folder=$3
+if [ -z "$actual_folder" ] || [ -z "${LBPBIN:-}" ] || [ -z "${LBPCONFIG:-}" ] || [ -z "${LBPDATA:-}" ] || [ -z "${LBPLOG:-}" ]; then
+    echo "<ERROR> LoxBerry did not provide the plugin paths or actual folder."
+    exit 2
+fi
+
+plugin_bin="$LBPBIN/$actual_folder"
+plugin_config="$LBPCONFIG/$actual_folder"
+plugin_data="$LBPDATA/$actual_folder"
+plugin_log="$LBPLOG/$actual_folder"
+config_file="$plugin_config/mcpserver.json"
+venv="$plugin_data/venv"
+new_venv="$plugin_data/.venv.new.$$"
+old_venv="$plugin_data/.venv.previous.$$"
+wheelhouse="$plugin_bin/wheelhouse"
+cleanup() {
+    rm -rf -- "$new_venv"
+}
+trap cleanup EXIT
+
+mkdir -p "$plugin_config" "$plugin_data/auth" "$plugin_log"
+chmod 700 "$plugin_data/auth"
+
+if [ ! -f "$config_file" ]; then
+    cp "$plugin_config/default-config.json" "$config_file"
+fi
+chmod 600 "$config_file"
+
+if [ ! -d "$wheelhouse" ] || ! find "$wheelhouse" -maxdepth 1 -name '*.whl' -print -quit | grep -q .; then
+    echo "<ERROR> Offline wheelhouse is missing from the package."
+    exit 2
+fi
+
+python3.13 -m venv "$new_venv" || exit 2
+"$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" -r "$plugin_bin/runtime-arm64.lock" || exit 2
+"$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" loxberry-mcpserver==0.1.0a1 || exit 2
+if [ -d "$venv" ]; then
+    mv "$venv" "$old_venv" || exit 2
+fi
+if ! mv "$new_venv" "$venv"; then
+    [ ! -d "$old_venv" ] || mv "$old_venv" "$venv"
+    exit 2
+fi
+rewrite_failed=0
+while IFS= read -r -d '' script; do
+    if [ "$(head -n 1 "$script")" = "#!$new_venv/bin/python" ]; then
+        sed -i "1c\\#!$venv/bin/python" "$script" || rewrite_failed=1
+    fi
+done < <(find "$venv/bin" -maxdepth 1 -type f -perm /111 -print0)
+if [ "$rewrite_failed" -ne 0 ]; then
+    rm -rf -- "$venv"
+    [ ! -d "$old_venv" ] || mv "$old_venv" "$venv"
+    exit 2
+fi
+rm -rf -- "$old_venv"
+trap - EXIT
+
+chown -R loxberry:loxberry "$plugin_config" "$plugin_data" "$plugin_log"
+chmod 700 "$plugin_data/venv" "$plugin_data/auth"
+echo "<OK> Python runtime installed offline for plugin folder $actual_folder."
+exit 0

--- a/postroot.sh
+++ b/postroot.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+set -u
+
+marker="# Managed by the LoxBerry MCP Server plugin."
+unit=/etc/systemd/system/loxberry-mcpserver.service
+apache=/etc/apache2/conf-available/loxberry-mcpserver.conf
+sudoers=/etc/sudoers.d/loxberry-mcpserver
+
+actual_folder=$3
+if [ -z "$actual_folder" ] || [ -z "${LBPBIN:-}" ] || [ -z "${LBPCONFIG:-}" ] || [ -z "${LBPDATA:-}" ] || [ -z "${LBPLOG:-}" ]; then
+    echo "<ERROR> LoxBerry plugin paths are unavailable."
+    exit 2
+fi
+plugin_config="$LBPCONFIG/$actual_folder"
+plugin_data="$LBPDATA/$actual_folder"
+plugin_log="$LBPLOG/$actual_folder"
+
+for target in "$unit" "$apache" "$sudoers"; do
+    if [ -e "$target" ] && ! grep -Fqx "$marker" "$target"; then
+        echo "<ERROR> Refusing to overwrite foreign file $target."
+        exit 2
+    fi
+done
+
+if ss -H -ltn 'sport = :8765' | grep -q . && ! systemctl is-active --quiet loxberry-mcpserver.service; then
+    echo "<ERROR> TCP port 8765 is already owned by another service."
+    exit 2
+fi
+if grep -RIl --exclude='loxberry-mcpserver.conf' '/plugins/mcpserver/mcp' /etc/apache2 2>/dev/null | grep -q .; then
+    echo "<ERROR> Another Apache configuration already owns /plugins/mcpserver/mcp."
+    exit 2
+fi
+
+key="$plugin_data/auth/install.key"
+mkdir -p "$plugin_data/auth"
+if [ ! -f "$key" ]; then
+    (umask 0137 && openssl rand 32 > "$key") || exit 2
+fi
+chown root:loxberry "$key"
+chmod 640 "$key"
+
+host=$(hostname -f 2>/dev/null || hostname)
+case "$host" in
+    *[!A-Za-z0-9.-]*|'') echo "<ERROR> Invalid local hostname."; exit 2 ;;
+esac
+
+sed \
+    -e "s|@CONFIG@|$plugin_config/mcpserver.json|g" \
+    -e "s|@SESSIONS@|$plugin_data/auth/sessions.json|g" \
+    -e "s|@TOKENS@|$plugin_data/auth/loxone-tokens.json.enc|g" \
+    -e "s|@KEY@|$key|g" \
+    -e "s|@HOST@|$host|g" \
+    -e "s|@VENV@|$plugin_data/venv|g" \
+    -e "s|@CONFIG_DIR@|$plugin_config|g" \
+    -e "s|@DATA_DIR@|$plugin_data|g" \
+    -e "s|@LOG_DIR@|$plugin_log|g" \
+    "$plugin_config/systemd/loxberry-mcpserver.service.in" > "$unit" || exit 2
+
+cp "$plugin_config/apache/mcpserver.conf" "$apache" || exit 2
+chown root:root "$unit" "$apache"
+chmod 644 "$unit" "$apache"
+{
+    echo "$marker"
+    echo 'loxberry ALL=(root) NOPASSWD: /bin/systemctl restart loxberry-mcpserver.service'
+    echo 'loxberry ALL=(root) NOPASSWD: /bin/systemctl is-active --quiet loxberry-mcpserver.service'
+} > "$sudoers"
+chmod 440 "$sudoers"
+visudo -cf "$sudoers" >/dev/null || { rm -f "$sudoers"; exit 2; }
+
+a2enmod proxy proxy_http >/dev/null || exit 2
+a2enconf loxberry-mcpserver >/dev/null || exit 2
+apache2ctl configtest >/dev/null || { a2disconf loxberry-mcpserver >/dev/null; exit 2; }
+systemctl daemon-reload
+systemctl enable loxberry-mcpserver.service >/dev/null
+systemctl restart loxberry-mcpserver.service
+systemctl reload apache2
+echo "<OK> Service and Apache proxy installed."
+exit 0

--- a/postupgrade.sh
+++ b/postupgrade.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -u
+
+actual_folder=$3
+if [ -z "$actual_folder" ] || [ -z "${LBPCONFIG:-}" ] || [ -z "${LBPDATA:-}" ]; then
+    echo "<ERROR> LoxBerry plugin paths are unavailable."
+    exit 2
+fi
+
+# Schema 1 is the first released configuration. The migration is intentionally
+# idempotent and never replaces an existing configuration or session store.
+plugin_config="$LBPCONFIG/$actual_folder"
+plugin_data="$LBPDATA/$actual_folder"
+if [ ! -f "$plugin_config/mcpserver.json" ]; then
+    cp "$plugin_config/default-config.json" "$plugin_config/mcpserver.json" || exit 2
+fi
+chmod 600 "$plugin_config/mcpserver.json"
+mkdir -p "$plugin_data/auth"
+chmod 700 "$plugin_data/auth"
+echo "<OK> Configuration and sessions retained."
+exit 0

--- a/preinstall.sh
+++ b/preinstall.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -u
+
+if ! command -v python3.13 >/dev/null 2>&1; then
+    echo "<ERROR> Python 3.13 is required."
+    exit 2
+fi
+if [ "$(dpkg --print-architecture 2>/dev/null)" != "arm64" ]; then
+    echo "<ERROR> This alpha package contains arm64 runtime wheels only."
+    exit 2
+fi
+for command in openssl systemctl apache2ctl; do
+    if ! command -v "$command" >/dev/null 2>&1; then
+        echo "<ERROR> Required command $command is unavailable."
+        exit 2
+    fi
+done
+echo "<OK> Runtime prerequisites are available."
+exit 0

--- a/prerelease.cfg
+++ b/prerelease.cfg
@@ -1,0 +1,4 @@
+[AUTOUPDATE]
+VERSION=0.1.0-alpha.1
+ARCHIVEURL=
+INFOURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases

--- a/preupgrade.sh
+++ b/preupgrade.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -u
+
+if [ -z "${LBPCONFIG:-}" ] || [ -z "${LBPDATA:-}" ]; then
+    echo "<ERROR> LoxBerry plugin paths are unavailable."
+    exit 2
+fi
+echo "<INFO> Existing configuration and sessions will be retained."
+exit 0

--- a/preupgrade.sh
+++ b/preupgrade.sh
@@ -1,9 +1,32 @@
 #!/bin/bash
 set -u
 
-if [ -z "${LBPCONFIG:-}" ] || [ -z "${LBPDATA:-}" ]; then
+actual_folder=$3
+installer_root=${6:-}
+if [ -z "$actual_folder" ] || [ -z "$installer_root" ] || [ -z "${LBPCONFIG:-}" ] || [ -z "${LBPDATA:-}" ]; then
     echo "<ERROR> LoxBerry plugin paths are unavailable."
     exit 2
 fi
-echo "<INFO> Existing configuration and sessions will be retained."
+
+config_file="$LBPCONFIG/$actual_folder/mcpserver.json"
+auth_dir="$LBPDATA/$actual_folder/auth"
+backup_dir="$installer_root/.mcpserver-upgrade"
+if [ -e "$backup_dir" ]; then
+    echo "<ERROR> Upgrade backup path is unsafe."
+    exit 2
+fi
+mkdir -p "$backup_dir" || exit 2
+chmod 700 "$backup_dir" || exit 2
+if [ -f "$config_file" ]; then
+    install -m 600 "$config_file" "$backup_dir/mcpserver.json" || exit 2
+    echo "<INFO> Existing configuration saved for the upgrade."
+else
+    echo "<INFO> No existing configuration needs to be saved."
+fi
+for auth_file in sessions.json loxone-tokens.json.enc install.key; do
+    if [ -f "$auth_dir/$auth_file" ]; then
+        install -m 600 "$auth_dir/$auth_file" "$backup_dir/$auth_file" || exit 2
+    fi
+done
+echo "<INFO> Existing sessions, encrypted tokens and installation key saved for the upgrade."
 exit 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loxberry-mcpserver"
-version = "0.0.1"
+version = "0.1.0-alpha.1"
 description = "Local MCP server for LoxBerry and Loxone"
 requires-python = ">=3.13,<3.14"
 license = "Apache-2.0"
 dependencies = [
+    "cryptography==50.0.0",
+    "httpx==0.28.1",
     "idna==3.18",
     "mcp==1.28.1",
     "websockets==17.0.1",

--- a/release.cfg
+++ b/release.cfg
@@ -1,0 +1,4 @@
+[AUTOUPDATE]
+VERSION=0.0.0
+ARCHIVEURL=
+INFOURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server

--- a/src/mcpserver/__init__.py
+++ b/src/mcpserver/__init__.py
@@ -5,6 +5,6 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("loxberry-mcpserver")
 except PackageNotFoundError:  # pragma: no cover - source tree without installation
-    __version__ = "0.0.0"
+    __version__ = "0.1.0-alpha.1"
 
 __all__ = ["__version__"]

--- a/src/mcpserver/admin.py
+++ b/src/mcpserver/admin.py
@@ -13,7 +13,7 @@ from typing import Any, Final
 from uuid import UUID
 
 from mcpserver import __version__
-from mcpserver.auth.loxone_store import EncryptedLoxoneTokenStore
+from mcpserver.auth.loxone_store import EncryptedLoxoneTokenStore, LoxoneTokenStoreError
 from mcpserver.auth.store import AtomicJsonAuthStore
 from mcpserver.config import AtomicConfigStore, ConfigError, PluginConfig
 from mcpserver.loxone.client import LoxoneClient, LoxoneConnectionError, MiniserverEndpoint
@@ -103,6 +103,8 @@ def _sessions() -> list[dict[str, Any]]:
     document = _auth_store().snapshot()
     result = []
     for family_id, record in document["families"].items():
+        if record.get("revoked"):
+            continue
         result.append(
             {
                 "id": family_id,
@@ -155,14 +157,18 @@ def _revoke(family_id: str | None) -> int:
 
         async def kill_tokens() -> None:
             for target, miniserver_id, identity_id in bindings:
-                token = token_store.get(target, miniserver_id, identity_id)
+                try:
+                    token = token_store.get(target, miniserver_id, identity_id)
+                except LoxoneTokenStoreError:
+                    token = None
                 if token is not None:
                     with suppress(LoxoneConnectionError):
                         await client.kill_token(token)
 
         asyncio.run(kill_tokens())
     for target in revoked:
-        token_store.delete(target)
+        with suppress(LoxoneTokenStoreError):
+            token_store.delete(target)
     return len(revoked)
 
 

--- a/src/mcpserver/admin.py
+++ b/src/mcpserver/admin.py
@@ -17,6 +17,7 @@ from mcpserver.auth.loxone_store import EncryptedLoxoneTokenStore, LoxoneTokenSt
 from mcpserver.auth.store import AtomicJsonAuthStore
 from mcpserver.config import AtomicConfigStore, ConfigError, PluginConfig
 from mcpserver.loxone.client import LoxoneClient, LoxoneConnectionError, MiniserverEndpoint
+from mcpserver.loxone.events import LoxoneProtocolError
 
 _MAX_REQUEST_BYTES: Final = 32 * 1024
 _SERVICE: Final = "loxberry-mcpserver.service"
@@ -63,24 +64,39 @@ def _service_active() -> bool:
 
 
 def _restart_service() -> None:
-    result = subprocess.run(
-        ["sudo", "-n", "/bin/systemctl", "restart", _SERVICE],
-        check=False,
-        stdin=subprocess.DEVNULL,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        timeout=15,
-    )
+    try:
+        result = subprocess.run(
+            ["sudo", "-n", "/bin/systemctl", "restart", _SERVICE],
+            check=False,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=15,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise AdminError("the service could not be restarted") from exc
     if result.returncode != 0:
-        raise AdminError("configuration was saved but the service could not be restarted")
+        raise AdminError("the service could not be restarted")
 
 
 def _save(payload: object) -> dict[str, Any]:
     if not isinstance(payload, dict):
         raise AdminError("configuration payload is invalid")
     config = PluginConfig.from_document(payload)
-    _config_store().save(config)
-    _restart_service()
+    store = _config_store()
+    previous = store.load()
+    store.save(config)
+    try:
+        _restart_service()
+    except AdminError as apply_error:
+        try:
+            store.save(previous)
+            _restart_service()
+        except (AdminError, ConfigError) as rollback_error:
+            raise AdminError("configuration apply and rollback failed") from rollback_error
+        raise AdminError(
+            "configuration was not applied; previous configuration restored"
+        ) from apply_error
     return {"configuration": config.to_document(), "applied": True}
 
 
@@ -146,9 +162,12 @@ def _revoke(family_id: str | None) -> int:
                         record["status"] = "revoked"
 
     _auth_store().mutate(mutate)
-    token_store = _token_store()
+    try:
+        token_store = _token_store()
+    except LoxoneTokenStoreError:
+        token_store = None
     config = _config_store().load()
-    if config.loxone_endpoint:
+    if config.loxone_endpoint and token_store is not None:
         client = LoxoneClient(
             MiniserverEndpoint.parse(config.loxone_endpoint),
             client_uuid=_CLIENT_UUID,
@@ -162,13 +181,14 @@ def _revoke(family_id: str | None) -> int:
                 except LoxoneTokenStoreError:
                     token = None
                 if token is not None:
-                    with suppress(LoxoneConnectionError):
+                    with suppress(LoxoneConnectionError, LoxoneProtocolError):
                         await client.kill_token(token)
 
         asyncio.run(kill_tokens())
-    for target in revoked:
-        with suppress(LoxoneTokenStoreError):
-            token_store.delete(target)
+    if token_store is not None:
+        for target in revoked:
+            with suppress(LoxoneTokenStoreError):
+                token_store.delete(target)
     return len(revoked)
 
 

--- a/src/mcpserver/admin.py
+++ b/src/mcpserver/admin.py
@@ -1,0 +1,228 @@
+"""Narrow JSON stdin/stdout boundary used by the authenticated Perl UI."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+from contextlib import suppress
+from pathlib import Path
+from typing import Any, Final
+from uuid import UUID
+
+from mcpserver import __version__
+from mcpserver.auth.loxone_store import EncryptedLoxoneTokenStore
+from mcpserver.auth.store import AtomicJsonAuthStore
+from mcpserver.config import AtomicConfigStore, ConfigError, PluginConfig
+from mcpserver.loxone.client import LoxoneClient, LoxoneConnectionError, MiniserverEndpoint
+
+_MAX_REQUEST_BYTES: Final = 32 * 1024
+_SERVICE: Final = "loxberry-mcpserver.service"
+_CLIENT_UUID: Final = UUID("3f52f6fe-3af0-4d30-a8bb-f429b9da4465")
+
+
+class AdminError(RuntimeError):
+    """A sanitized, user-actionable administrative error."""
+
+
+def _path(name: str, *, suffix: str | None = None) -> Path:
+    value = os.getenv(name, "").strip()
+    path = Path(value)
+    if not value or not path.is_absolute() or (suffix is not None and path.suffix != suffix):
+        raise AdminError("plugin storage is not configured")
+    return path
+
+
+def _config_store() -> AtomicConfigStore:
+    return AtomicConfigStore(_path("MCPSERVER_CONFIG", suffix=".json"))
+
+
+def _auth_store() -> AtomicJsonAuthStore:
+    return AtomicJsonAuthStore(_path("MCPSERVER_AUTH_STORE", suffix=".json"))
+
+
+def _token_store() -> EncryptedLoxoneTokenStore:
+    return EncryptedLoxoneTokenStore(
+        _path("MCPSERVER_LOXONE_TOKEN_STORE", suffix=".enc"),
+        _path("MCPSERVER_INSTALL_KEY", suffix=".key"),
+    )
+
+
+def _service_active() -> bool:
+    result = subprocess.run(
+        ["sudo", "-n", "/bin/systemctl", "is-active", "--quiet", _SERVICE],
+        check=False,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        timeout=5,
+    )
+    return result.returncode == 0
+
+
+def _restart_service() -> None:
+    result = subprocess.run(
+        ["sudo", "-n", "/bin/systemctl", "restart", _SERVICE],
+        check=False,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        timeout=15,
+    )
+    if result.returncode != 0:
+        raise AdminError("configuration was saved but the service could not be restarted")
+
+
+def _save(payload: object) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise AdminError("configuration payload is invalid")
+    config = PluginConfig.from_document(payload)
+    _config_store().save(config)
+    _restart_service()
+    return {"configuration": config.to_document(), "applied": True}
+
+
+async def _test_connection(payload: object) -> dict[str, Any]:
+    if not isinstance(payload, dict) or not isinstance(payload.get("endpoint"), str):
+        raise AdminError("endpoint is required")
+    endpoint = MiniserverEndpoint.parse(payload["endpoint"])
+    try:
+        result = await LoxoneClient(endpoint, client_uuid=_CLIENT_UUID, timeout_seconds=10).probe()
+    except LoxoneConnectionError as exc:
+        raise AdminError(str(exc)) from None
+    return {
+        "reachable": True,
+        "firmware": result.firmware,
+        "transport": "wss" if endpoint.secure else "ws",
+    }
+
+
+def _sessions() -> list[dict[str, Any]]:
+    document = _auth_store().snapshot()
+    result = []
+    for family_id, record in document["families"].items():
+        result.append(
+            {
+                "id": family_id,
+                "client": str(record.get("client_id", ""))[:12],
+                "identity": str(record.get("identity_id", ""))[:12],
+                "expires_at": record.get("expires_at"),
+                "revoked": bool(record.get("revoked", False)),
+            }
+        )
+    return sorted(result, key=lambda item: str(item["id"]))
+
+
+def _revoke(family_id: str | None) -> int:
+    revoked: list[str] = []
+    bindings: list[tuple[str, str, str]] = []
+
+    def mutate(document: dict[str, Any]) -> None:
+        targets = (
+            [family_id]
+            if family_id is not None
+            else [key for key, item in document["families"].items() if not item.get("revoked")]
+        )
+        for target in targets:
+            family = document["families"].get(target)
+            if family is None:
+                continue
+            family["revoked"] = True
+            revoked.append(target)
+            bindings.append(
+                (
+                    target,
+                    str(family.get("miniserver_id", "")),
+                    str(family.get("identity_id", "")),
+                )
+            )
+            for collection in ("codes", "access_tokens", "refresh_tokens"):
+                for record in document[collection].values():
+                    if record.get("family_id") == target:
+                        record["status"] = "revoked"
+
+    _auth_store().mutate(mutate)
+    token_store = _token_store()
+    config = _config_store().load()
+    if config.loxone_endpoint:
+        client = LoxoneClient(
+            MiniserverEndpoint.parse(config.loxone_endpoint),
+            client_uuid=_CLIENT_UUID,
+            timeout_seconds=config.connection_timeout,
+        )
+
+        async def kill_tokens() -> None:
+            for target, miniserver_id, identity_id in bindings:
+                token = token_store.get(target, miniserver_id, identity_id)
+                if token is not None:
+                    with suppress(LoxoneConnectionError):
+                        await client.kill_token(token)
+
+        asyncio.run(kill_tokens())
+    for target in revoked:
+        token_store.delete(target)
+    return len(revoked)
+
+
+def _diagnostic() -> dict[str, Any]:
+    config = _config_store().load()
+    endpoint = MiniserverEndpoint.parse(config.loxone_endpoint) if config.loxone_endpoint else None
+    return {
+        "schema_version": 1,
+        "plugin_version": __version__,
+        "service_active": _service_active(),
+        "enabled": config.enabled,
+        "transport": ("wss" if endpoint is not None and endpoint.secure else "ws")
+        if endpoint is not None
+        else "not_configured",
+        "session_count": len(_sessions()),
+    }
+
+
+def dispatch(request: object) -> dict[str, Any]:
+    if not isinstance(request, dict) or not isinstance(request.get("action"), str):
+        raise AdminError("request is invalid")
+    action = request["action"]
+    payload = request.get("payload", {})
+    if action == "get_config":
+        return {"configuration": _config_store().load().to_document()}
+    if action == "save_config":
+        return _save(payload)
+    if action == "status":
+        return {"version": __version__, "service_active": _service_active()}
+    if action == "test_connection":
+        return asyncio.run(_test_connection(payload))
+    if action == "list_sessions":
+        return {"sessions": _sessions()}
+    if action == "revoke_session":
+        family_id = payload.get("id") if isinstance(payload, dict) else None
+        if not isinstance(family_id, str) or len(family_id) > 128:
+            raise AdminError("session identifier is invalid")
+        return {"revoked": _revoke(family_id)}
+    if action == "revoke_all":
+        return {"revoked": _revoke(None)}
+    if action == "diagnostic":
+        return _diagnostic()
+    raise AdminError("action is not supported")
+
+
+def main() -> None:
+    try:
+        raw = sys.stdin.buffer.read(_MAX_REQUEST_BYTES + 1)
+        if len(raw) > _MAX_REQUEST_BYTES:
+            raise AdminError("request is too large")
+        response = {"ok": True, "data": dispatch(json.loads(raw))}
+    except (AdminError, ConfigError, ValueError, json.JSONDecodeError) as exc:
+        response = {"ok": False, "error": {"code": "invalid_request", "message": str(exc)}}
+    except Exception:
+        response = {
+            "ok": False,
+            "error": {"code": "internal_error", "message": "administrative action failed"},
+        }
+    sys.stdout.write(json.dumps(response, ensure_ascii=True, separators=(",", ":")) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mcpserver/auth/loxone_store.py
+++ b/src/mcpserver/auth/loxone_store.py
@@ -1,0 +1,254 @@
+"""AES-GCM protected storage for renewable Loxone JWTs."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import secrets
+import stat
+import sys
+import threading
+from contextlib import contextmanager, suppress
+from pathlib import Path
+from typing import Any, BinaryIO, Final
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from mcpserver.loxone.client import LoxoneToken
+
+_SCHEMA_VERSION: Final = 1
+
+
+def _lock_file(handle: BinaryIO) -> None:
+    if sys.platform == "win32":  # pragma: win32 cover
+        import msvcrt
+
+        handle.seek(0)
+        if handle.read(1) == b"":
+            handle.seek(0)
+            handle.write(b"0")
+            handle.flush()
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+    else:  # pragma: posix cover
+        import fcntl
+
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+
+
+def _unlock_file(handle: BinaryIO) -> None:
+    if sys.platform == "win32":  # pragma: win32 cover
+        import msvcrt
+
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+    else:  # pragma: posix cover
+        import fcntl
+
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+class LoxoneTokenStoreError(RuntimeError):
+    """The encrypted Loxone token store cannot be used safely."""
+
+
+def _encoded(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode("ascii")
+
+
+def _decoded(value: object) -> bytes:
+    if not isinstance(value, str):
+        raise LoxoneTokenStoreError("encrypted token store is invalid")
+    try:
+        return base64.urlsafe_b64decode(value.encode("ascii"))
+    except (ValueError, UnicodeError) as exc:
+        raise LoxoneTokenStoreError("encrypted token store is invalid") from exc
+
+
+class EncryptedLoxoneTokenStore:
+    """Persist individual Loxone tokens with record-bound authenticated encryption."""
+
+    def __init__(self, path: Path, key_path: Path) -> None:
+        if not path.is_absolute() or not key_path.is_absolute():
+            raise ValueError("token and key paths must be absolute")
+        self.path = path
+        self.key_path = key_path
+        self.lock_path = path.with_name(f".{path.name}.lock")
+        self._lock = threading.RLock()
+        self._key = self._read_key()
+        self._prepare()
+
+    def _read_key(self) -> bytes:
+        try:
+            metadata = self.key_path.lstat()
+            if not stat.S_ISREG(metadata.st_mode) or self.key_path.is_symlink():
+                raise LoxoneTokenStoreError("installation key is not a regular file")
+            key = self.key_path.read_bytes()
+        except LoxoneTokenStoreError:
+            raise
+        except OSError as exc:
+            raise LoxoneTokenStoreError("installation key is unavailable") from exc
+        if len(key) != 32:
+            raise LoxoneTokenStoreError("installation key has an invalid length")
+        return key
+
+    def _prepare(self) -> None:
+        try:
+            self.path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+            os.chmod(self.path.parent, 0o700)
+            with self._locked():
+                if not self.path.exists():
+                    self._write({"schema_version": _SCHEMA_VERSION, "tokens": {}})
+                else:
+                    self._read()
+        except LoxoneTokenStoreError:
+            raise
+        except OSError as exc:
+            raise LoxoneTokenStoreError("encrypted token store cannot be prepared") from exc
+
+    @contextmanager
+    def _locked(self):  # type: ignore[no-untyped-def]
+        with self._lock:
+            try:
+                with self.lock_path.open("a+b") as handle:
+                    os.chmod(self.lock_path, 0o600)
+                    _lock_file(handle)
+                    try:
+                        yield
+                    finally:
+                        _unlock_file(handle)
+            except LoxoneTokenStoreError:
+                raise
+            except OSError as exc:
+                raise LoxoneTokenStoreError("encrypted token store lock failed") from exc
+
+    @staticmethod
+    def _validate(document: object) -> dict[str, Any]:
+        if (
+            not isinstance(document, dict)
+            or set(document) != {"schema_version", "tokens"}
+            or document.get("schema_version") != _SCHEMA_VERSION
+            or not isinstance(document.get("tokens"), dict)
+        ):
+            raise LoxoneTokenStoreError("encrypted token store is invalid")
+        return document
+
+    def _read(self) -> dict[str, Any]:
+        try:
+            metadata = self.path.lstat()
+            if not stat.S_ISREG(metadata.st_mode) or self.path.is_symlink():
+                raise LoxoneTokenStoreError("encrypted token store path is unsafe")
+            return self._validate(json.loads(self.path.read_text(encoding="utf-8")))
+        except LoxoneTokenStoreError:
+            raise
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            raise LoxoneTokenStoreError("encrypted token store is unreadable") from exc
+
+    def _write(self, document: dict[str, Any]) -> None:
+        self._validate(document)
+        temporary = self.path.with_name(f".{self.path.name}.{secrets.token_hex(8)}.tmp")
+        try:
+            descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as handle:
+                json.dump(
+                    document, handle, ensure_ascii=True, separators=(",", ":"), sort_keys=True
+                )
+                handle.write("\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.chmod(temporary, 0o600)
+            os.replace(temporary, self.path)
+            os.chmod(self.path, 0o600)
+        except OSError as exc:
+            with suppress(OSError):
+                temporary.unlink(missing_ok=True)
+            raise LoxoneTokenStoreError("encrypted token store update failed") from exc
+
+    @staticmethod
+    def _aad(family_id: str, miniserver_id: str, identity_id: str) -> bytes:
+        return f"{_SCHEMA_VERSION}\0{family_id}\0{miniserver_id}\0{identity_id}".encode()
+
+    def put(
+        self,
+        family_id: str,
+        miniserver_id: str,
+        identity_id: str,
+        token: LoxoneToken,
+    ) -> None:
+        if not all((family_id, miniserver_id, identity_id, token.value, token.username)):
+            raise ValueError("token metadata must not be empty")
+        plaintext = json.dumps(
+            {
+                "value": token.value,
+                "username": token.username,
+                "hash_key": token.hash_key,
+                "hash_algorithm": token.hash_algorithm,
+                "valid_until": token.valid_until,
+            },
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode()
+        nonce = secrets.token_bytes(12)
+        ciphertext = AESGCM(self._key).encrypt(
+            nonce, plaintext, self._aad(family_id, miniserver_id, identity_id)
+        )
+        with self._locked():
+            document = self._read()
+            document["tokens"][family_id] = {
+                "miniserver_id": miniserver_id,
+                "identity_id": identity_id,
+                "nonce": _encoded(nonce),
+                "ciphertext": _encoded(ciphertext),
+            }
+            self._write(document)
+
+    def get(self, family_id: str, miniserver_id: str, identity_id: str) -> LoxoneToken | None:
+        with self._locked():
+            record = self._read()["tokens"].get(family_id)
+        if record is None:
+            return None
+        if (
+            not isinstance(record, dict)
+            or record.get("miniserver_id") != miniserver_id
+            or record.get("identity_id") != identity_id
+        ):
+            raise LoxoneTokenStoreError("encrypted token binding is invalid")
+        try:
+            plaintext = AESGCM(self._key).decrypt(
+                _decoded(record.get("nonce")),
+                _decoded(record.get("ciphertext")),
+                self._aad(family_id, miniserver_id, identity_id),
+            )
+            value = json.loads(plaintext)
+            if (
+                not isinstance(value, dict)
+                or not isinstance(value.get("value"), str)
+                or not isinstance(value.get("username"), str)
+                or not isinstance(value.get("hash_key"), str)
+                or not isinstance(value.get("hash_algorithm"), str)
+                or not isinstance(value.get("valid_until"), int)
+            ):
+                raise LoxoneTokenStoreError("decrypted Loxone token is invalid")
+        except LoxoneTokenStoreError:
+            raise
+        except Exception as exc:
+            raise LoxoneTokenStoreError("encrypted Loxone token cannot be decrypted") from exc
+        return LoxoneToken(
+            value["value"],
+            value["username"],
+            value["hash_key"],
+            value["hash_algorithm"],
+            value["valid_until"],
+        )
+
+    def delete(self, family_id: str) -> None:
+        with self._locked():
+            document = self._read()
+            if document["tokens"].pop(family_id, None) is not None:
+                self._write(document)
+
+    def family_ids(self) -> tuple[str, ...]:
+        with self._locked():
+            return tuple(sorted(self._read()["tokens"]))

--- a/src/mcpserver/auth/provider.py
+++ b/src/mcpserver/auth/provider.py
@@ -27,6 +27,8 @@ AUTHORIZATION_CODE_TTL: Final = 5 * 60
 ACCESS_TOKEN_TTL: Final = 10 * 60
 REFRESH_FAMILY_TTL: Final = 30 * 24 * 60 * 60
 _MAX_REGISTERED_CLIENTS: Final = 256
+_MAX_ACTIVE_FAMILIES: Final = 256
+_MAX_FAMILIES_PER_CLIENT: Final = 16
 _UNUSED_CLIENT_TTL: Final = 24 * 60 * 60
 
 
@@ -92,11 +94,13 @@ class Phase0OAuthProvider(
         issuer: str,
         resource: str,
         clock: Callable[[], float] = time.time,
+        on_family_revoked: Callable[[str], None] | None = None,
     ) -> None:
         self.store = store
         self.issuer = issuer
         self.resource = resource
         self._clock = clock
+        self._on_family_revoked = on_family_revoked
 
     def now(self) -> int:
         return int(self._clock())
@@ -152,6 +156,8 @@ class Phase0OAuthProvider(
         }
         for family_id in expired_families:
             document["families"].pop(family_id, None)
+            if self._on_family_revoked is not None:
+                self._on_family_revoked(family_id)
         document["codes"] = {
             digest: record
             for digest, record in document["codes"].items()
@@ -194,13 +200,14 @@ class Phase0OAuthProvider(
         resource: str,
         identity_id: str,
         miniserver_id: str,
+        family_id: str | None = None,
     ) -> str:
         if resource != self.resource:
             raise TokenError("invalid_grant", "Resource mismatch")
         raw_code = _opaque_token()
         digest = token_digest(raw_code)
         now = self.now()
-        family_id = secrets.token_hex(16)
+        family_id = family_id or secrets.token_hex(16)
         record = {
             "client_id": client_id,
             "redirect_uri": redirect_uri,
@@ -215,8 +222,19 @@ class Phase0OAuthProvider(
         }
 
         def insert(document: dict[str, Any]) -> None:
+            self._garbage_collect(document)
             if client_id not in document["clients"]:
                 raise TokenError("invalid_client", "Client registration is unavailable")
+            active_families = [
+                item for item in document["families"].values() if not item.get("revoked", False)
+            ]
+            if len(active_families) >= _MAX_ACTIVE_FAMILIES:
+                raise TokenError("invalid_request", "Session capacity reached")
+            if (
+                sum(item.get("client_id") == client_id for item in active_families)
+                >= _MAX_FAMILIES_PER_CLIENT
+            ):
+                raise TokenError("invalid_request", "Client session capacity reached")
             document["codes"][digest] = record
             document["families"][family_id] = {
                 "client_id": client_id,
@@ -342,8 +360,7 @@ class Phase0OAuthProvider(
             refresh_token=raw_refresh,
         )
 
-    @staticmethod
-    def _revoke_family(document: dict[str, Any], family_id: str) -> None:
+    def _revoke_family(self, document: dict[str, Any], family_id: str) -> None:
         family = document["families"].get(family_id)
         if family is not None:
             family["revoked"] = True
@@ -351,6 +368,8 @@ class Phase0OAuthProvider(
             for record in document[collection].values():
                 if record.get("family_id") == family_id:
                     record["status"] = "revoked"
+        if self._on_family_revoked is not None:
+            self._on_family_revoked(family_id)
 
     @staticmethod
     def _refresh_model(raw_token: str, record: dict[str, Any]) -> StoredRefreshToken:

--- a/src/mcpserver/auth/provider.py
+++ b/src/mcpserver/auth/provider.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import secrets
 import time
 from collections.abc import Callable
@@ -23,6 +24,7 @@ from pydantic import AnyUrl
 from mcpserver.auth.store import AtomicJsonAuthStore, token_digest
 
 SCOPE: Final = "loxone:read"
+_LOGGER = logging.getLogger("mcpserver.auth.provider")
 AUTHORIZATION_CODE_TTL: Final = 5 * 60
 ACCESS_TOKEN_TTL: Final = 10 * 60
 REFRESH_FAMILY_TTL: Final = 30 * 24 * 60 * 60
@@ -369,7 +371,13 @@ class Phase0OAuthProvider(
                 if record.get("family_id") == family_id:
                     record["status"] = "revoked"
         if self._on_family_revoked is not None:
-            self._on_family_revoked(family_id)
+            try:
+                self._on_family_revoked(family_id)
+            except Exception as exc:
+                _LOGGER.warning(
+                    "component=oauth severity=WARNING outcome=token_cleanup_failed error_type=%s",
+                    type(exc).__name__,
+                )
 
     @staticmethod
     def _refresh_model(raw_token: str, record: dict[str, Any]) -> StoredRefreshToken:

--- a/src/mcpserver/auth/store.py
+++ b/src/mcpserver/auth/store.py
@@ -19,6 +19,7 @@ from typing import Any, BinaryIO, Final, Protocol, TypeVar, cast
 
 _SCHEMA_VERSION: Final = 1
 _COLLECTIONS: Final = ("clients", "codes", "access_tokens", "refresh_tokens", "families")
+_MAX_STORE_BYTES: Final = 4 * 1024 * 1024
 T = TypeVar("T")
 
 
@@ -149,6 +150,8 @@ class AtomicJsonAuthStore:
 
     def _read_unlocked(self) -> dict[str, Any]:
         try:
+            if self.path.stat().st_size > _MAX_STORE_BYTES:
+                raise AuthStoreError("Auth store exceeds its size limit")
             raw = self.path.read_text(encoding="utf-8")
             return self._validate(json.loads(raw))
         except AuthStoreError:
@@ -158,17 +161,19 @@ class AtomicJsonAuthStore:
 
     def _write_unlocked(self, document: dict[str, Any]) -> None:
         self._validate(document)
+        serialized = json.dumps(
+            document,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        if len(serialized.encode("utf-8")) + 1 > _MAX_STORE_BYTES:
+            raise AuthStoreError("Auth store exceeds its size limit")
         temporary = self.path.with_name(f".{self.path.name}.{secrets.token_hex(8)}.tmp")
         try:
             descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
             with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as handle:
-                json.dump(
-                    document,
-                    handle,
-                    ensure_ascii=True,
-                    separators=(",", ":"),
-                    sort_keys=True,
-                )
+                handle.write(serialized)
                 handle.write("\n")
                 handle.flush()
                 os.fsync(handle.fileno())

--- a/src/mcpserver/auth/web.py
+++ b/src/mcpserver/auth/web.py
@@ -201,7 +201,7 @@ class Phase0OAuthWeb:
         try:
             await LoxoneClient(self.endpoint, client_uuid=self._client_uuid).kill_token(token)
         except LoxoneConnectionError:
-            return False
+            token.destroy()
         transaction.loxone_token = None
         return True
 

--- a/src/mcpserver/auth/web.py
+++ b/src/mcpserver/auth/web.py
@@ -36,6 +36,7 @@ from mcpserver.loxone.client import (
     LoxoneToken,
     MiniserverEndpoint,
 )
+from mcpserver.loxone.events import LoxoneProtocolError
 
 _MAX_FORM_BYTES: Final = 16 * 1024
 _MAX_JSON_BYTES: Final = 32 * 1024
@@ -200,7 +201,7 @@ class Phase0OAuthWeb:
             return True
         try:
             await LoxoneClient(self.endpoint, client_uuid=self._client_uuid).kill_token(token)
-        except LoxoneConnectionError:
+        except (LoxoneConnectionError, LoxoneProtocolError):
             token.destroy()
         transaction.loxone_token = None
         return True

--- a/src/mcpserver/auth/web.py
+++ b/src/mcpserver/auth/web.py
@@ -28,6 +28,7 @@ from pydantic import ValidationError
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 
+from mcpserver.auth.loxone_store import EncryptedLoxoneTokenStore
 from mcpserver.auth.provider import SCOPE, Phase0OAuthProvider
 from mcpserver.loxone.client import (
     LoxoneClient,
@@ -179,11 +180,13 @@ class Phase0OAuthWeb:
         endpoint: MiniserverEndpoint,
         issuer: str,
         resource: str,
+        loxone_store: EncryptedLoxoneTokenStore | None = None,
     ) -> None:
         self.provider = provider
         self.endpoint = endpoint
         self.issuer = issuer
         self.resource = resource
+        self.loxone_store = loxone_store
         self.transactions: dict[str, LoginTransaction] = {}
         self._client_uuid = uuid5(NAMESPACE_URL, issuer)
         self._login_slots = asyncio.Semaphore(2)
@@ -425,13 +428,39 @@ class Phase0OAuthWeb:
                 and transaction.miniserver_id
             ):
                 transaction.phase = "approving"
-                if not await self._kill(transaction):
-                    transaction.phase = "consent"
-                    return _html_page(
-                        "Authorization unavailable",
-                        "<h1>Authorization unavailable</h1>",
-                        status=503,
-                    )
+                family_id: str | None = None
+                if self.loxone_store is None:
+                    if not await self._kill(transaction):
+                        transaction.phase = "consent"
+                        return _html_page(
+                            "Authorization unavailable",
+                            "<h1>Authorization unavailable</h1>",
+                            status=503,
+                        )
+                else:
+                    family_id = secrets.token_hex(16)
+                    token = transaction.loxone_token
+                    if token is None:
+                        transaction.phase = "consent"
+                        return _html_page(
+                            "Authorization unavailable",
+                            "<h1>Authorization unavailable</h1>",
+                            status=503,
+                        )
+                    try:
+                        self.loxone_store.put(
+                            family_id,
+                            transaction.miniserver_id,
+                            transaction.identity_id,
+                            token,
+                        )
+                    except Exception:
+                        transaction.phase = "consent"
+                        return _html_page(
+                            "Authorization unavailable",
+                            "<h1>Authorization unavailable</h1>",
+                            status=503,
+                        )
                 try:
                     code = self.provider.issue_authorization_code(
                         client_id=transaction.client_id,
@@ -440,14 +469,18 @@ class Phase0OAuthWeb:
                         resource=transaction.resource,
                         identity_id=transaction.identity_id,
                         miniserver_id=transaction.miniserver_id,
+                        family_id=family_id,
                     )
                 except TokenError:
+                    if family_id is not None and self.loxone_store is not None:
+                        self.loxone_store.delete(family_id)
                     transaction.phase = "consent"
                     return _html_page(
                         "Authorization unavailable",
                         "<h1>Authorization unavailable</h1>",
                         status=503,
                     )
+                transaction.loxone_token = None
                 transaction.phase = "finished"
                 self.transactions.pop(transaction_id, None)
                 response = _redirect(

--- a/src/mcpserver/config.py
+++ b/src/mcpserver/config.py
@@ -1,0 +1,219 @@
+"""Validated, atomically persisted Phase 1 plugin configuration."""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import secrets
+import stat
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Final
+from urllib.parse import urlsplit
+
+import idna
+
+from mcpserver.loxone.client import MiniserverEndpoint
+
+SCHEMA_VERSION: Final = 1
+DEFAULT_CONNECTION_TIMEOUT: Final = 10.0
+DEFAULT_REQUESTS_PER_MINUTE: Final = 60
+DEFAULT_MAX_PARALLEL_CALLS: Final = 4
+
+
+class ConfigError(ValueError):
+    """The plugin configuration is invalid or cannot be persisted safely."""
+
+
+def _mapping(value: object, *, name: str) -> dict[str, Any]:
+    if not isinstance(value, dict) or any(not isinstance(key, str) for key in value):
+        raise ConfigError(f"{name} must be an object")
+    return value
+
+
+def _boolean(value: object, *, name: str) -> bool:
+    if not isinstance(value, bool):
+        raise ConfigError(f"{name} must be a boolean")
+    return value
+
+
+def _number(value: object, *, name: str, minimum: float, maximum: float) -> float:
+    if not isinstance(value, int | float) or isinstance(value, bool):
+        raise ConfigError(f"{name} must be a number")
+    result = float(value)
+    if not minimum <= result <= maximum:
+        raise ConfigError(f"{name} is outside the supported range")
+    return result
+
+
+def _integer(value: object, *, name: str, minimum: int, maximum: int) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or not minimum <= value <= maximum:
+        raise ConfigError(f"{name} is outside the supported range")
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class PluginConfig:
+    """The small public Phase 1 configuration contract."""
+
+    enabled: bool = False
+    public_origin: str = ""
+    loxone_endpoint: str = ""
+    connection_timeout: float = DEFAULT_CONNECTION_TIMEOUT
+    loxone_read_enabled: bool = True
+    requests_per_minute: int = DEFAULT_REQUESTS_PER_MINUTE
+    max_parallel_calls: int = DEFAULT_MAX_PARALLEL_CALLS
+    _source: dict[str, Any] | None = None
+
+    @classmethod
+    def defaults(cls) -> PluginConfig:
+        return cls(_source={})
+
+    @classmethod
+    def from_document(cls, document: object) -> PluginConfig:
+        root = _mapping(document, name="configuration")
+        if root.get("schema_version") != SCHEMA_VERSION:
+            raise ConfigError("schema_version is unsupported")
+        server = _mapping(root.get("server", {}), name="server")
+        loxone = _mapping(root.get("loxone", {}), name="loxone")
+        tools = _mapping(root.get("tools", {}), name="tools")
+        limits = _mapping(root.get("limits", {}), name="limits")
+
+        enabled = _boolean(server.get("enabled", False), name="server.enabled")
+        public_origin_value = server.get("public_origin", "")
+        if not isinstance(public_origin_value, str) or len(public_origin_value) > 512:
+            raise ConfigError("server.public_origin must be text")
+        public_origin = public_origin_value.strip()
+        if public_origin:
+            parsed_origin = urlsplit(public_origin)
+            if (
+                parsed_origin.scheme != "https"
+                or parsed_origin.hostname is None
+                or parsed_origin.path
+                or parsed_origin.query
+                or parsed_origin.fragment
+                or parsed_origin.username is not None
+                or parsed_origin.password is not None
+            ):
+                raise ConfigError("server.public_origin must be an HTTPS origin")
+            try:
+                origin_host = idna.encode(
+                    parsed_origin.hostname, uts46=True, std3_rules=True
+                ).decode("ascii")
+                origin_port = parsed_origin.port
+            except (idna.IDNAError, ValueError) as exc:
+                raise ConfigError("server.public_origin is not canonical") from exc
+            if ":" in origin_host:
+                origin_host = f"[{origin_host}]"
+            authority = (
+                origin_host if origin_port in {None, 443} else f"{origin_host}:{origin_port}"
+            )
+            if public_origin != f"https://{authority}":
+                raise ConfigError("server.public_origin is not canonical")
+        endpoint_value = loxone.get("endpoint", "")
+        if not isinstance(endpoint_value, str) or len(endpoint_value) > 512:
+            raise ConfigError("loxone.endpoint must be text")
+        endpoint = endpoint_value.strip()
+        if endpoint:
+            try:
+                MiniserverEndpoint.parse(endpoint)
+            except ValueError as exc:
+                raise ConfigError(str(exc)) from exc
+        if enabled and (not endpoint or not public_origin):
+            raise ConfigError("server.public_origin and loxone.endpoint are required when enabled")
+
+        timeout = _number(
+            loxone.get("connection_timeout", DEFAULT_CONNECTION_TIMEOUT),
+            name="loxone.connection_timeout",
+            minimum=1,
+            maximum=60,
+        )
+        read_enabled = _boolean(
+            tools.get("loxone_read_enabled", True), name="tools.loxone_read_enabled"
+        )
+        if enabled and not read_enabled:
+            raise ConfigError("the Phase 1 service requires tools.loxone_read_enabled")
+        requests = _integer(
+            limits.get("requests_per_minute", DEFAULT_REQUESTS_PER_MINUTE),
+            name="limits.requests_per_minute",
+            minimum=1,
+            maximum=600,
+        )
+        parallel = _integer(
+            limits.get("max_parallel_calls", DEFAULT_MAX_PARALLEL_CALLS),
+            name="limits.max_parallel_calls",
+            minimum=1,
+            maximum=32,
+        )
+        return cls(
+            enabled=enabled,
+            public_origin=public_origin,
+            loxone_endpoint=endpoint,
+            connection_timeout=timeout,
+            loxone_read_enabled=read_enabled,
+            requests_per_minute=requests,
+            max_parallel_calls=parallel,
+            _source=copy.deepcopy(root),
+        )
+
+    def to_document(self) -> dict[str, Any]:
+        document = copy.deepcopy(self._source) if self._source is not None else {}
+        document["schema_version"] = SCHEMA_VERSION
+        for key in ("server", "loxone", "tools", "limits"):
+            current = document.get(key)
+            if not isinstance(current, dict):
+                document[key] = {}
+        document["server"]["enabled"] = self.enabled
+        document["server"]["public_origin"] = self.public_origin
+        document["loxone"]["endpoint"] = self.loxone_endpoint
+        document["loxone"]["connection_timeout"] = self.connection_timeout
+        document["tools"]["loxone_read_enabled"] = self.loxone_read_enabled
+        document["limits"]["requests_per_minute"] = self.requests_per_minute
+        document["limits"]["max_parallel_calls"] = self.max_parallel_calls
+        return document
+
+
+class AtomicConfigStore:
+    """Read and atomically replace the authoritative JSON configuration."""
+
+    def __init__(self, path: Path) -> None:
+        if not path.is_absolute() or path.suffix.lower() != ".json":
+            raise ValueError("configuration path must be an absolute JSON file")
+        self.path = path
+
+    def load(self) -> PluginConfig:
+        if not self.path.exists():
+            return PluginConfig.defaults()
+        try:
+            metadata = self.path.lstat()
+            if not stat.S_ISREG(metadata.st_mode) or self.path.is_symlink():
+                raise ConfigError("configuration path is not a regular file")
+            return PluginConfig.from_document(json.loads(self.path.read_text(encoding="utf-8")))
+        except ConfigError:
+            raise
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            raise ConfigError("configuration is unreadable") from exc
+
+    def save(self, config: PluginConfig) -> None:
+        document = config.to_document()
+        PluginConfig.from_document(document)
+        temporary: Path | None = None
+        try:
+            self.path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+            temporary = self.path.with_name(f".{self.path.name}.{secrets.token_hex(8)}.tmp")
+            descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as handle:
+                json.dump(document, handle, ensure_ascii=True, sort_keys=True, indent=2)
+                handle.write("\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.chmod(temporary, 0o600)
+            os.replace(temporary, self.path)
+            os.chmod(self.path, 0o600)
+        except OSError as exc:
+            if temporary is not None:
+                with suppress(OSError):
+                    temporary.unlink(missing_ok=True)
+            raise ConfigError("configuration update failed") from exc

--- a/src/mcpserver/loxone/client.py
+++ b/src/mcpserver/loxone/client.py
@@ -6,6 +6,7 @@ import asyncio
 import ipaddress
 import json
 import logging
+import re
 from collections.abc import AsyncIterator, Mapping
 from dataclasses import dataclass, field
 from typing import Any, Final
@@ -62,11 +63,60 @@ def _loxone_uuid(value: UUID) -> str:
 
 @dataclass(frozen=True, slots=True)
 class MiniserverEndpoint:
-    """A literal private Gen. 1 HTTP endpoint without path or credentials."""
+    """A canonical generation-aware Miniserver origin without credentials."""
 
     origin: str
     host: str
     port: int
+    secure: bool = False
+
+    @classmethod
+    def parse(cls, value: str) -> MiniserverEndpoint:
+        parsed = urlsplit(value)
+        if parsed.scheme == "http":
+            return cls.parse_gen1(value)
+        if (
+            parsed.scheme != "https"
+            or parsed.hostname is None
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.path not in {"", "/"}
+            or parsed.query
+            or parsed.fragment
+            or "%" in parsed.netloc
+            or "\\" in parsed.netloc
+        ):
+            raise ValueError("Gen. 2 endpoint must be an HTTPS origin without credentials")
+        host = parsed.hostname.lower()
+        try:
+            address = ipaddress.ip_address(host)
+            canonical_host = f"[{address}]" if address.version == 6 else str(address)
+            host = str(address)
+        except ValueError:
+            if (
+                len(host) > 253
+                or host.endswith(".")
+                or any(
+                    not label
+                    or len(label) > 63
+                    or label.startswith("-")
+                    or label.endswith("-")
+                    or re.fullmatch(r"[a-z0-9-]+", label) is None
+                    for label in host.split(".")
+                )
+            ):
+                raise ValueError("Gen. 2 endpoint contains an invalid hostname") from None
+            canonical_host = host
+        try:
+            port = parsed.port or 443
+        except ValueError as exc:
+            raise ValueError("Gen. 2 endpoint contains an invalid port") from exc
+        if not 1 <= port <= 65535:
+            raise ValueError("Gen. 2 endpoint contains an invalid port")
+        origin = f"https://{canonical_host}" if port == 443 else f"https://{canonical_host}:{port}"
+        if value.rstrip("/") != origin:
+            raise ValueError("Gen. 2 endpoint must use a canonical HTTPS origin")
+        return cls(origin=origin, host=host, port=port, secure=True)
 
     @classmethod
     def parse_gen1(cls, value: str) -> MiniserverEndpoint:
@@ -97,13 +147,15 @@ class MiniserverEndpoint:
         origin = f"http://{host}" if port == 80 else f"http://{host}:{port}"
         if value.rstrip("/") != origin:
             raise ValueError("Gen. 1 endpoint must use a canonical origin")
-        return cls(origin=origin, host=str(address), port=port)
+        return cls(origin=origin, host=str(address), port=port, secure=False)
 
     @property
     def websocket_url(self) -> str:
         host = f"[{self.host}]" if ":" in self.host else self.host
-        authority = host if self.port == 80 else f"{host}:{self.port}"
-        return f"ws://{authority}/ws/rfc6455"
+        default_port = 443 if self.secure else 80
+        authority = host if self.port == default_port else f"{host}:{self.port}"
+        scheme = "wss" if self.secure else "ws"
+        return f"{scheme}://{authority}/ws/rfc6455"
 
 
 @dataclass(frozen=True, slots=True)
@@ -287,8 +339,10 @@ class LoxoneClient:
         if not isinstance(value, Mapping):
             raise LoxoneConnectionError("Miniserver probe returned an invalid value")
         https_status = value.get("httpsStatus")
-        if https_status not in {None, 0, "0"}:
+        if not self.endpoint.secure and https_status not in {None, 0, "0"}:
             raise LoxoneConnectionError("TLS-capable Miniservers require the Gen. 2 HTTPS adapter")
+        if self.endpoint.secure and https_status in {None, 0, "0"}:
+            raise LoxoneConnectionError("Gen. 2 endpoint did not confirm TLS support")
         firmware = value.get("version", value.get("versionStr"))
         serial = value.get("snr", value.get("serialNr"))
         if not isinstance(firmware, str) or not isinstance(serial, str):
@@ -337,25 +391,26 @@ class LoxoneClient:
             raise LoxoneConnectionError("Miniserver WebSocket connection failed") from exc
 
     async def acquire_token(self, username: str, password: str) -> LoxoneToken:
-        public_key = await self.websocket_public_key()
         escaped_user = quote(username, safe="")
         websocket = await self._connect_websocket()
         encryptor = CommandEncryptor.generate()
         try:
-            session_key = encryptor.encrypted_session_key(public_key)
-            await _websocket_command(
-                websocket,
-                encryptor,
-                f"jdev/sys/keyexchange/{session_key}",
-                encrypted=False,
-                timeout_seconds=self.timeout_seconds,
-                max_payload_bytes=self.max_response_bytes,
-            )
+            if not self.endpoint.secure:
+                public_key = await self.websocket_public_key()
+                session_key = encryptor.encrypted_session_key(public_key)
+                await _websocket_command(
+                    websocket,
+                    encryptor,
+                    f"jdev/sys/keyexchange/{session_key}",
+                    encrypted=False,
+                    timeout_seconds=self.timeout_seconds,
+                    max_payload_bytes=self.max_response_bytes,
+                )
             key_value = await _websocket_command(
                 websocket,
                 encryptor,
                 f"jdev/sys/getkey2/{escaped_user}",
-                encrypted=True,
+                encrypted=not self.endpoint.secure,
                 timeout_seconds=self.timeout_seconds,
                 max_payload_bytes=self.max_response_bytes,
             )
@@ -380,7 +435,7 @@ class LoxoneClient:
                 websocket,
                 encryptor,
                 command,
-                encrypted=True,
+                encrypted=not self.endpoint.secure,
                 timeout_seconds=self.timeout_seconds,
                 max_payload_bytes=self.max_response_bytes,
             )
@@ -412,7 +467,9 @@ class LoxoneClient:
     async def open_session(self, token: LoxoneToken) -> LoxoneWebSocketSession:
         if not token.value:
             raise LoxoneConnectionError("Loxone token is no longer available")
-        public_key = await self.websocket_public_key()
+        public_key = ""
+        if not self.endpoint.secure:
+            public_key = await self.websocket_public_key()
         websocket = await self._connect_websocket()
         session = LoxoneWebSocketSession(
             websocket,
@@ -420,6 +477,7 @@ class LoxoneClient:
             token=token,
             timeout_seconds=self.timeout_seconds,
             max_payload_bytes=self.max_response_bytes,
+            secure_transport=self.endpoint.secure,
         )
         try:
             await session.authenticate()
@@ -440,12 +498,14 @@ class LoxoneWebSocketSession:
         token: LoxoneToken,
         timeout_seconds: float,
         max_payload_bytes: int,
+        secure_transport: bool = False,
     ) -> None:
         self._websocket = websocket
         self._public_key = public_key
         self._token = token
         self._timeout = timeout_seconds
         self._max_payload = max_payload_bytes
+        self._secure_transport = secure_transport
         self._encryptor = CommandEncryptor.generate()
 
     async def _receive(self) -> tuple[MessageHeader, str | bytes | None]:
@@ -466,16 +526,17 @@ class LoxoneWebSocketSession:
         )
 
     async def authenticate(self) -> None:
-        session_key = self._encryptor.encrypted_session_key(self._public_key)
-        await self._command(f"jdev/sys/keyexchange/{session_key}")
+        if not self._secure_transport:
+            session_key = self._encryptor.encrypted_session_key(self._public_key)
+            await self._command(f"jdev/sys/keyexchange/{session_key}")
         digest = await self._fresh_token_digest()
         await self._command(
             f"authwithtoken/{digest}/{quote(self._token.username, safe='')}",
-            encrypted=True,
+            encrypted=not self._secure_transport,
         )
 
     async def _fresh_token_digest(self) -> str:
-        key = await self._command("jdev/sys/getkey", encrypted=True)
+        key = await self._command("jdev/sys/getkey", encrypted=not self._secure_transport)
         if not isinstance(key, str):
             raise LoxoneConnectionError("Miniserver returned an invalid token hashing key")
         return token_hmac(self._token.value, key, self._token.hash_algorithm)
@@ -499,7 +560,9 @@ class LoxoneWebSocketSession:
         """Rotate the in-memory JWT over the authenticated encrypted WebSocket."""
         digest = await self._fresh_token_digest()
         user = quote(self._token.username, safe="")
-        value = await self._command(f"jdev/sys/refreshjwt/{digest}/{user}", encrypted=True)
+        value = await self._command(
+            f"jdev/sys/refreshjwt/{digest}/{user}", encrypted=not self._secure_transport
+        )
         if not isinstance(value, Mapping):
             raise LoxoneConnectionError("Miniserver returned an invalid refreshed token")
         refreshed = value.get("token")
@@ -514,7 +577,9 @@ class LoxoneWebSocketSession:
         digest = await self._fresh_token_digest()
         user = quote(self._token.username, safe="")
         try:
-            await self._command(f"jdev/sys/killtoken/{digest}/{user}", encrypted=True)
+            await self._command(
+                f"jdev/sys/killtoken/{digest}/{user}", encrypted=not self._secure_transport
+            )
         except ConnectionClosedOK:
             # A Miniserver may close the authenticated connection immediately
             # after invalidating the connection token. A normal close is the

--- a/src/mcpserver/loxone/runtime.py
+++ b/src/mcpserver/loxone/runtime.py
@@ -1,0 +1,182 @@
+"""User-isolated Loxone connection and cache lifecycle for read-only tools."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import defaultdict, deque
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager, suppress
+from dataclasses import dataclass
+from uuid import NAMESPACE_URL, uuid5
+
+from mcpserver.auth.loxone_store import EncryptedLoxoneTokenStore, LoxoneTokenStoreError
+from mcpserver.auth.provider import StoredAccessToken
+from mcpserver.loxone.cache import UserStateCache
+from mcpserver.loxone.client import (
+    LoxoneClient,
+    LoxoneConnectionError,
+    LoxoneToken,
+    LoxoneWebSocketSession,
+)
+from mcpserver.loxone.models import Control, LoxoneStructure, StateRecord
+
+_LOXONE_EPOCH_UNIX = 1_230_768_000
+_REFRESH_BEFORE_SECONDS = 24 * 60 * 60
+
+
+class RuntimeUnavailable(RuntimeError):
+    """The identity-bound Loxone runtime is not currently available."""
+
+
+def _state_uuids(controls: tuple[Control, ...]) -> frozenset[str]:
+    result: set[str] = set()
+    for control in controls:
+        result.update(uuid for _name, uuid in control.state_uuids)
+        result.update(_state_uuids(control.subcontrols))
+    return frozenset(result)
+
+
+@dataclass(slots=True)
+class RuntimeSnapshot:
+    subject: str
+    structure: LoxoneStructure
+    connected: bool
+
+
+@dataclass(slots=True)
+class _ConnectionRecord:
+    structure: LoxoneStructure
+    allowed_states: frozenset[str]
+    session: LoxoneWebSocketSession
+    task: asyncio.Task[None]
+    connected: bool = True
+
+
+class LoxoneRuntime:
+    """Create one bounded live read session per immutable OAuth family."""
+
+    def __init__(
+        self,
+        endpoint: object,
+        token_store: EncryptedLoxoneTokenStore,
+        *,
+        timeout_seconds: float = 10.0,
+        requests_per_minute: int = 60,
+        max_parallel_calls: int = 4,
+    ) -> None:
+        from mcpserver.loxone.client import MiniserverEndpoint
+
+        if not isinstance(endpoint, MiniserverEndpoint):
+            raise TypeError("endpoint must be a MiniserverEndpoint")
+        self.endpoint = endpoint
+        self.token_store = token_store
+        self.client = LoxoneClient(
+            endpoint,
+            client_uuid=uuid5(NAMESPACE_URL, "https://loxberry.local/plugins/mcpserver"),
+            timeout_seconds=timeout_seconds,
+        )
+        self.cache = UserStateCache()
+        self._records: dict[str, _ConnectionRecord] = {}
+        self._locks: defaultdict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
+        self._rate: defaultdict[str, deque[float]] = defaultdict(deque)
+        self._rate_limit = requests_per_minute
+        self._parallel = asyncio.Semaphore(max_parallel_calls)
+
+    @asynccontextmanager
+    async def call_slot(self, access: StoredAccessToken) -> AsyncIterator[None]:
+        if "loxone:read" not in access.scopes:
+            raise PermissionError("loxone:read scope is required")
+        now = time.monotonic()
+        values = self._rate[access.family_id]
+        while values and values[0] <= now - 60:
+            values.popleft()
+        if len(values) >= self._rate_limit:
+            raise RuntimeUnavailable("request rate limit exceeded")
+        values.append(now)
+        async with self._parallel:
+            yield
+
+    async def snapshot(self, access: StoredAccessToken) -> RuntimeSnapshot:
+        subject = access.family_id
+        record = self._records.get(subject)
+        if record is None or record.task.done():
+            async with self._locks[subject]:
+                record = self._records.get(subject)
+                if record is None or record.task.done():
+                    record = await self._connect(access)
+                    self._records[subject] = record
+        return RuntimeSnapshot(
+            subject, record.structure, record.connected and not record.task.done()
+        )
+
+    async def _connect(self, access: StoredAccessToken) -> _ConnectionRecord:
+        try:
+            token = self.token_store.get(access.family_id, access.miniserver_id, access.identity_id)
+        except LoxoneTokenStoreError as exc:
+            raise RuntimeUnavailable("Loxone authorization is unavailable") from exc
+        if token is None:
+            raise RuntimeUnavailable("Loxone authorization is unavailable")
+        try:
+            session = await self.client.open_session(token)
+            structure = await session.load_structure()
+        except LoxoneConnectionError as exc:
+            raise RuntimeUnavailable("Miniserver connection failed") from exc
+        allowed = _state_uuids(structure.controls)
+        self.cache.begin_connection(access.family_id)
+        placeholder = asyncio.create_task(asyncio.sleep(0))
+        record = _ConnectionRecord(structure, allowed, session, placeholder)
+        record.task = asyncio.create_task(self._maintain(access, token, record))
+        return record
+
+    async def _maintain(
+        self,
+        access: StoredAccessToken,
+        token: LoxoneToken,
+        record: _ConnectionRecord,
+    ) -> None:
+        events = asyncio.create_task(self._pump_events(access.family_id, record))
+        try:
+            while not events.done():
+                refresh_at = token.valid_until + _LOXONE_EPOCH_UNIX - _REFRESH_BEFORE_SECONDS
+                timeout = max(1.0, min(3600.0, refresh_at - time.time()))
+                done, _pending = await asyncio.wait({events}, timeout=timeout)
+                if done:
+                    await events
+                    break
+                if refresh_at <= time.time():
+                    await record.session.refresh_token()
+                    self.token_store.put(
+                        access.family_id,
+                        access.miniserver_id,
+                        access.identity_id,
+                        token,
+                    )
+        except Exception:
+            record.connected = False
+            self.cache.disconnect(access.family_id)
+        finally:
+            events.cancel()
+            with suppress(asyncio.CancelledError):
+                await events
+            await record.session.close()
+
+    async def _pump_events(self, subject: str, record: _ConnectionRecord) -> None:
+        async for event_batch in record.session.state_events():
+            self.cache.apply(subject, event_batch, allowed_uuids=record.allowed_states)
+
+    def state(self, snapshot: RuntimeSnapshot, uuid: str) -> StateRecord:
+        return self.cache.get(snapshot.subject, uuid)
+
+    async def revoke(self, family_id: str) -> None:
+        record = self._records.pop(family_id, None)
+        if record is not None:
+            record.task.cancel()
+            with suppress(asyncio.CancelledError):
+                await record.task
+        self.cache.clear(family_id)
+        self.token_store.delete(family_id)
+
+    async def close(self) -> None:
+        for family_id in tuple(self._records):
+            await self.revoke(family_id)

--- a/src/mcpserver/server.py
+++ b/src/mcpserver/server.py
@@ -1,4 +1,4 @@
-"""MCP transport foundation with no released domain tools."""
+"""Loopback MCP transport with the Phase 1 read-only tool surface."""
 
 from __future__ import annotations
 
@@ -17,10 +17,13 @@ from starlette.responses import JSONResponse, Response
 from starlette.types import ASGIApp
 
 from mcpserver import __version__
+from mcpserver.auth.loxone_store import EncryptedLoxoneTokenStore
 from mcpserver.auth.provider import SCOPE, Phase0OAuthProvider
 from mcpserver.auth.store import AtomicJsonAuthStore
 from mcpserver.auth.web import Phase0OAuthWeb
+from mcpserver.loxone.runtime import LoxoneRuntime
 from mcpserver.settings import ServerSettings
+from mcpserver.tools import register_read_tools
 
 SERVER_NAME: Final = "LoxBerry MCP Server"
 _TRANSPORT_LOGGER_NAME: Final = "mcp.server.transport_security"
@@ -90,15 +93,30 @@ class _TransportValidationMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
 
 
+class _DisabledServiceMiddleware(BaseHTTPMiddleware):
+    """Keep health available while failing closed for all public protocol routes."""
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        if request.url.path != "/healthz":
+            return JSONResponse(
+                {"ok": False, "error": "service_disabled"},
+                status_code=503,
+            )
+        return await call_next(request)
+
+
 class _ForwardedHostFastMCP(FastMCP):
     """FastMCP application that also validates Apache's original Host header."""
 
     forwarded_allowed_hosts: tuple[str, ...] = ()
     transport_guard: TransportSecurityMiddleware | None = None
+    service_enabled: bool = True
 
     def streamable_http_app(self) -> Starlette:
         app = super().streamable_http_app()
         app.router.redirect_slashes = False
+        if not self.service_enabled:
+            app.add_middleware(_DisabledServiceMiddleware)
         app.add_middleware(
             _ForwardedHostValidationMiddleware,
             allowed_hosts=self.forwarded_allowed_hosts,
@@ -129,18 +147,30 @@ def create_server(settings: ServerSettings) -> FastMCP:
     oauth_web: Phase0OAuthWeb | None = None
     oauth_auth: AuthSettings | None = None
     token_verifier: _Phase0TokenVerifier | None = None
+    runtime: LoxoneRuntime | None = None
     if settings.phase0_auth is not None:
         auth_store = AtomicJsonAuthStore(settings.phase0_auth.store_path)
+        loxone_store: EncryptedLoxoneTokenStore | None = None
+        if (
+            settings.phase0_auth.loxone_store_path is not None
+            and settings.phase0_auth.install_key_path is not None
+        ):
+            loxone_store = EncryptedLoxoneTokenStore(
+                settings.phase0_auth.loxone_store_path,
+                settings.phase0_auth.install_key_path,
+            )
         provider = Phase0OAuthProvider(
             auth_store,
             issuer=settings.phase0_auth.issuer_url,
             resource=settings.phase0_auth.resource_url,
+            on_family_revoked=loxone_store.delete if loxone_store is not None else None,
         )
         oauth_web = Phase0OAuthWeb(
             provider,
             endpoint=settings.phase0_auth.loxone_endpoint,
             issuer=settings.phase0_auth.issuer_url,
             resource=settings.phase0_auth.resource_url,
+            loxone_store=loxone_store,
         )
         oauth_auth = AuthSettings(
             issuer_url=AnyHttpUrl(settings.phase0_auth.issuer_url),
@@ -148,6 +178,15 @@ def create_server(settings: ServerSettings) -> FastMCP:
             required_scopes=[SCOPE],
         )
         token_verifier = _Phase0TokenVerifier(provider)
+        if loxone_store is not None:
+            config = settings.phase0_auth.plugin_config
+            runtime = LoxoneRuntime(
+                settings.phase0_auth.loxone_endpoint,
+                loxone_store,
+                timeout_seconds=config.connection_timeout if config is not None else 10.0,
+                requests_per_minute=config.requests_per_minute if config is not None else 60,
+                max_parallel_calls=config.max_parallel_calls if config is not None else 4,
+            )
 
     server = _ForwardedHostFastMCP(
         SERVER_NAME,
@@ -162,6 +201,8 @@ def create_server(settings: ServerSettings) -> FastMCP:
     )
     server.forwarded_allowed_hosts = settings.allowed_hosts
     server.transport_guard = transport_guard
+    server.service_enabled = settings.service_enabled
+    register_read_tools(server, runtime)
 
     if oauth_web is not None:
         server.custom_route("/authorize", methods=["GET", "POST"], include_in_schema=False)(
@@ -195,6 +236,10 @@ def create_server(settings: ServerSettings) -> FastMCP:
 
 def main() -> None:
     """Run Streamable HTTP on the configured loopback port."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s component=%(name)s severity=%(levelname)s %(message)s",
+    )
     settings = ServerSettings.from_environment()
     create_server(settings).run(transport="streamable-http")
 

--- a/src/mcpserver/settings.py
+++ b/src/mcpserver/settings.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import ipaddress
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Final
 from urllib.parse import urlsplit
 
 import idna
 
+from mcpserver.config import AtomicConfigStore, PluginConfig
 from mcpserver.loxone.client import MiniserverEndpoint
 
 SERVER_PORT: Final = 8765
@@ -160,11 +161,14 @@ def _validate_origins(origins: tuple[str, ...]) -> tuple[str, ...]:
 
 @dataclass(frozen=True, slots=True)
 class Phase0AuthSettings:
-    """Injected Phase-0 OAuth settings; no Loxone credentials are persisted."""
+    """Validated OAuth and Loxone runtime paths (name retained for compatibility)."""
 
     public_origin: str
     store_path: Path
     loxone_endpoint: MiniserverEndpoint
+    loxone_store_path: Path | None = None
+    install_key_path: Path | None = None
+    plugin_config: PluginConfig | None = None
 
     @property
     def resource_url(self) -> str:
@@ -200,7 +204,58 @@ def _phase0_auth_from_environment() -> Phase0AuthSettings | None:
     return Phase0AuthSettings(
         public_origin=public_origin,
         store_path=store_path,
-        loxone_endpoint=MiniserverEndpoint.parse_gen1(values[2]),
+        loxone_endpoint=MiniserverEndpoint.parse(values[2]),
+    )
+
+
+def _phase1_auth_from_environment(
+    base: Phase0AuthSettings | None,
+) -> tuple[Phase0AuthSettings | None, bool]:
+    config_value = os.getenv("MCPSERVER_CONFIG", "").strip()
+    token_value = os.getenv("MCPSERVER_LOXONE_TOKEN_STORE", "").strip()
+    key_value = os.getenv("MCPSERVER_INSTALL_KEY", "").strip()
+    if bool(token_value) != bool(key_value):
+        raise ValueError(
+            "MCPSERVER_LOXONE_TOKEN_STORE and MCPSERVER_INSTALL_KEY are required together"
+        )
+    config: PluginConfig | None = None
+    if config_value:
+        config_path = Path(config_value)
+        if not config_path.is_absolute():
+            raise ValueError("MCPSERVER_CONFIG must be an absolute path")
+        config = AtomicConfigStore(config_path).load()
+        if not config.enabled:
+            return None, False
+        if base is None:
+            public_origin = config.public_origin or os.getenv("MCPSERVER_PUBLIC_ORIGIN", "").strip()
+            auth_store = os.getenv("MCPSERVER_AUTH_STORE", "").strip()
+            if not public_origin or not auth_store or not config.loxone_endpoint:
+                raise ValueError("OAuth settings are required when the plugin is enabled")
+            public_origin = _validate_origins((public_origin,))[0]
+            if not public_origin.startswith("https://"):
+                raise ValueError("MCPSERVER_PUBLIC_ORIGIN must use HTTPS")
+            store_path = Path(auth_store)
+            if not store_path.is_absolute() or store_path.suffix.lower() != ".json":
+                raise ValueError("MCPSERVER_AUTH_STORE must be an absolute JSON file path")
+            base = Phase0AuthSettings(
+                public_origin=public_origin,
+                store_path=store_path,
+                loxone_endpoint=MiniserverEndpoint.parse(config.loxone_endpoint),
+            )
+    if base is None:
+        return None, True
+    endpoint = base.loxone_endpoint
+    if config is not None and config.loxone_endpoint:
+        endpoint = MiniserverEndpoint.parse(config.loxone_endpoint)
+    return (
+        replace(
+            base,
+            loxone_endpoint=endpoint,
+            loxone_store_path=Path(token_value) if token_value else None,
+            install_key_path=Path(key_value) if key_value else None,
+            plugin_config=config,
+        ),
+        True,
     )
 
 
@@ -213,6 +268,7 @@ class ServerSettings:
     allowed_hosts: tuple[str, ...]
     allowed_origins: tuple[str, ...]
     phase0_auth: Phase0AuthSettings | None = None
+    service_enabled: bool = True
 
     @classmethod
     def from_environment(cls) -> ServerSettings:
@@ -237,10 +293,25 @@ class ServerSettings:
                 setting="MCPSERVER_ALLOWED_ORIGINS",
             )
         )
+        phase_auth, service_enabled = _phase1_auth_from_environment(
+            None if os.getenv("MCPSERVER_CONFIG", "").strip() else _phase0_auth_from_environment()
+        )
+        if phase_auth is not None and phase_auth.plugin_config is not None:
+            public = urlsplit(phase_auth.public_origin)
+            public_host = public.hostname or ""
+            if ":" in public_host:
+                public_host = f"[{public_host}]"
+            if public.port is not None and public.port != 443:
+                public_host = f"{public_host}:{public.port}"
+            if public_host not in allowed_hosts:
+                allowed_hosts = (*allowed_hosts, public_host)
+            if phase_auth.public_origin not in allowed_origins:
+                allowed_origins = (*allowed_origins, phase_auth.public_origin)
         return cls(
             host=host,
             port=port,
             allowed_hosts=allowed_hosts,
             allowed_origins=allowed_origins,
-            phase0_auth=_phase0_auth_from_environment(),
+            phase0_auth=phase_auth,
+            service_enabled=service_enabled,
         )

--- a/src/mcpserver/tools.py
+++ b/src/mcpserver/tools.py
@@ -15,7 +15,7 @@ from uuid import uuid4
 from mcp.server.auth.middleware.auth_context import get_access_token
 from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, JsonValue
 
 from mcpserver.auth.provider import StoredAccessToken
 from mcpserver.loxone.models import Control, Freshness, NamedGroup
@@ -27,23 +27,110 @@ MAX_STATE_UUIDS: Final = 100
 _LOGGER = logging.getLogger("mcpserver.tools")
 
 
+class ErrorData(BaseModel):
+    error: str
+    message: str
+
+
+class NamedGroupData(BaseModel):
+    uuid: str
+    name: str
+
+
+class NamedGroupPageData(BaseModel):
+    items: list[NamedGroupData]
+    next_cursor: str | None
+
+
+class ControlSummaryData(BaseModel):
+    uuid: str
+    name: str
+    type: str
+    room: NamedGroupData | None
+    category: NamedGroupData | None
+
+
+class ControlPageData(BaseModel):
+    items: list[ControlSummaryData]
+    next_cursor: str | None
+
+
+class StateReferenceData(BaseModel):
+    name: str
+    uuid: str
+
+
+class CapabilitiesData(BaseModel):
+    readable: bool
+    allowed_actions: list[str]
+
+
+class ControlDescriptionData(ControlSummaryData):
+    states: list[StateReferenceData]
+    capabilities: CapabilitiesData
+
+
+class StateData(BaseModel):
+    uuid: str
+    value: JsonValue
+    freshness: str
+    observed_at: str | None
+
+
+class StatesData(BaseModel):
+    states: list[StateData]
+
+
+class SystemStatusData(BaseModel):
+    reachable: bool
+    miniserver_serial: str
+    structure_last_modified: str
+    cache_freshness: str
+
+
 class ToolEnvelope(BaseModel):
     ok: bool
-    data: Any
+    data: object
     warnings: list[str] = Field(default_factory=list)
     observed_at: str
     stale: bool
     trace_id: str
 
 
+class SystemStatusEnvelope(ToolEnvelope):
+    data: SystemStatusData | ErrorData
+
+
+class NamedGroupPageEnvelope(ToolEnvelope):
+    data: NamedGroupPageData | ErrorData
+
+
+class ControlPageEnvelope(ToolEnvelope):
+    data: ControlPageData | ErrorData
+
+
+class ControlDescriptionEnvelope(ToolEnvelope):
+    data: ControlDescriptionData | ErrorData
+
+
+class StatesEnvelope(ToolEnvelope):
+    data: StatesData | ErrorData
+
+
 def _now() -> str:
     return datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
 
-def _result(data: Any, *, stale: bool = False, warnings: list[str] | None = None) -> ToolEnvelope:
+def _result[EnvelopeT: ToolEnvelope](
+    envelope_type: type[EnvelopeT],
+    data: Any,
+    *,
+    stale: bool = False,
+    warnings: list[str] | None = None,
+) -> EnvelopeT:
     trace_id = str(uuid4())
     _LOGGER.info("component=tools severity=INFO trace_id=%s outcome=ok", trace_id)
-    return ToolEnvelope(
+    return envelope_type(
         ok=True,
         data=data,
         warnings=warnings or [],
@@ -53,14 +140,16 @@ def _result(data: Any, *, stale: bool = False, warnings: list[str] | None = None
     )
 
 
-def _error(code: str, message: str) -> ToolEnvelope:
+def _error[EnvelopeT: ToolEnvelope](
+    envelope_type: type[EnvelopeT], code: str, message: str
+) -> EnvelopeT:
     trace_id = str(uuid4())
     _LOGGER.warning(
         "component=tools severity=WARNING trace_id=%s outcome=error code=%s",
         trace_id,
         code,
     )
-    return ToolEnvelope(
+    return envelope_type(
         ok=False,
         data={"error": code, "message": message},
         observed_at=_now(),
@@ -173,10 +262,11 @@ def register_read_tools(server: FastMCP, runtime: LoxoneRuntime | None) -> None:
         annotations=annotations,
         structured_output=True,
     )
-    async def get_system_status() -> ToolEnvelope:
+    async def get_system_status() -> SystemStatusEnvelope:
         try:
             _access_token, snapshot = await _snapshot(runtime)
             return _result(
+                SystemStatusEnvelope,
                 {
                     "reachable": snapshot.connected,
                     "miniserver_serial": snapshot.structure.identity.miniserver_serial,
@@ -186,9 +276,13 @@ def register_read_tools(server: FastMCP, runtime: LoxoneRuntime | None) -> None:
                 stale=not snapshot.connected,
             )
         except PermissionError:
-            return _error("unauthenticated", "Authentication with loxone:read is required")
+            return _error(
+                SystemStatusEnvelope,
+                "unauthenticated",
+                "Authentication with loxone:read is required",
+            )
         except RuntimeUnavailable as exc:
-            return _error("temporarily_unavailable", str(exc))
+            return _error(SystemStatusEnvelope, "temporarily_unavailable", str(exc))
 
     @server.tool(
         name="loxone_list_rooms",
@@ -196,18 +290,25 @@ def register_read_tools(server: FastMCP, runtime: LoxoneRuntime | None) -> None:
         annotations=annotations,
         structured_output=True,
     )
-    async def list_rooms(cursor: str | None = None, limit: int = DEFAULT_PAGE_SIZE) -> ToolEnvelope:
+    async def list_rooms(
+        cursor: str | None = None, limit: int = DEFAULT_PAGE_SIZE
+    ) -> NamedGroupPageEnvelope:
         try:
             _access_token, snapshot = await _snapshot(runtime)
             return _result(
-                _page(cursors, "rooms", _groups(snapshot.structure.rooms), cursor, limit)
+                NamedGroupPageEnvelope,
+                _page(cursors, "rooms", _groups(snapshot.structure.rooms), cursor, limit),
             )
         except ValueError as exc:
-            return _error("invalid_input", str(exc))
+            return _error(NamedGroupPageEnvelope, "invalid_input", str(exc))
         except PermissionError:
-            return _error("unauthenticated", "Authentication with loxone:read is required")
+            return _error(
+                NamedGroupPageEnvelope,
+                "unauthenticated",
+                "Authentication with loxone:read is required",
+            )
         except RuntimeUnavailable as exc:
-            return _error("temporarily_unavailable", str(exc))
+            return _error(NamedGroupPageEnvelope, "temporarily_unavailable", str(exc))
 
     @server.tool(
         name="loxone_list_categories",
@@ -217,18 +318,23 @@ def register_read_tools(server: FastMCP, runtime: LoxoneRuntime | None) -> None:
     )
     async def list_categories(
         cursor: str | None = None, limit: int = DEFAULT_PAGE_SIZE
-    ) -> ToolEnvelope:
+    ) -> NamedGroupPageEnvelope:
         try:
             _access_token, snapshot = await _snapshot(runtime)
             return _result(
-                _page(cursors, "categories", _groups(snapshot.structure.categories), cursor, limit)
+                NamedGroupPageEnvelope,
+                _page(cursors, "categories", _groups(snapshot.structure.categories), cursor, limit),
             )
         except ValueError as exc:
-            return _error("invalid_input", str(exc))
+            return _error(NamedGroupPageEnvelope, "invalid_input", str(exc))
         except PermissionError:
-            return _error("unauthenticated", "Authentication with loxone:read is required")
+            return _error(
+                NamedGroupPageEnvelope,
+                "unauthenticated",
+                "Authentication with loxone:read is required",
+            )
         except RuntimeUnavailable as exc:
-            return _error("temporarily_unavailable", str(exc))
+            return _error(NamedGroupPageEnvelope, "temporarily_unavailable", str(exc))
 
     @server.tool(
         name="loxone_find_controls",
@@ -243,9 +349,9 @@ def register_read_tools(server: FastMCP, runtime: LoxoneRuntime | None) -> None:
         control_type: str | None = None,
         cursor: str | None = None,
         limit: int = DEFAULT_PAGE_SIZE,
-    ) -> ToolEnvelope:
+    ) -> ControlPageEnvelope:
         if query is not None and len(query) > 200:
-            return _error("invalid_input", "query is too long")
+            return _error(ControlPageEnvelope, "invalid_input", "query is too long")
         try:
             _access_token, snapshot = await _snapshot(runtime)
             controls = _flatten(snapshot.structure.controls)
@@ -262,13 +368,20 @@ def register_read_tools(server: FastMCP, runtime: LoxoneRuntime | None) -> None:
                 json.dumps([normalized, room_uuid, category_uuid, control_type]).encode()
             ).hexdigest()
             values = [_control_summary(item, snapshot) for item in matches]
-            return _result(_page(cursors, f"controls:{scope}", values, cursor, limit))
+            return _result(
+                ControlPageEnvelope,
+                _page(cursors, f"controls:{scope}", values, cursor, limit),
+            )
         except ValueError as exc:
-            return _error("invalid_input", str(exc))
+            return _error(ControlPageEnvelope, "invalid_input", str(exc))
         except PermissionError:
-            return _error("unauthenticated", "Authentication with loxone:read is required")
+            return _error(
+                ControlPageEnvelope,
+                "unauthenticated",
+                "Authentication with loxone:read is required",
+            )
         except RuntimeUnavailable as exc:
-            return _error("temporarily_unavailable", str(exc))
+            return _error(ControlPageEnvelope, "temporarily_unavailable", str(exc))
 
     @server.tool(
         name="loxone_describe_control",
@@ -276,7 +389,7 @@ def register_read_tools(server: FastMCP, runtime: LoxoneRuntime | None) -> None:
         annotations=annotations,
         structured_output=True,
     )
-    async def describe_control(control_uuid: str) -> ToolEnvelope:
+    async def describe_control(control_uuid: str) -> ControlDescriptionEnvelope:
         try:
             _access_token, snapshot = await _snapshot(runtime)
             control = next(
@@ -288,15 +401,19 @@ def register_read_tools(server: FastMCP, runtime: LoxoneRuntime | None) -> None:
                 None,
             )
             if control is None:
-                return _error("not_found", "control is not visible")
+                return _error(ControlDescriptionEnvelope, "not_found", "control is not visible")
             value = _control_summary(control, snapshot)
             value["states"] = [{"name": name, "uuid": uuid} for name, uuid in control.state_uuids]
             value["capabilities"] = {"readable": True, "allowed_actions": []}
-            return _result(value)
+            return _result(ControlDescriptionEnvelope, value)
         except PermissionError:
-            return _error("unauthenticated", "Authentication with loxone:read is required")
+            return _error(
+                ControlDescriptionEnvelope,
+                "unauthenticated",
+                "Authentication with loxone:read is required",
+            )
         except RuntimeUnavailable as exc:
-            return _error("temporarily_unavailable", str(exc))
+            return _error(ControlDescriptionEnvelope, "temporarily_unavailable", str(exc))
 
     @server.tool(
         name="loxone_get_states",
@@ -304,13 +421,17 @@ def register_read_tools(server: FastMCP, runtime: LoxoneRuntime | None) -> None:
         annotations=annotations,
         structured_output=True,
     )
-    async def get_states(state_uuids: list[str]) -> ToolEnvelope:
+    async def get_states(state_uuids: list[str]) -> StatesEnvelope:
         if (
             not state_uuids
             or len(state_uuids) > MAX_STATE_UUIDS
             or len(set(state_uuids)) != len(state_uuids)
         ):
-            return _error("invalid_input", "state_uuids must contain 1 to 100 unique values")
+            return _error(
+                StatesEnvelope,
+                "invalid_input",
+                "state_uuids must contain 1 to 100 unique values",
+            )
         try:
             _access_token, snapshot = await _snapshot(runtime)
             allowed = {
@@ -319,7 +440,7 @@ def register_read_tools(server: FastMCP, runtime: LoxoneRuntime | None) -> None:
                 for _name, uuid in control.state_uuids
             }
             if any(uuid not in allowed for uuid in state_uuids):
-                return _error("not_found", "one or more states are not visible")
+                return _error(StatesEnvelope, "not_found", "one or more states are not visible")
             records = [runtime.state(snapshot, uuid) for uuid in state_uuids] if runtime else []
             stale = any(record.freshness is not Freshness.CURRENT for record in records)
             values = [
@@ -337,8 +458,12 @@ def register_read_tools(server: FastMCP, runtime: LoxoneRuntime | None) -> None:
                 }
                 for record in records
             ]
-            return _result({"states": values}, stale=stale)
+            return _result(StatesEnvelope, {"states": values}, stale=stale)
         except PermissionError:
-            return _error("unauthenticated", "Authentication with loxone:read is required")
+            return _error(
+                StatesEnvelope,
+                "unauthenticated",
+                "Authentication with loxone:read is required",
+            )
         except RuntimeUnavailable as exc:
-            return _error("temporarily_unavailable", str(exc))
+            return _error(StatesEnvelope, "temporarily_unavailable", str(exc))

--- a/src/mcpserver/tools.py
+++ b/src/mcpserver/tools.py
@@ -1,0 +1,344 @@
+"""Stable read-only MCP tool contracts for the Phase 1 alpha."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import logging
+import secrets
+from datetime import UTC, datetime
+from typing import Any, Final
+from uuid import uuid4
+
+from mcp.server.auth.middleware.auth_context import get_access_token
+from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
+from pydantic import BaseModel, Field
+
+from mcpserver.auth.provider import StoredAccessToken
+from mcpserver.loxone.models import Control, Freshness, NamedGroup
+from mcpserver.loxone.runtime import LoxoneRuntime, RuntimeSnapshot, RuntimeUnavailable
+
+DEFAULT_PAGE_SIZE: Final = 50
+MAX_PAGE_SIZE: Final = 100
+MAX_STATE_UUIDS: Final = 100
+_LOGGER = logging.getLogger("mcpserver.tools")
+
+
+class ToolEnvelope(BaseModel):
+    ok: bool
+    data: Any
+    warnings: list[str] = Field(default_factory=list)
+    observed_at: str
+    stale: bool
+    trace_id: str
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _result(data: Any, *, stale: bool = False, warnings: list[str] | None = None) -> ToolEnvelope:
+    trace_id = str(uuid4())
+    _LOGGER.info("component=tools severity=INFO trace_id=%s outcome=ok", trace_id)
+    return ToolEnvelope(
+        ok=True,
+        data=data,
+        warnings=warnings or [],
+        observed_at=_now(),
+        stale=stale,
+        trace_id=trace_id,
+    )
+
+
+def _error(code: str, message: str) -> ToolEnvelope:
+    trace_id = str(uuid4())
+    _LOGGER.warning(
+        "component=tools severity=WARNING trace_id=%s outcome=error code=%s",
+        trace_id,
+        code,
+    )
+    return ToolEnvelope(
+        ok=False,
+        data={"error": code, "message": message},
+        observed_at=_now(),
+        stale=False,
+        trace_id=trace_id,
+    )
+
+
+class _CursorCodec:
+    def __init__(self) -> None:
+        self._key = secrets.token_bytes(32)
+
+    def encode(self, scope: str, offset: int) -> str:
+        body = json.dumps({"scope": scope, "offset": offset}, separators=(",", ":")).encode()
+        signature = hmac.new(self._key, body, hashlib.sha256).digest()
+        return base64.urlsafe_b64encode(body + signature).decode().rstrip("=")
+
+    def decode(self, scope: str, value: str | None) -> int:
+        if value is None:
+            return 0
+        if len(value) > 512:
+            raise ValueError("cursor is invalid")
+        try:
+            raw = base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))
+            body, signature = raw[:-32], raw[-32:]
+            if not hmac.compare_digest(
+                signature, hmac.new(self._key, body, hashlib.sha256).digest()
+            ):
+                raise ValueError
+            document = json.loads(body)
+            offset = document.get("offset")
+            if document.get("scope") != scope or not isinstance(offset, int) or offset < 0:
+                raise ValueError
+            return offset
+        except (UnicodeError, ValueError, json.JSONDecodeError):
+            raise ValueError("cursor is invalid") from None
+
+
+def _access() -> StoredAccessToken:
+    access = get_access_token()
+    if not isinstance(access, StoredAccessToken):
+        raise PermissionError("authentication is required")
+    return access
+
+
+def _groups(items: tuple[NamedGroup, ...]) -> list[dict[str, str]]:
+    return [{"uuid": item.uuid, "name": item.name} for item in items]
+
+
+def _flatten(controls: tuple[Control, ...]) -> list[Control]:
+    result: list[Control] = []
+    for control in controls:
+        result.append(control)
+        result.extend(_flatten(control.subcontrols))
+    return result
+
+
+def _control_summary(control: Control, snapshot: RuntimeSnapshot) -> dict[str, Any]:
+    rooms = {item.uuid: item.name for item in snapshot.structure.rooms}
+    categories = {item.uuid: item.name for item in snapshot.structure.categories}
+    return {
+        "uuid": control.uuid,
+        "name": control.name,
+        "type": control.control_type,
+        "room": (
+            {"uuid": control.room_uuid, "name": rooms.get(control.room_uuid, "")}
+            if control.room_uuid
+            else None
+        ),
+        "category": (
+            {"uuid": control.category_uuid, "name": categories.get(control.category_uuid, "")}
+            if control.category_uuid
+            else None
+        ),
+    }
+
+
+def _page(
+    codec: _CursorCodec, scope: str, items: list[Any], cursor: str | None, limit: int
+) -> dict[str, Any]:
+    if not 1 <= limit <= MAX_PAGE_SIZE:
+        raise ValueError("limit must be between 1 and 100")
+    offset = codec.decode(scope, cursor)
+    selected = items[offset : offset + limit]
+    next_offset = offset + len(selected)
+    return {
+        "items": selected,
+        "next_cursor": codec.encode(scope, next_offset) if next_offset < len(items) else None,
+    }
+
+
+async def _snapshot(runtime: LoxoneRuntime | None) -> tuple[StoredAccessToken, RuntimeSnapshot]:
+    if runtime is None:
+        raise RuntimeUnavailable("the service is not configured")
+    access = _access()
+    async with runtime.call_slot(access):
+        return access, await runtime.snapshot(access)
+
+
+def register_read_tools(server: FastMCP, runtime: LoxoneRuntime | None) -> None:
+    """Publish exactly the six stable Phase 1 read-only tools."""
+    annotations = ToolAnnotations(readOnlyHint=True, destructiveHint=False, openWorldHint=False)
+    cursors = _CursorCodec()
+
+    @server.tool(
+        name="loxone_get_system_status",
+        description=(
+            "Get sanitized Miniserver connection and cache status for this Loxone identity."
+        ),
+        annotations=annotations,
+        structured_output=True,
+    )
+    async def get_system_status() -> ToolEnvelope:
+        try:
+            _access_token, snapshot = await _snapshot(runtime)
+            return _result(
+                {
+                    "reachable": snapshot.connected,
+                    "miniserver_serial": snapshot.structure.identity.miniserver_serial,
+                    "structure_last_modified": snapshot.structure.last_modified,
+                    "cache_freshness": "current" if snapshot.connected else "stale",
+                },
+                stale=not snapshot.connected,
+            )
+        except PermissionError:
+            return _error("unauthenticated", "Authentication with loxone:read is required")
+        except RuntimeUnavailable as exc:
+            return _error("temporarily_unavailable", str(exc))
+
+    @server.tool(
+        name="loxone_list_rooms",
+        description="List visible Loxone rooms.",
+        annotations=annotations,
+        structured_output=True,
+    )
+    async def list_rooms(cursor: str | None = None, limit: int = DEFAULT_PAGE_SIZE) -> ToolEnvelope:
+        try:
+            _access_token, snapshot = await _snapshot(runtime)
+            return _result(
+                _page(cursors, "rooms", _groups(snapshot.structure.rooms), cursor, limit)
+            )
+        except ValueError as exc:
+            return _error("invalid_input", str(exc))
+        except PermissionError:
+            return _error("unauthenticated", "Authentication with loxone:read is required")
+        except RuntimeUnavailable as exc:
+            return _error("temporarily_unavailable", str(exc))
+
+    @server.tool(
+        name="loxone_list_categories",
+        description="List visible Loxone categories.",
+        annotations=annotations,
+        structured_output=True,
+    )
+    async def list_categories(
+        cursor: str | None = None, limit: int = DEFAULT_PAGE_SIZE
+    ) -> ToolEnvelope:
+        try:
+            _access_token, snapshot = await _snapshot(runtime)
+            return _result(
+                _page(cursors, "categories", _groups(snapshot.structure.categories), cursor, limit)
+            )
+        except ValueError as exc:
+            return _error("invalid_input", str(exc))
+        except PermissionError:
+            return _error("unauthenticated", "Authentication with loxone:read is required")
+        except RuntimeUnavailable as exc:
+            return _error("temporarily_unavailable", str(exc))
+
+    @server.tool(
+        name="loxone_find_controls",
+        description="Search visible Loxone controls by text, room, category, and type.",
+        annotations=annotations,
+        structured_output=True,
+    )
+    async def find_controls(
+        query: str | None = None,
+        room_uuid: str | None = None,
+        category_uuid: str | None = None,
+        control_type: str | None = None,
+        cursor: str | None = None,
+        limit: int = DEFAULT_PAGE_SIZE,
+    ) -> ToolEnvelope:
+        if query is not None and len(query) > 200:
+            return _error("invalid_input", "query is too long")
+        try:
+            _access_token, snapshot = await _snapshot(runtime)
+            controls = _flatten(snapshot.structure.controls)
+            normalized = query.casefold().strip() if query else None
+            matches = [
+                item
+                for item in controls
+                if (normalized is None or normalized in item.name.casefold())
+                and (room_uuid is None or item.room_uuid == room_uuid)
+                and (category_uuid is None or item.category_uuid == category_uuid)
+                and (control_type is None or item.control_type == control_type)
+            ]
+            scope = hashlib.sha256(
+                json.dumps([normalized, room_uuid, category_uuid, control_type]).encode()
+            ).hexdigest()
+            values = [_control_summary(item, snapshot) for item in matches]
+            return _result(_page(cursors, f"controls:{scope}", values, cursor, limit))
+        except ValueError as exc:
+            return _error("invalid_input", str(exc))
+        except PermissionError:
+            return _error("unauthenticated", "Authentication with loxone:read is required")
+        except RuntimeUnavailable as exc:
+            return _error("temporarily_unavailable", str(exc))
+
+    @server.tool(
+        name="loxone_describe_control",
+        description="Describe one visible Loxone control and its read-only states.",
+        annotations=annotations,
+        structured_output=True,
+    )
+    async def describe_control(control_uuid: str) -> ToolEnvelope:
+        try:
+            _access_token, snapshot = await _snapshot(runtime)
+            control = next(
+                (
+                    item
+                    for item in _flatten(snapshot.structure.controls)
+                    if item.uuid == control_uuid
+                ),
+                None,
+            )
+            if control is None:
+                return _error("not_found", "control is not visible")
+            value = _control_summary(control, snapshot)
+            value["states"] = [{"name": name, "uuid": uuid} for name, uuid in control.state_uuids]
+            value["capabilities"] = {"readable": True, "allowed_actions": []}
+            return _result(value)
+        except PermissionError:
+            return _error("unauthenticated", "Authentication with loxone:read is required")
+        except RuntimeUnavailable as exc:
+            return _error("temporarily_unavailable", str(exc))
+
+    @server.tool(
+        name="loxone_get_states",
+        description="Get current cached values for up to 100 visible state UUIDs.",
+        annotations=annotations,
+        structured_output=True,
+    )
+    async def get_states(state_uuids: list[str]) -> ToolEnvelope:
+        if (
+            not state_uuids
+            or len(state_uuids) > MAX_STATE_UUIDS
+            or len(set(state_uuids)) != len(state_uuids)
+        ):
+            return _error("invalid_input", "state_uuids must contain 1 to 100 unique values")
+        try:
+            _access_token, snapshot = await _snapshot(runtime)
+            allowed = {
+                uuid
+                for control in _flatten(snapshot.structure.controls)
+                for _name, uuid in control.state_uuids
+            }
+            if any(uuid not in allowed for uuid in state_uuids):
+                return _error("not_found", "one or more states are not visible")
+            records = [runtime.state(snapshot, uuid) for uuid in state_uuids] if runtime else []
+            stale = any(record.freshness is not Freshness.CURRENT for record in records)
+            values = [
+                {
+                    "uuid": record.uuid,
+                    "value": record.value,
+                    "freshness": record.freshness.value,
+                    "observed_at": (
+                        datetime.fromtimestamp(record.observed_at, UTC)
+                        .isoformat()
+                        .replace("+00:00", "Z")
+                        if record.observed_at is not None
+                        else None
+                    ),
+                }
+                for record in records
+            ]
+            return _result({"states": values}, stale=stale)
+        except PermissionError:
+            return _error("unauthenticated", "Authentication with loxone:read is required")
+        except RuntimeUnavailable as exc:
+            return _error("temporarily_unavailable", str(exc))

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,130 @@
+<style>
+  .mcp-page { max-width: 76rem; margin: 0 auto; padding: .5rem; overflow-wrap: anywhere; }
+  .mcp-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 20rem), 1fr)); gap: 1rem; }
+  .mcp-card { min-width: 0; padding: 1rem; border: 1px solid #c9cdd2; border-radius: .4rem; background: #fff; }
+  .mcp-form { display: grid; gap: .85rem; }
+  .mcp-field { display: grid; gap: .3rem; min-width: 0; }
+  .mcp-field input { box-sizing: border-box; width: 100%; max-width: 100%; min-height: 2.75rem; }
+  .mcp-actions { display: flex; flex-wrap: wrap; gap: .6rem; align-items: center; }
+  .mcp-actions button { min-height: 2.75rem; max-width: 100%; }
+  .mcp-status { padding: .65rem; border-left: .3rem solid #6b7280; background: #f3f4f6; }
+  .mcp-status[data-kind="success"] { border-color: #198754; }
+  .mcp-status[data-kind="error"] { border-color: #b91c1c; }
+  .mcp-table-wrap { max-width: 100%; overflow-x: auto; }
+  .mcp-table { width: 100%; border-collapse: collapse; }
+  .mcp-table th, .mcp-table td { padding: .5rem; text-align: left; border-bottom: 1px solid #ddd; }
+  .mcp-page :focus-visible { outline: 3px solid #1261a0; outline-offset: 2px; }
+  @media (max-width: 30rem) {
+    .mcp-card { padding: .75rem; }
+    .mcp-actions > * { width: 100%; }
+    #diagnostics .lb-table-scroll { overflow-x: visible; }
+    #diagnostics .lb-table,
+    #diagnostics .lb-table tbody,
+    #diagnostics .lb-table tr,
+    #diagnostics .lb-table td { display: block; box-sizing: border-box; width: 100%; min-width: 0; }
+    #diagnostics .lb-table tr { padding: .35rem 0; border-bottom: 1px solid #ddd; }
+    #diagnostics .lb-table td { padding: .25rem 0; border: 0; overflow-wrap: anywhere; }
+    #diagnostics .lb-table td:first-child,
+    #diagnostics .lb-table td:last-child { display: none; }
+  }
+</style>
+
+<main class="mcp-page">
+  <TMPL_IF NOTICE><div class="mcp-status" role="status"><TMPL_VAR NOTICE ESCAPE=HTML></div></TMPL_IF>
+  <div id="ajax-status" class="mcp-status" role="status" aria-live="polite" hidden></div>
+
+  <section id="setup" class="mcp-card" aria-labelledby="setup-title">
+    <h2 id="setup-title"><TMPL_VAR SETUP.TITLE></h2>
+    <form class="mcp-form" method="post" action="index.cgi">
+      <input type="hidden" name="action" value="save_config">
+      <label class="mcp-field"><span><TMPL_VAR SETUP.PUBLIC_ORIGIN></span><input name="public_origin" type="url" value="<TMPL_VAR PUBLIC_ORIGIN ESCAPE=HTML>" placeholder="https://loxberry.local" required></label>
+      <label class="mcp-field"><span><TMPL_VAR SETUP.ENDPOINT></span><input name="endpoint" type="url" value="<TMPL_VAR ENDPOINT ESCAPE=HTML>" placeholder="http://192.168.1.20" required></label>
+      <div class="mcp-grid">
+        <label class="mcp-field"><span><TMPL_VAR SETUP.TIMEOUT></span><input name="connection_timeout" type="number" min="1" max="60" value="<TMPL_VAR CONNECTION_TIMEOUT ESCAPE=HTML>"></label>
+        <label class="mcp-field"><span><TMPL_VAR SETUP.RATE></span><input name="requests_per_minute" type="number" min="1" max="600" value="<TMPL_VAR REQUESTS_PER_MINUTE ESCAPE=HTML>"></label>
+        <label class="mcp-field"><span><TMPL_VAR SETUP.PARALLEL></span><input name="max_parallel_calls" type="number" min="1" max="32" value="<TMPL_VAR MAX_PARALLEL_CALLS ESCAPE=HTML>"></label>
+      </div>
+      <label><input name="enabled" type="checkbox" value="1" <TMPL_IF ENABLED>checked</TMPL_IF>> <TMPL_VAR SETUP.ENABLED></label>
+      <div class="mcp-actions">
+        <button class="lb-button" type="submit"><TMPL_VAR ACTION.SAVE></button>
+      </div>
+    </form>
+    <form class="mcp-actions" method="post" action="index.cgi" data-ajax="test_connection">
+      <input type="hidden" name="action" value="test_connection">
+      <input type="hidden" name="endpoint" value="<TMPL_VAR ENDPOINT ESCAPE=HTML>">
+      <button class="lb-button" type="submit"><TMPL_VAR ACTION.TEST></button>
+    </form>
+  </section>
+
+  <div class="mcp-grid">
+    <section id="status" class="mcp-card" aria-labelledby="status-title">
+      <h2 id="status-title"><TMPL_VAR STATUS.TITLE></h2>
+      <p><TMPL_VAR STATUS.VERSION>: <code><TMPL_VAR VERSION ESCAPE=HTML></code></p>
+      <p><TMPL_VAR STATUS.SERVICE>: <strong id="service-state"><TMPL_IF SERVICE_ACTIVE><TMPL_VAR STATUS.RUNNING><TMPL_ELSE><TMPL_VAR STATUS.STOPPED></TMPL_IF></strong></p>
+      <form method="post" action="index.cgi" data-ajax="status"><input type="hidden" name="action" value="status"><button class="lb-button" type="submit"><TMPL_VAR ACTION.REFRESH></button></form>
+    </section>
+
+    <section id="help" class="mcp-card" aria-labelledby="help-title">
+      <h2 id="help-title"><TMPL_VAR HELP.TITLE></h2>
+      <p><TMPL_VAR HELP.READ_ONLY></p>
+      <p><code>/plugins/mcpserver/mcp</code></p>
+      <p><a href="https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server" target="_blank" rel="noopener"><TMPL_VAR HELP.PROJECT></a></p>
+    </section>
+  </div>
+
+  <section id="sessions" class="mcp-card" aria-labelledby="sessions-title">
+    <h2 id="sessions-title"><TMPL_VAR SESSIONS.TITLE></h2>
+    <TMPL_IF HAS_SESSIONS>
+      <div class="mcp-table-wrap"><table class="mcp-table"><thead><tr><th><TMPL_VAR SESSIONS.CLIENT></th><th><TMPL_VAR SESSIONS.IDENTITY></th><th><TMPL_VAR SESSIONS.EXPIRES></th><th><TMPL_VAR SESSIONS.ACTION></th></tr></thead><tbody>
+      <TMPL_LOOP SESSIONS><tr><td><code><TMPL_VAR client ESCAPE=HTML></code></td><td><code><TMPL_VAR identity ESCAPE=HTML></code></td><td><TMPL_VAR expires_at ESCAPE=HTML></td><td><form method="post" action="index.cgi" data-ajax="revoke_session"><input type="hidden" name="action" value="revoke_session"><input type="hidden" name="id" value="<TMPL_VAR id ESCAPE=HTML>"><button class="lb-button" type="submit"><TMPL_VAR ACTION.REVOKE></button></form></td></tr></TMPL_LOOP>
+      </tbody></table></div>
+      <form method="post" action="index.cgi" data-ajax="revoke_all"><input type="hidden" name="action" value="revoke_all"><button class="lb-button" type="submit"><TMPL_VAR ACTION.REVOKE_ALL></button></form>
+    <TMPL_ELSE><p><TMPL_VAR SESSIONS.EMPTY></p></TMPL_IF>
+  </section>
+
+  <section id="diagnostics" class="mcp-card" aria-labelledby="diagnostics-title">
+    <h2 id="diagnostics-title"><TMPL_VAR DIAGNOSTICS.TITLE></h2>
+    <p><TMPL_VAR DIAGNOSTICS.TEXT></p>
+    <form method="post" action="index.cgi"><input type="hidden" name="action" value="diagnostic"><button class="lb-button" type="submit"><TMPL_VAR ACTION.DIAGNOSTIC></button></form>
+    <TMPL_VAR LOGLIST>
+  </section>
+</main>
+
+<script>
+(() => {
+  const status = document.getElementById('ajax-status');
+  for (const form of document.querySelectorAll('form[data-ajax]')) {
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const button = form.querySelector('button[type="submit"]');
+      button.disabled = true;
+      button.setAttribute('aria-busy', 'true');
+      status.hidden = false;
+      status.dataset.kind = '';
+      status.textContent = '<TMPL_VAR AJAX.WORKING ESCAPE=JS>';
+      const body = new FormData(form);
+      body.set('ajax', '1');
+      const controller = new AbortController();
+      const timeout = window.setTimeout(() => controller.abort(), 15000);
+      try {
+        const response = await fetch('index.cgi', {method: 'POST', body, signal: controller.signal, headers: {'X-Requested-With': 'XMLHttpRequest'}});
+        const result = await response.json();
+        if (!response.ok || !result.ok) throw new Error(result.error?.message || '<TMPL_VAR AJAX.ERROR ESCAPE=JS>');
+        status.dataset.kind = 'success';
+        status.textContent = '<TMPL_VAR AJAX.SUCCESS ESCAPE=JS>';
+        if (form.dataset.ajax === 'status') document.getElementById('service-state').textContent = result.data.service_active ? '<TMPL_VAR STATUS.RUNNING ESCAPE=JS>' : '<TMPL_VAR STATUS.STOPPED ESCAPE=JS>';
+        if (form.dataset.ajax.startsWith('revoke')) window.location.reload();
+      } catch (error) {
+        status.dataset.kind = 'error';
+        if (error instanceof DOMException && error.name === 'AbortError') status.textContent = '<TMPL_VAR AJAX.TIMEOUT ESCAPE=JS>';
+        else if (error instanceof TypeError) status.textContent = '<TMPL_VAR AJAX.NETWORK ESCAPE=JS>';
+        else status.textContent = error instanceof Error ? error.message : '<TMPL_VAR AJAX.ERROR ESCAPE=JS>';
+      } finally {
+        window.clearTimeout(timeout);
+        button.disabled = false;
+        button.removeAttribute('aria-busy');
+      }
+    });
+  }
+})();
+</script>

--- a/templates/lang/language_de.ini
+++ b/templates/lang/language_de.ini
@@ -1,0 +1,57 @@
+[BASIC]
+TITLE=LoxBerry MCP Server
+
+[NAV]
+SETUP=Einrichtung
+STATUS=Status
+SESSIONS=Clients und Sitzungen
+DIAGNOSTICS=Diagnose und Logs
+HELP=Hilfe
+
+[SETUP]
+TITLE=Einrichtung
+PUBLIC_ORIGIN=Öffentliche lokale HTTPS-Origin
+ENDPOINT=Miniserver-Endpunkt
+TIMEOUT=Verbindungs-Timeout (Sekunden)
+RATE=Aufrufe pro Minute
+PARALLEL=Parallele Aufrufe
+ENABLED=Dienst aktivieren
+
+[STATUS]
+TITLE=Status
+VERSION=Version
+SERVICE=Dienst
+RUNNING=läuft
+STOPPED=gestoppt
+
+[SESSIONS]
+TITLE=Clients und Sitzungen
+CLIENT=Client
+IDENTITY=Identität
+EXPIRES=Läuft ab
+ACTION=Aktion
+EMPTY=Keine Sitzungen vorhanden.
+
+[DIAGNOSTICS]
+TITLE=Diagnose und Logs
+TEXT=Logs werden maskiert über den integrierten LoxBerry-Logviewer angezeigt.
+
+[HELP]
+TITLE=Hilfe
+READ_ONLY=Diese Alpha veröffentlicht ausschließlich sechs lesende Loxone-Werkzeuge mit Scope loxone:read.
+PROJECT=Projekt und Anleitungen öffnen
+
+[ACTION]
+SAVE=Speichern und anwenden
+TEST=Verbindung testen
+REFRESH=Status aktualisieren
+REVOKE=Widerrufen
+REVOKE_ALL=Alle widerrufen
+DIAGNOSTIC=Maskierte Diagnose exportieren
+
+[AJAX]
+WORKING=Anfrage läuft …
+SUCCESS=Aktion erfolgreich abgeschlossen.
+ERROR=Aktion fehlgeschlagen.
+TIMEOUT=Zeitüberschreitung bei der Anfrage.
+NETWORK=Netzwerkfehler. Der serverseitige Ablauf bleibt verfügbar.

--- a/templates/lang/language_en.ini
+++ b/templates/lang/language_en.ini
@@ -1,0 +1,57 @@
+[BASIC]
+TITLE=LoxBerry MCP Server
+
+[NAV]
+SETUP=Setup
+STATUS=Status
+SESSIONS=Clients and sessions
+DIAGNOSTICS=Diagnostics and logs
+HELP=Help
+
+[SETUP]
+TITLE=Setup
+PUBLIC_ORIGIN=Public local HTTPS origin
+ENDPOINT=Miniserver endpoint
+TIMEOUT=Connection timeout (seconds)
+RATE=Calls per minute
+PARALLEL=Parallel calls
+ENABLED=Enable service
+
+[STATUS]
+TITLE=Status
+VERSION=Version
+SERVICE=Service
+RUNNING=running
+STOPPED=stopped
+
+[SESSIONS]
+TITLE=Clients and sessions
+CLIENT=Client
+IDENTITY=Identity
+EXPIRES=Expires
+ACTION=Action
+EMPTY=No sessions exist.
+
+[DIAGNOSTICS]
+TITLE=Diagnostics and logs
+TEXT=Masked logs are shown through the integrated LoxBerry log viewer.
+
+[HELP]
+TITLE=Help
+READ_ONLY=This alpha publishes exactly six read-only Loxone tools with the loxone:read scope.
+PROJECT=Open project and guides
+
+[ACTION]
+SAVE=Save and apply
+TEST=Test connection
+REFRESH=Refresh status
+REVOKE=Revoke
+REVOKE_ALL=Revoke all
+DIAGNOSTIC=Export masked diagnostics
+
+[AJAX]
+WORKING=Request in progress …
+SUCCESS=Action completed successfully.
+ERROR=Action failed.
+TIMEOUT=The request timed out.
+NETWORK=Network error. The server-rendered fallback remains available.

--- a/tests/perl_stubs/LoxBerry/Log.pm
+++ b/tests/perl_stubs/LoxBerry/Log.pm
@@ -1,0 +1,10 @@
+package LoxBerry::Log;
+use strict;
+use warnings;
+use Exporter 'import';
+our @EXPORT = qw(LOGERR);
+sub new { return bless {}, shift; }
+sub LOGSTART { return; }
+sub LOGERR { return; }
+sub get_notifications_html { return ''; }
+1;

--- a/tests/perl_stubs/LoxBerry/System.pm
+++ b/tests/perl_stubs/LoxBerry/System.pm
@@ -1,0 +1,10 @@
+package LoxBerry::System;
+use strict;
+use warnings;
+use Exporter 'import';
+our @EXPORT = qw($lbpplugindir $lbpconfigdir $lbpdatadir $lbpbindir $lbptemplatedir);
+our ($lbpplugindir, $lbpconfigdir, $lbpdatadir, $lbpbindir, $lbptemplatedir);
+sub pluginversion { return 'test'; }
+sub read_file { return ''; }
+sub readlanguage { return (); }
+1;

--- a/tests/perl_stubs/LoxBerry/Web.pm
+++ b/tests/perl_stubs/LoxBerry/Web.pm
@@ -1,0 +1,7 @@
+package LoxBerry::Web;
+use strict;
+use warnings;
+sub lbheader { return; }
+sub lbfooter { return; }
+sub loglist_html { return ''; }
+1;

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -5,7 +5,8 @@ from pathlib import Path
 
 import pytest
 
-from mcpserver.admin import dispatch
+from mcpserver.admin import _revoke, dispatch
+from mcpserver.auth.loxone_store import LoxoneTokenStoreError
 from mcpserver.auth.store import AtomicJsonAuthStore
 from mcpserver.config import AtomicConfigStore, PluginConfig
 
@@ -44,3 +45,81 @@ def test_diagnostic_contains_no_paths_endpoint_or_identity(
 def test_admin_rejects_unknown_actions() -> None:
     with pytest.raises(Exception, match="not supported"):
         dispatch({"action": "delete_everything"})
+
+
+def test_session_list_excludes_revoked_families(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    auth_path = (tmp_path / "data" / "auth" / "sessions.json").resolve()
+    store = AtomicJsonAuthStore(auth_path)
+
+    def add_families(document: dict[str, object]) -> None:
+        families = document["families"]
+        assert isinstance(families, dict)
+        families["active-family"] = {
+            "client_id": "active-client",
+            "identity_id": "active-identity",
+            "expires_at": 1_900_000_000,
+            "revoked": False,
+        }
+        families["revoked-family"] = {
+            "client_id": "revoked-client",
+            "identity_id": "revoked-identity",
+            "expires_at": 1_900_000_000,
+            "revoked": True,
+        }
+
+    store.mutate(add_families)
+    monkeypatch.setenv("MCPSERVER_AUTH_STORE", str(auth_path))
+
+    result = dispatch({"action": "list_sessions"})
+
+    assert [session["id"] for session in result["sessions"]] == ["active-family"]
+
+
+def test_revoke_survives_unreadable_encrypted_token(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    auth_path = (tmp_path / "data" / "auth" / "sessions.json").resolve()
+    store = AtomicJsonAuthStore(auth_path)
+
+    def add_family(document: dict[str, object]) -> None:
+        families = document["families"]
+        assert isinstance(families, dict)
+        families["family"] = {
+            "client_id": "client",
+            "identity_id": "identity",
+            "miniserver_id": "miniserver",
+            "expires_at": 1_900_000_000,
+            "revoked": False,
+        }
+
+    store.mutate(add_family)
+
+    class BrokenTokenStore:
+        def get(self, family_id: str, miniserver_id: str, identity_id: str) -> None:
+            raise LoxoneTokenStoreError("cannot decrypt")
+
+        def delete(self, family_id: str) -> None:
+            raise LoxoneTokenStoreError("cannot read store")
+
+    monkeypatch.setenv("MCPSERVER_AUTH_STORE", str(auth_path))
+    monkeypatch.setattr("mcpserver.admin._token_store", lambda: BrokenTokenStore())
+    monkeypatch.setattr(
+        "mcpserver.admin._config_store",
+        lambda: type(
+            "ConfigStore",
+            (),
+            {
+                "load": lambda self: PluginConfig.from_document(
+                    {
+                        "schema_version": 1,
+                        "loxone": {"endpoint": "http://192.168.10.20"},
+                    }
+                )
+            },
+        )(),
+    )
+
+    assert _revoke(None) == 1
+    assert store.snapshot()["families"]["family"]["revoked"] is True

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from mcpserver.admin import dispatch
+from mcpserver.auth.store import AtomicJsonAuthStore
+from mcpserver.config import AtomicConfigStore, PluginConfig
+
+
+def test_diagnostic_contains_no_paths_endpoint_or_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = (tmp_path / "config" / "mcpserver.json").resolve()
+    auth_path = (tmp_path / "data" / "auth" / "sessions.json").resolve()
+    AtomicConfigStore(config_path).save(
+        PluginConfig.from_document(
+            {
+                "schema_version": 1,
+                "server": {
+                    "enabled": True,
+                    "public_origin": "https://loxberry.example",
+                },
+                "loxone": {"endpoint": "http://192.168.10.20"},
+            }
+        )
+    )
+    AtomicJsonAuthStore(auth_path)
+    monkeypatch.setenv("MCPSERVER_CONFIG", str(config_path))
+    monkeypatch.setenv("MCPSERVER_AUTH_STORE", str(auth_path))
+    monkeypatch.setattr("mcpserver.admin._service_active", lambda: True)
+
+    result = dispatch({"action": "diagnostic"})
+    serialized = json.dumps(result)
+
+    assert result["service_active"] is True
+    assert result["transport"] == "ws"
+    assert "192.168" not in serialized
+    assert str(tmp_path) not in serialized
+
+
+def test_admin_rejects_unknown_actions() -> None:
+    with pytest.raises(Exception, match="not supported"):
+        dispatch({"action": "delete_everything"})

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -5,10 +5,12 @@ from pathlib import Path
 
 import pytest
 
-from mcpserver.admin import _revoke, dispatch
+from mcpserver.admin import AdminError, _revoke, _save, dispatch
 from mcpserver.auth.loxone_store import LoxoneTokenStoreError
 from mcpserver.auth.store import AtomicJsonAuthStore
 from mcpserver.config import AtomicConfigStore, PluginConfig
+from mcpserver.loxone.client import LoxoneToken
+from mcpserver.loxone.events import LoxoneProtocolError
 
 
 def test_diagnostic_contains_no_paths_endpoint_or_identity(
@@ -45,6 +47,36 @@ def test_diagnostic_contains_no_paths_endpoint_or_identity(
 def test_admin_rejects_unknown_actions() -> None:
     with pytest.raises(Exception, match="not supported"):
         dispatch({"action": "delete_everything"})
+
+
+def test_failed_config_apply_restores_previous_configuration(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = AtomicConfigStore((tmp_path / "config" / "mcpserver.json").resolve())
+    previous = PluginConfig.defaults()
+    store.save(previous)
+    restarts = 0
+
+    def restart() -> None:
+        nonlocal restarts
+        restarts += 1
+        if restarts == 1:
+            raise AdminError("simulated apply failure")
+
+    monkeypatch.setattr("mcpserver.admin._config_store", lambda: store)
+    monkeypatch.setattr("mcpserver.admin._restart_service", restart)
+
+    with pytest.raises(AdminError, match="previous configuration restored"):
+        _save(
+            {
+                "schema_version": 1,
+                "server": {"enabled": True, "public_origin": "https://loxberry.example"},
+                "loxone": {"endpoint": "http://192.168.10.20"},
+            }
+        )
+
+    assert restarts == 2
+    assert store.load().to_document() == previous.to_document()
 
 
 def test_session_list_excludes_revoked_families(
@@ -122,4 +154,97 @@ def test_revoke_survives_unreadable_encrypted_token(
     )
 
     assert _revoke(None) == 1
+    assert store.snapshot()["families"]["family"]["revoked"] is True
+
+
+def test_revoke_survives_corrupt_encrypted_token_store_constructor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    auth_path = (tmp_path / "data" / "auth" / "sessions.json").resolve()
+    token_path = (tmp_path / "data" / "auth" / "loxone-tokens.json.enc").resolve()
+    key_path = (tmp_path / "data" / "auth" / "install.key").resolve()
+    store = AtomicJsonAuthStore(auth_path)
+
+    def add_family(document: dict[str, object]) -> None:
+        families = document["families"]
+        assert isinstance(families, dict)
+        families["family"] = {
+            "client_id": "client",
+            "identity_id": "identity",
+            "miniserver_id": "miniserver",
+            "expires_at": 1_900_000_000,
+            "revoked": False,
+        }
+
+    store.mutate(add_family)
+    token_path.parent.mkdir(parents=True, exist_ok=True)
+    token_path.write_text("not-json", encoding="utf-8")
+    key_path.write_bytes(b"k" * 32)
+    monkeypatch.setenv("MCPSERVER_AUTH_STORE", str(auth_path))
+    monkeypatch.setenv("MCPSERVER_LOXONE_TOKEN_STORE", str(token_path))
+    monkeypatch.setenv("MCPSERVER_INSTALL_KEY", str(key_path))
+    monkeypatch.setattr(
+        "mcpserver.admin._config_store",
+        lambda: type("ConfigStore", (), {"load": lambda self: PluginConfig.defaults()})(),
+    )
+
+    assert _revoke("family") == 1
+    assert store.snapshot()["families"]["family"]["revoked"] is True
+
+
+def test_revoke_deletes_local_token_after_remote_protocol_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    auth_path = (tmp_path / "data" / "auth" / "sessions.json").resolve()
+    store = AtomicJsonAuthStore(auth_path)
+
+    def add_family(document: dict[str, object]) -> None:
+        families = document["families"]
+        assert isinstance(families, dict)
+        families["family"] = {
+            "client_id": "client",
+            "identity_id": "identity",
+            "miniserver_id": "miniserver",
+            "expires_at": 1_900_000_000,
+            "revoked": False,
+        }
+
+    store.mutate(add_family)
+    deleted: list[str] = []
+
+    class TrackingTokenStore:
+        def get(self, family_id: str, miniserver_id: str, identity_id: str) -> LoxoneToken:
+            return LoxoneToken("jwt", "user", "key", "SHA256", 1)
+
+        def delete(self, family_id: str) -> None:
+            deleted.append(family_id)
+
+    class ProtocolFailingClient:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            pass
+
+        async def kill_token(self, token: LoxoneToken) -> None:
+            raise LoxoneProtocolError("unexpected response")
+
+    monkeypatch.setenv("MCPSERVER_AUTH_STORE", str(auth_path))
+    monkeypatch.setattr("mcpserver.admin._token_store", lambda: TrackingTokenStore())
+    monkeypatch.setattr("mcpserver.admin.LoxoneClient", ProtocolFailingClient)
+    monkeypatch.setattr(
+        "mcpserver.admin._config_store",
+        lambda: type(
+            "ConfigStore",
+            (),
+            {
+                "load": lambda self: PluginConfig.from_document(
+                    {
+                        "schema_version": 1,
+                        "loxone": {"endpoint": "http://192.168.10.20"},
+                    }
+                )
+            },
+        )(),
+    )
+
+    assert _revoke("family") == 1
+    assert deleted == ["family"]
     assert store.snapshot()["families"]["family"]["revoked"] is True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from mcpserver.config import AtomicConfigStore, ConfigError, PluginConfig
+
+
+def test_defaults_are_disabled_and_bounded() -> None:
+    config = PluginConfig.defaults()
+
+    assert config.enabled is False
+    assert config.loxone_endpoint == ""
+    assert config.loxone_read_enabled is True
+    assert config.connection_timeout == 10
+    assert config.requests_per_minute == 60
+    assert config.max_parallel_calls == 4
+
+
+def test_configuration_round_trip_preserves_unknown_keys(tmp_path: Path) -> None:
+    store = AtomicConfigStore((tmp_path / "config.json").resolve())
+    config = PluginConfig.from_document(
+        {
+            "schema_version": 1,
+            "server": {"enabled": True, "public_origin": "https://loxberry.local"},
+            "loxone": {"endpoint": "http://192.168.1.10"},
+            "tools": {"loxone_read_enabled": True},
+            "limits": {"requests_per_minute": 30, "max_parallel_calls": 2},
+            "future": {"keep": True},
+        }
+    )
+
+    store.save(config)
+
+    assert store.load().to_document() == config.to_document()
+    assert json.loads(store.path.read_text(encoding="utf-8"))["future"] == {"keep": True}
+
+
+@pytest.mark.parametrize(
+    "document",
+    [
+        {},
+        {"schema_version": 2},
+        {"schema_version": 1, "server": {"enabled": True}},
+        {
+            "schema_version": 1,
+            "server": {"enabled": False},
+            "limits": {"requests_per_minute": 0},
+        },
+        {
+            "schema_version": 1,
+            "server": {"enabled": False},
+            "loxone": {"endpoint": "http://public.example"},
+        },
+    ],
+)
+def test_invalid_configuration_is_rejected(document: object) -> None:
+    with pytest.raises(ConfigError):
+        PluginConfig.from_document(document)
+
+
+def test_failed_save_keeps_previous_valid_configuration(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = AtomicConfigStore((tmp_path / "config.json").resolve())
+    original = PluginConfig.defaults()
+    store.save(original)
+
+    def fail_replace(source: Path, destination: Path) -> None:
+        raise OSError("simulated failure")
+
+    monkeypatch.setattr("mcpserver.config.os.replace", fail_replace)
+    with pytest.raises(ConfigError, match="update failed"):
+        store.save(
+            PluginConfig.from_document(
+                {
+                    "schema_version": 1,
+                    "server": {
+                        "enabled": True,
+                        "public_origin": "https://loxberry.local",
+                    },
+                    "loxone": {"endpoint": "http://192.168.1.20"},
+                }
+            )
+        )
+
+    assert store.load().to_document() == original.to_document()

--- a/tests/test_loxone_client.py
+++ b/tests/test_loxone_client.py
@@ -265,6 +265,38 @@ async def test_probe_rejects_tls_capable_miniserver(monkeypatch: pytest.MonkeyPa
         await client.probe()
 
 
+def test_gen2_endpoint_requires_canonical_https_and_uses_wss() -> None:
+    endpoint = MiniserverEndpoint.parse("https://miniserver.example")
+
+    assert endpoint.secure is True
+    assert endpoint.websocket_url == "wss://miniserver.example/ws/rfc6455"
+    with pytest.raises(ValueError, match="HTTPS"):
+        MiniserverEndpoint.parse("ftp://miniserver.example")
+    with pytest.raises(ValueError, match="canonical"):
+        MiniserverEndpoint.parse("https://MINISERVER.example")
+
+
+@pytest.mark.asyncio
+async def test_gen2_probe_requires_confirmed_tls(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = LoxoneClient(
+        MiniserverEndpoint.parse("https://miniserver.example"),
+        client_uuid=UUID("098802e1-02b4-603c-ffff-eee000d80cfd"),
+    )
+
+    async def fake_get_json(path: str) -> dict[str, object]:
+        assert path == "/jdev/cfg/apiKey"
+        return {
+            "LL": {
+                "Code": "200",
+                "value": {"version": "15.0", "snr": "000000000000", "httpsStatus": 0},
+            }
+        }
+
+    monkeypatch.setattr(client, "_get_json", fake_get_json)
+    with pytest.raises(LoxoneConnectionError, match="confirm TLS"):
+        await client.probe()
+
+
 @pytest.mark.asyncio
 async def test_token_acquisition_encrypts_credentials_and_retains_hash_algorithm(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_loxone_store.py
+++ b/tests/test_loxone_store.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mcpserver.auth.loxone_store import EncryptedLoxoneTokenStore, LoxoneTokenStoreError
+from mcpserver.loxone.client import LoxoneToken
+
+
+def _store(tmp_path: Path) -> EncryptedLoxoneTokenStore:
+    key = tmp_path / "install.key"
+    key.write_bytes(b"k" * 32)
+    return EncryptedLoxoneTokenStore((tmp_path / "loxone-tokens.json.enc").resolve(), key.resolve())
+
+
+def _token() -> LoxoneToken:
+    return LoxoneToken("secret-jwt", "reader", "hash-key", "SHA256", 2_000_000_000)
+
+
+def test_token_is_encrypted_and_bound_to_family_identity_and_miniserver(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.put("family", "miniserver", "identity", _token())
+
+    raw = store.path.read_text(encoding="utf-8")
+    assert "secret-jwt" not in raw
+    assert store.get("family", "miniserver", "identity") == _token()
+    with pytest.raises(LoxoneTokenStoreError, match="binding"):
+        store.get("family", "other", "identity")
+
+
+def test_delete_removes_only_selected_family(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.put("family-1", "miniserver", "identity", _token())
+    store.put("family-2", "miniserver", "identity", _token())
+
+    store.delete("family-1")
+
+    assert store.get("family-1", "miniserver", "identity") is None
+    assert store.family_ids() == ("family-2",)
+
+
+def test_wrong_installation_key_cannot_decrypt(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.put("family", "miniserver", "identity", _token())
+    store.key_path.write_bytes(b"z" * 32)
+    reopened = EncryptedLoxoneTokenStore(store.path, store.key_path)
+
+    with pytest.raises(LoxoneTokenStoreError, match="cannot be decrypted"):
+        reopened.get("family", "miniserver", "identity")

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -18,8 +18,13 @@ from starlette.testclient import TestClient
 
 from mcpserver.auth.provider import SCOPE, Phase0OAuthProvider
 from mcpserver.auth.store import AtomicJsonAuthStore
-from mcpserver.auth.web import Phase0OAuthWeb, _limited_body
-from mcpserver.loxone.client import LoxoneToken, MiniserverEndpoint, ProbeResult
+from mcpserver.auth.web import LoginTransaction, Phase0OAuthWeb, _limited_body
+from mcpserver.loxone.client import (
+    LoxoneConnectionError,
+    LoxoneToken,
+    MiniserverEndpoint,
+    ProbeResult,
+)
 
 ISSUER = "https://public.example/plugins/mcpserver/oauth"
 RESOURCE = "https://public.example/plugins/mcpserver/mcp"
@@ -534,6 +539,47 @@ async def test_parallel_login_posts_acquire_only_one_loxone_token(
     assert sorted(response.status_code for response in responses) == [200, 400]
     assert len(acquired) == 1
     await web._kill(transaction)
+
+
+@pytest.mark.asyncio
+async def test_expired_login_transaction_is_removed_when_remote_kill_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    provider = _provider(tmp_path)
+    web = Phase0OAuthWeb(
+        provider,
+        endpoint=MiniserverEndpoint.parse_gen1("http://192.168.255.254"),
+        issuer=ISSUER,
+        resource=RESOURCE,
+    )
+    token = LoxoneToken("sensitive-jwt", "user", "key", "SHA256", 1)
+    transaction = LoginTransaction(
+        transaction_id="expired",
+        client_id="client",
+        client_name="Client",
+        redirect_uri=REDIRECT,
+        state="state",
+        code_challenge=CHALLENGE,
+        resource=RESOURCE,
+        csrf_token="csrf",
+        created_at=0,
+        loxone_token=token,
+    )
+    web.transactions[transaction.transaction_id] = transaction
+
+    class FailingLoxoneClient:
+        def __init__(self, endpoint: object, *, client_uuid: object) -> None:
+            pass
+
+        async def kill_token(self, value: LoxoneToken) -> None:
+            raise LoxoneConnectionError("remote unavailable")
+
+    monkeypatch.setattr("mcpserver.auth.web.LoxoneClient", FailingLoxoneClient)
+    await web._cleanup()
+
+    assert web.transactions == {}
+    assert transaction.loxone_token is None
+    assert token.value == ""
 
 
 @pytest.mark.asyncio

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -25,6 +25,7 @@ from mcpserver.loxone.client import (
     MiniserverEndpoint,
     ProbeResult,
 )
+from mcpserver.loxone.events import LoxoneProtocolError
 
 ISSUER = "https://public.example/plugins/mcpserver/oauth"
 RESOURCE = "https://public.example/plugins/mcpserver/mcp"
@@ -541,9 +542,12 @@ async def test_parallel_login_posts_acquire_only_one_loxone_token(
     await web._kill(transaction)
 
 
+@pytest.mark.parametrize("failure_type", [LoxoneConnectionError, LoxoneProtocolError])
 @pytest.mark.asyncio
 async def test_expired_login_transaction_is_removed_when_remote_kill_fails(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_type: type[Exception],
 ) -> None:
     provider = _provider(tmp_path)
     web = Phase0OAuthWeb(
@@ -572,7 +576,7 @@ async def test_expired_login_transaction_is_removed_when_remote_kill_fails(
             pass
 
         async def kill_token(self, value: LoxoneToken) -> None:
-            raise LoxoneConnectionError("remote unavailable")
+            raise failure_type("remote unavailable")
 
     monkeypatch.setattr("mcpserver.auth.web.LoxoneClient", FailingLoxoneClient)
     await web._cleanup()
@@ -580,6 +584,39 @@ async def test_expired_login_transaction_is_removed_when_remote_kill_fails(
     assert web.transactions == {}
     assert transaction.loxone_token is None
     assert token.value == ""
+
+
+@pytest.mark.asyncio
+async def test_refresh_replay_revocation_survives_token_cleanup_failure(tmp_path: Path) -> None:
+    def fail_cleanup(family_id: str) -> None:
+        raise RuntimeError("simulated encrypted-store failure")
+
+    provider = Phase0OAuthProvider(
+        AtomicJsonAuthStore(tmp_path / "auth" / "sessions.json"),
+        issuer=ISSUER,
+        resource=RESOURCE,
+        clock=Clock(),
+        on_family_revoked=fail_cleanup,
+    )
+    client = await _client(provider)
+    raw_code = provider.issue_authorization_code(
+        client_id=client.client_id or "",
+        redirect_uri=REDIRECT,
+        code_challenge=CHALLENGE,
+        resource=RESOURCE,
+        identity_id="identity",
+        miniserver_id="miniserver",
+    )
+    code = await provider.load_authorization_code(client, raw_code)
+    assert code is not None
+    issued = await provider.exchange_authorization_code(client, code)
+    refresh = await provider.load_refresh_token(client, issued.refresh_token or "")
+    assert refresh is not None
+    await provider.exchange_refresh_token(client, refresh, [SCOPE])
+
+    assert await provider.load_refresh_token(client, issued.refresh_token or "") is None
+    document = provider.store.snapshot()
+    assert document["families"][refresh.family_id]["revoked"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -229,6 +229,40 @@ def test_plugin_archive_verifier_accepts_builder_output(tmp_path: Path) -> None:
 
     assert verify_archive(output) == hashlib.sha256(output.read_bytes()).hexdigest()
 
+    with zipfile.ZipFile(output) as source:
+        omitted = next(
+            name
+            for name in source.namelist()
+            if name.startswith("bin/wheelhouse/")
+            and not name.startswith("bin/wheelhouse/loxberry_mcpserver-")
+        )
+        tampered = tmp_path / "tampered.zip"
+        with zipfile.ZipFile(tampered, "w") as destination:
+            for entry in source.infolist():
+                if entry.filename != omitted:
+                    destination.writestr(entry, source.read(entry))
+    tampered_digest = hashlib.sha256(tampered.read_bytes()).hexdigest()
+    tampered.with_suffix(".zip.sha256").write_text(
+        f"{tampered_digest}  {tampered.name}\n", encoding="ascii"
+    )
+    with pytest.raises(PackageVerificationError, match="does not match its lock"):
+        verify_archive(tampered)
+
+    (wheelhouse / "foreign_package-9.9-py3-none-any.whl").write_bytes(b"foreign")
+    rejected = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "tools" / "build_plugin.py"),
+            "--wheelhouse",
+            str(wheelhouse),
+            "--output",
+            str(tmp_path / "rejected.zip"),
+        ],
+        check=False,
+        cwd=ROOT,
+    )
+    assert rejected.returncode != 0
+
 
 def test_release_helpers_exclude_stale_project_wheel_and_refuse_overwrite(
     tmp_path: Path,
@@ -238,9 +272,11 @@ def test_release_helpers_exclude_stale_project_wheel_and_refuse_overwrite(
     source.mkdir()
     destination.mkdir()
     (source / "dependency-1.0-py3-none-any.whl").write_bytes(b"dependency")
+    (source / "dependency-0.9-py3-none-any.whl").write_bytes(b"stale dependency")
+    (source / "foreign-1.0-py3-none-any.whl").write_bytes(b"foreign")
     (source / "loxberry_mcpserver-0.1.0a1-py3-none-any.whl").write_bytes(b"stale")
 
-    _copy_runtime_wheels(source, destination)
+    _copy_runtime_wheels(source, destination, {"dependency": "1.0"})
 
     assert [item.name for item in destination.iterdir()] == ["dependency-1.0-py3-none-any.whl"]
     candidate = tmp_path / "candidate.zip"
@@ -249,6 +285,18 @@ def test_release_helpers_exclude_stale_project_wheel_and_refuse_overwrite(
     output.write_bytes(b"old")
     with pytest.raises(RuntimeError, match="different content"):
         _publish(candidate, output, hashlib.sha256(candidate.read_bytes()).hexdigest())
+
+
+@pytest.mark.parametrize("script", ["tools/verify_plugin.py", "tools/build_release_candidate.py"])
+def test_documented_python_automation_clis_start_without_pythonpath(script: str) -> None:
+    result = subprocess.run(
+        [sys.executable, script, "--help"],
+        check=False,
+        cwd=ROOT,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    assert result.returncode == 0
 
 
 def test_mcp_client_probe_has_valid_powershell_syntax() -> None:

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -54,6 +54,23 @@ def test_v4_package_manifest_is_present() -> None:
     assert "LBPDATA/$actual_folder" in hooks
 
 
+def test_upgrade_preserves_configuration_in_plugin_data() -> None:
+    preupgrade = (ROOT / "preupgrade.sh").read_text(encoding="utf-8")
+    postinstall = (ROOT / "postinstall.sh").read_text(encoding="utf-8")
+
+    assert "installer_root=${6:-}" in preupgrade
+    assert 'backup_dir="$installer_root/.mcpserver-upgrade"' in preupgrade
+    assert 'install -m 600 "$config_file" "$backup_dir/mcpserver.json"' in preupgrade
+    assert "sessions.json loxone-tokens.json.enc install.key" in preupgrade
+    assert "installer_root=${6:-}" in postinstall
+    assert 'upgrade_backup="$upgrade_backup_dir/mcpserver.json"' in postinstall
+    assert 'install -m 600 "$upgrade_backup" "$config_file"' in postinstall
+    assert "sessions.json loxone-tokens.json.enc install.key" in postinstall
+    assert postinstall.index('install -m 600 "$upgrade_backup" "$config_file"') < postinstall.index(
+        'cp "$plugin_config/default-config.json" "$config_file"'
+    )
+
+
 def test_shell_hooks_have_valid_syntax() -> None:
     bash = shutil.which("bash")
     if bash is None:

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
 import configparser
+import hashlib
+import os
 import shutil
 import subprocess
+import sys
 import zipfile
 from pathlib import Path
 
 import pytest
 
-from tools.build_plugin import _EXECUTABLES, _add
+from tools.build_plugin import _EXECUTABLES, _add, _locked_requirements
+from tools.build_release_candidate import _copy_runtime_wheels, _publish
+from tools.verify_plugin import PackageVerificationError, verify_archive
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -186,3 +191,88 @@ def test_package_builder_emits_unix_executable_modes(tmp_path: Path) -> None:
         assert executable.external_attr >> 16 & 0o777 == 0o755
         assert regular.external_attr >> 16 & 0o777 == 0o644
         assert "bin/healthcheck" in _EXECUTABLES
+
+
+def test_package_builder_normalizes_installed_text_to_lf(tmp_path: Path) -> None:
+    source = tmp_path / "runtime.lock"
+    source.write_bytes(b"first\r\nsecond\r\n")
+    output = tmp_path / "test.zip"
+
+    with zipfile.ZipFile(output, "w") as archive:
+        _add(archive, source, "bin/runtime-arm64.lock")
+
+    with zipfile.ZipFile(output) as archive:
+        assert archive.read("bin/runtime-arm64.lock") == b"first\nsecond\n"
+
+
+def test_plugin_archive_verifier_accepts_builder_output(tmp_path: Path) -> None:
+    wheelhouse = tmp_path / "wheelhouse"
+    wheelhouse.mkdir()
+    for name, version in _locked_requirements(ROOT / "requirements" / "runtime-arm64.lock").items():
+        wheel_name = name.replace("-", "_")
+        (wheelhouse / f"{wheel_name}-{version}-py3-none-any.whl").write_bytes(b"wheel")
+    (wheelhouse / "loxberry_mcpserver-0.1.0a1-py3-none-any.whl").write_bytes(b"project")
+    output = tmp_path / "plugin.zip"
+
+    subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "tools" / "build_plugin.py"),
+            "--wheelhouse",
+            str(wheelhouse),
+            "--output",
+            str(output),
+        ],
+        check=True,
+        cwd=ROOT,
+    )
+
+    assert verify_archive(output) == hashlib.sha256(output.read_bytes()).hexdigest()
+
+
+def test_release_helpers_exclude_stale_project_wheel_and_refuse_overwrite(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    source.mkdir()
+    destination.mkdir()
+    (source / "dependency-1.0-py3-none-any.whl").write_bytes(b"dependency")
+    (source / "loxberry_mcpserver-0.1.0a1-py3-none-any.whl").write_bytes(b"stale")
+
+    _copy_runtime_wheels(source, destination)
+
+    assert [item.name for item in destination.iterdir()] == ["dependency-1.0-py3-none-any.whl"]
+    candidate = tmp_path / "candidate.zip"
+    output = tmp_path / "published.zip"
+    candidate.write_bytes(b"new")
+    output.write_bytes(b"old")
+    with pytest.raises(RuntimeError, match="different content"):
+        _publish(candidate, output, hashlib.sha256(candidate.read_bytes()).hexdigest())
+
+
+def test_mcp_client_probe_has_valid_powershell_syntax() -> None:
+    pwsh = shutil.which("pwsh")
+    if pwsh is None:
+        pytest.skip("PowerShell is unavailable")
+    script = ROOT / "tools" / "test_mcp_client.ps1"
+    command = (
+        "$errors=$null; [void][System.Management.Automation.Language.Parser]::"
+        "ParseFile($env:MCPSERVER_POWERSHELL_TEST_SCRIPT,[ref]$null,[ref]$errors); "
+        "if($errors.Count){exit 1}"
+    )
+    subprocess.run(
+        [pwsh, "-NoProfile", "-Command", command],
+        check=True,
+        env={**os.environ, "MCPSERVER_POWERSHELL_TEST_SCRIPT": str(script)},
+    )
+
+
+def test_plugin_archive_verifier_rejects_checksum_mismatch(tmp_path: Path) -> None:
+    archive = tmp_path / "plugin.zip"
+    with zipfile.ZipFile(archive, "w") as package:
+        package.writestr("plugin.cfg", b"invalid")
+    archive.with_suffix(".zip.sha256").write_text(f"{'0' * 64}  {archive.name}\n", encoding="ascii")
+
+    with pytest.raises(PackageVerificationError, match="checksum"):
+        verify_archive(archive)

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -262,6 +262,42 @@ def test_plugin_archive_verifier_accepts_builder_output(tmp_path: Path) -> None:
         cwd=ROOT,
     )
     assert rejected.returncode != 0
+    (wheelhouse / "foreign_package-9.9-py3-none-any.whl").unlink()
+    (wheelhouse / "loxberry_mcpserver-0.0.9-py3-none-any.whl").write_bytes(b"stale project")
+    stale_project = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "tools" / "build_plugin.py"),
+            "--wheelhouse",
+            str(wheelhouse),
+            "--output",
+            str(tmp_path / "stale-project.zip"),
+        ],
+        check=False,
+        cwd=ROOT,
+    )
+    assert stale_project.returncode != 0
+
+    placeholder = tmp_path / "placeholder.zip"
+    with zipfile.ZipFile(output) as source, zipfile.ZipFile(placeholder, "w") as destination:
+        for entry in source.infolist():
+            if entry.filename.startswith("bin/wheelhouse/loxberry_mcpserver-"):
+                replacement = zipfile.ZipInfo(
+                    "bin/wheelhouse/loxberry_mcpserver-0.1.0a1-placeholder.txt",
+                    entry.date_time,
+                )
+                replacement.create_system = entry.create_system
+                replacement.external_attr = entry.external_attr
+                replacement.compress_type = entry.compress_type
+                destination.writestr(replacement, b"not a wheel")
+            else:
+                destination.writestr(entry, source.read(entry))
+    placeholder_digest = hashlib.sha256(placeholder.read_bytes()).hexdigest()
+    placeholder.with_suffix(".zip.sha256").write_text(
+        f"{placeholder_digest}  {placeholder.name}\n", encoding="ascii"
+    )
+    with pytest.raises(PackageVerificationError, match="invalid entry"):
+        verify_archive(placeholder)
 
 
 def test_release_helpers_exclude_stale_project_wheel_and_refuse_overwrite(

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import configparser
+import shutil
+import subprocess
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from tools.build_plugin import _EXECUTABLES, _add
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_plugin_identity_and_platform_contract() -> None:
+    parser = configparser.ConfigParser()
+    parser.read(ROOT / "plugin.cfg", encoding="utf-8")
+
+    assert parser["PLUGIN"]["NAME"] == "mcpserver"
+    assert parser["PLUGIN"]["FOLDER"] == "mcpserver"
+    assert parser["PLUGIN"]["TITLE"] == "LoxBerry MCP Server"
+    assert parser["PLUGIN"]["VERSION"] == "0.1.0-alpha.1"
+    assert parser["SYSTEM"]["LB_MINIMUM"] == "4.0.0"
+    assert parser["SYSTEM"]["INTERFACE"] == "2.0"
+    for name in ("release.cfg", "prerelease.cfg"):
+        update = configparser.ConfigParser()
+        update.read(ROOT / name, encoding="utf-8")
+        assert "AUTOUPDATE" in update
+
+
+def test_v4_package_manifest_is_present() -> None:
+    required = [
+        "preinstall.sh",
+        "preupgrade.sh",
+        "postinstall.sh",
+        "postroot.sh",
+        "postupgrade.sh",
+        "uninstall/uninstall.sh",
+        "bin/healthcheck",
+        "icons/icon.svg",
+        "webfrontend/htmlauth/index.cgi",
+        "templates/index.html",
+        "templates/lang/language_de.ini",
+        "templates/lang/language_en.ini",
+    ]
+    assert all((ROOT / item).is_file() for item in required)
+    hooks = "\n".join(
+        (ROOT / item).read_text(encoding="utf-8")
+        for item in ("postinstall.sh", "postupgrade.sh", "postroot.sh")
+    )
+    assert "actual_folder=$3" in hooks
+    assert "LBPCONFIG/$actual_folder" in hooks
+    assert "LBPDATA/$actual_folder" in hooks
+
+
+def test_shell_hooks_have_valid_syntax() -> None:
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.skip("bash is unavailable")
+    scripts = [
+        "preinstall.sh",
+        "preupgrade.sh",
+        "postinstall.sh",
+        "postroot.sh",
+        "postupgrade.sh",
+        "uninstall/uninstall.sh",
+        "bin/healthcheck",
+        "bin/mcpserver-admin",
+    ]
+    subprocess.run([bash, "-n", *(str(ROOT / item) for item in scripts)], check=True)
+
+
+def test_postroot_keeps_installer_alive_during_apache_activation() -> None:
+    hook = (ROOT / "postroot.sh").read_text(encoding="utf-8")
+
+    assert "systemctl restart apache2" not in hook
+    assert "systemctl reload apache2" in hook
+    assert hook.index("systemctl restart loxberry-mcpserver.service") < hook.index(
+        "systemctl reload apache2"
+    )
+    assert '(umask 0137 && openssl rand 32 > "$key")' in hook
+    assert 'chmod 644 "$unit" "$apache"' in hook
+
+
+def test_postinstall_rewrites_moved_venv_entrypoints() -> None:
+    hook = (ROOT / "postinstall.sh").read_text(encoding="utf-8")
+
+    assert '"#!$new_venv/bin/python"' in hook
+    assert 'sed -i "1c\\\\#!$venv/bin/python"' in hook
+    assert 'rm -rf -- "$venv"' in hook
+    assert 'mv "$old_venv" "$venv"' in hook
+
+
+def test_package_builder_includes_plugin_icon() -> None:
+    source = (ROOT / "tools" / "build_plugin.py").read_text(encoding="utf-8")
+
+    assert '"icons"' in source
+    assert (ROOT / "icons" / "icon.svg").is_file()
+
+
+def test_perl_admin_cgi_has_valid_syntax() -> None:
+    perl = shutil.which("perl")
+    if perl is None:
+        pytest.skip("perl is unavailable")
+    subprocess.run(
+        [
+            perl,
+            f"-I{ROOT / 'tests' / 'perl_stubs'}",
+            "-c",
+            str(ROOT / "webfrontend/htmlauth/index.cgi"),
+        ],
+        check=True,
+    )
+
+
+def test_language_files_have_matching_contracts() -> None:
+    def keys(path: Path) -> set[tuple[str, str]]:
+        parser = configparser.ConfigParser()
+        parser.optionxform = str  # type: ignore[assignment]
+        parser.read(path, encoding="utf-8")
+        return {(section, key) for section in parser.sections() for key in parser[section]}
+
+    assert keys(ROOT / "templates/lang/language_de.ini") == keys(
+        ROOT / "templates/lang/language_en.ini"
+    )
+
+
+def test_ui_is_nojqm_responsive_and_progressively_enhanced() -> None:
+    cgi = (ROOT / "webfrontend/htmlauth/index.cgi").read_text(encoding="utf-8")
+    template = (ROOT / "templates/index.html").read_text(encoding="utf-8")
+
+    assert "'nojqm'" in cgi
+    assert "ajax-generic.php" not in cgi + template
+    assert 'method="post"' in template
+    assert "fetch('index.cgi'" in template
+    assert "overflow-x: auto" in template
+    assert "@media (max-width: 30rem)" in template
+    assert "#diagnostics .lb-table-scroll { overflow-x: visible; }" in template
+    assert ":focus-visible" in template
+
+
+def test_installed_text_files_use_lf_only() -> None:
+    paths = [
+        *(ROOT / name for name in ("plugin.cfg", "release.cfg", "prerelease.cfg")),
+        *(ROOT / name for name in ("preinstall.sh", "postinstall.sh", "postroot.sh")),
+        *(
+            item
+            for folder in ("bin", "config", "templates", "uninstall", "webfrontend")
+            for item in (ROOT / folder).rglob("*")
+            if item.is_file()
+        ),
+    ]
+    for path in paths:
+        assert b"\r\n" not in path.read_bytes(), path
+
+
+def test_package_builder_emits_unix_executable_modes(tmp_path: Path) -> None:
+    output = tmp_path / "test.zip"
+    source = ROOT / "bin" / "healthcheck"
+    with zipfile.ZipFile(output, "w") as archive:
+        _add(archive, source, "bin/healthcheck")
+        _add(archive, ROOT / "plugin.cfg", "plugin.cfg")
+
+    with zipfile.ZipFile(output) as archive:
+        executable = archive.getinfo("bin/healthcheck")
+        regular = archive.getinfo("plugin.cfg")
+        assert executable.create_system == 3
+        assert executable.external_attr >> 16 & 0o777 == 0o755
+        assert regular.external_attr >> 16 & 0o777 == 0o644
+        assert "bin/healthcheck" in _EXECUTABLES

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -31,6 +31,32 @@ def test_health_is_small_and_contains_no_configuration() -> None:
     assert set(response.json()) == {"ok", "service", "version"}
 
 
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("post", "/mcp"),
+        ("get", "/.well-known/oauth-protected-resource/plugins/mcpserver/mcp"),
+        ("get", "/authorize"),
+    ],
+)
+def test_disabled_service_exposes_only_health(method: str, path: str) -> None:
+    settings = ServerSettings(
+        host="127.0.0.1",
+        port=8765,
+        allowed_hosts=("testserver",),
+        allowed_origins=(),
+        service_enabled=False,
+    )
+    app = create_server(settings).streamable_http_app()
+    with TestClient(app, base_url="http://testserver") as client:
+        health = client.get("/healthz")
+        response = client.request(method, path)
+
+    assert health.status_code == 200
+    assert response.status_code == 503
+    assert response.json() == {"ok": False, "error": "service_disabled"}
+
+
 def test_health_rejects_unknown_host() -> None:
     app = create_server(_settings()).streamable_http_app()
     with TestClient(app, base_url="http://untrusted.example") as client:
@@ -137,7 +163,7 @@ def test_mcp_initialize_uses_expected_protocol() -> None:
     assert response.json()["result"]["serverInfo"]["name"] == "LoxBerry MCP Server"
 
 
-def test_no_unreleased_domain_tools_are_published() -> None:
+def test_exact_phase1_read_only_tools_are_published() -> None:
     app = create_server(_settings()).streamable_http_app()
     request = {
         "jsonrpc": "2.0",
@@ -154,7 +180,17 @@ def test_no_unreleased_domain_tools_are_published() -> None:
         response = client.post("/mcp", json=request, headers=headers)
 
     assert response.status_code == 200
-    assert response.json()["result"]["tools"] == []
+    tools = response.json()["result"]["tools"]
+    assert [tool["name"] for tool in tools] == [
+        "loxone_get_system_status",
+        "loxone_list_rooms",
+        "loxone_list_categories",
+        "loxone_find_controls",
+        "loxone_describe_control",
+        "loxone_get_states",
+    ]
+    assert all(tool["annotations"]["readOnlyHint"] is True for tool in tools)
+    assert all(tool["annotations"]["destructiveHint"] is False for tool in tools)
 
 
 def test_oauth_routes_and_protected_resource_metadata_are_exact(tmp_path: Path) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -191,6 +191,8 @@ def test_exact_phase1_read_only_tools_are_published() -> None:
     ]
     assert all(tool["annotations"]["readOnlyHint"] is True for tool in tools)
     assert all(tool["annotations"]["destructiveHint"] is False for tool in tools)
+    assert all(tool["outputSchema"]["properties"]["data"].get("anyOf") for tool in tools)
+    assert all(tool["outputSchema"].get("$defs") for tool in tools)
 
 
 def test_oauth_routes_and_protected_resource_metadata_are_exact(tmp_path: Path) -> None:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -22,6 +22,9 @@ def test_secure_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
         "MCPSERVER_PUBLIC_ORIGIN",
         "MCPSERVER_AUTH_STORE",
         "MCPSERVER_LOXONE_ENDPOINT",
+        "MCPSERVER_CONFIG",
+        "MCPSERVER_LOXONE_TOKEN_STORE",
+        "MCPSERVER_INSTALL_KEY",
     ):
         monkeypatch.delenv(key, raising=False)
 
@@ -32,6 +35,47 @@ def test_secure_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     assert settings.allowed_hosts == ("127.0.0.1:8765", "localhost:8765")
     assert settings.allowed_origins == ()
     assert settings.phase0_auth is None
+    assert settings.service_enabled is True
+
+
+def test_disabled_phase1_configuration_fails_closed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config = tmp_path / "mcpserver.json"
+    config.write_text('{"schema_version":1,"server":{"enabled":false}}', encoding="utf-8")
+    monkeypatch.setenv("MCPSERVER_CONFIG", str(config))
+
+    settings = ServerSettings.from_environment()
+
+    assert settings.phase0_auth is None
+    assert settings.service_enabled is False
+
+
+def test_enabled_phase1_configuration_supplies_endpoint_and_public_origin(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config = tmp_path / "mcpserver.json"
+    config.write_text(
+        '{"schema_version":1,"server":{"enabled":true,"public_origin":'
+        '"https://mcp.example"},"loxone":{"endpoint":"https://miniserver.example"}}',
+        encoding="utf-8",
+    )
+    key = tmp_path / "install.key"
+    key.write_bytes(b"k" * 32)
+    monkeypatch.setenv("MCPSERVER_CONFIG", str(config))
+    monkeypatch.setenv("MCPSERVER_PUBLIC_ORIGIN", "")
+    monkeypatch.setenv("MCPSERVER_AUTH_STORE", str(tmp_path / "sessions.json"))
+    monkeypatch.delenv("MCPSERVER_LOXONE_ENDPOINT", raising=False)
+    monkeypatch.setenv("MCPSERVER_LOXONE_TOKEN_STORE", str(tmp_path / "tokens.json.enc"))
+    monkeypatch.setenv("MCPSERVER_INSTALL_KEY", str(key))
+
+    settings = ServerSettings.from_environment()
+
+    assert settings.phase0_auth is not None
+    assert settings.service_enabled is True
+    assert settings.phase0_auth.loxone_endpoint.secure is True
+    assert "mcp.example" in settings.allowed_hosts
+    assert "https://mcp.example" in settings.allowed_origins
 
 
 def test_phase0_auth_settings_are_derived_without_credentials(

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pytest
+
+from mcpserver.tools import _CursorCodec, _page
+
+
+def test_opaque_cursor_paginates_without_exposing_offset() -> None:
+    codec = _CursorCodec()
+    first = _page(codec, "rooms", list(range(75)), None, 50)
+
+    assert first["items"] == list(range(50))
+    assert isinstance(first["next_cursor"], str)
+    assert "50" not in first["next_cursor"]
+    second = _page(codec, "rooms", list(range(75)), first["next_cursor"], 50)
+    assert second == {"items": list(range(50, 75)), "next_cursor": None}
+
+
+def test_cursor_cannot_cross_scope_or_be_modified() -> None:
+    codec = _CursorCodec()
+    cursor = codec.encode("rooms", 2)
+
+    with pytest.raises(ValueError, match="cursor is invalid"):
+        codec.decode("categories", cursor)
+    with pytest.raises(ValueError, match="cursor is invalid"):
+        codec.decode("rooms", cursor[:-1] + ("A" if cursor[-1] != "A" else "B"))
+
+
+@pytest.mark.parametrize("limit", [0, 101])
+def test_page_limit_is_bounded(limit: int) -> None:
+    with pytest.raises(ValueError, match="between 1 and 100"):
+        _page(_CursorCodec(), "rooms", [], None, limit)

--- a/tools/build_plugin.py
+++ b/tools/build_plugin.py
@@ -1,0 +1,132 @@
+"""Create a deterministic LoxBerry V4 ZIP from a verified offline wheelhouse."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import zipfile
+from pathlib import Path
+from typing import Final
+
+_TIMESTAMP: Final = (2026, 1, 1, 0, 0, 0)
+_ROOT_FILES: Final = (
+    ".gitattributes",
+    "LICENSE",
+    "plugin.cfg",
+    "preinstall.sh",
+    "preupgrade.sh",
+    "release.cfg",
+    "prerelease.cfg",
+    "postinstall.sh",
+    "postroot.sh",
+    "postupgrade.sh",
+)
+_DIRECTORIES: Final = ("config", "icons", "templates", "uninstall", "webfrontend")
+_EXECUTABLES: Final = {
+    "preinstall.sh",
+    "preupgrade.sh",
+    "postinstall.sh",
+    "postroot.sh",
+    "postupgrade.sh",
+    "uninstall/uninstall.sh",
+    "bin/healthcheck",
+    "bin/mcpserver-admin",
+    "webfrontend/htmlauth/index.cgi",
+}
+
+
+def _locked_requirements(lock: Path) -> dict[str, str]:
+    requirements: dict[str, str] = {}
+    for line in lock.read_text(encoding="utf-8").splitlines():
+        match = re.match(r"([A-Za-z0-9_.-]+)==([A-Za-z0-9_.+-]+)$", line)
+        if match:
+            name = re.sub(r"[-_.]+", "-", match.group(1)).lower()
+            requirements[name] = match.group(2)
+    return requirements
+
+
+def _wheel_names(wheelhouse: Path) -> set[str]:
+    return {
+        re.sub(
+            r"[-_.]+",
+            "-",
+            re.split(r"-(?=\d)", item.name, maxsplit=1)[0],
+        ).lower()
+        for item in wheelhouse.glob("*.whl")
+    }
+
+
+def _wheel_versions(wheelhouse: Path) -> set[tuple[str, str]]:
+    result: set[tuple[str, str]] = set()
+    for item in wheelhouse.glob("*.whl"):
+        parts = item.name.removesuffix(".whl").split("-")
+        if len(parts) >= 5:
+            result.add((re.sub(r"[-_.]+", "-", parts[0]).lower(), parts[1].lower()))
+    return result
+
+
+def _add(archive: zipfile.ZipFile, source: Path, target: str) -> None:
+    info = zipfile.ZipInfo(target.replace("\\", "/"), _TIMESTAMP)
+    info.create_system = 3
+    info.compress_type = zipfile.ZIP_DEFLATED
+    mode = 0o755 if target.replace("\\", "/") in _EXECUTABLES else 0o644
+    info.external_attr = (mode | 0o100000) << 16
+    archive.writestr(info, source.read_bytes())
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--wheelhouse", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    root = Path(__file__).resolve().parents[1]
+    wheelhouse = args.wheelhouse.resolve()
+    output = args.output.resolve()
+    lock = root / "requirements" / "runtime-arm64.lock"
+
+    requirements = _locked_requirements(lock)
+    wheel_versions = _wheel_versions(wheelhouse)
+    missing = set(requirements) - _wheel_names(wheelhouse)
+    mismatched = {
+        name
+        for name, version in requirements.items()
+        if (name, version.lower()) not in wheel_versions
+    }
+    project_wheels = tuple(wheelhouse.glob("loxberry_mcpserver-0.1.0a1-*.whl"))
+    if missing or mismatched or len(project_wheels) != 1:
+        detail = ", ".join(sorted(missing | mismatched)) or "project wheel"
+        raise SystemExit(f"wheelhouse is incomplete: {detail}")
+
+    entries: list[tuple[Path, str]] = []
+    entries.extend((root / name, name) for name in _ROOT_FILES)
+    entries.extend(
+        (item, item.relative_to(root).as_posix())
+        for directory in _DIRECTORIES
+        for item in (root / directory).rglob("*")
+        if item.is_file()
+    )
+    entries.extend(
+        [
+            (root / "bin" / "healthcheck", "bin/healthcheck"),
+            (root / "bin" / "mcpserver-admin", "bin/mcpserver-admin"),
+            (lock, "bin/runtime-arm64.lock"),
+        ]
+    )
+    entries.extend((item, f"bin/wheelhouse/{item.name}") for item in wheelhouse.glob("*.whl"))
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(output, "w") as archive:
+        for source, target in sorted(entries, key=lambda item: item[1]):
+            _add(archive, source, target)
+    digest = hashlib.sha256(output.read_bytes()).hexdigest()
+    output.with_suffix(output.suffix + ".sha256").write_text(
+        f"{digest}  {output.name}\n", encoding="ascii", newline="\n"
+    )
+    print(output)
+    print(output.with_suffix(output.suffix + ".sha256"))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/build_plugin.py
+++ b/tools/build_plugin.py
@@ -113,11 +113,14 @@ def main() -> int:
     lock = root / "requirements" / "runtime-arm64.lock"
 
     requirements = _locked_requirements(lock)
-    wheel_versions = _wheel_versions(wheelhouse)
+    wheel_files = list(wheelhouse.glob("*.whl"))
+    wheel_identities = _wheel_identities(wheelhouse)
+    wheel_versions = set(wheel_identities)
+    project_identities = [
+        identity for identity in wheel_identities if identity[0] == "loxberry-mcpserver"
+    ]
     runtime_wheels = [
-        identity
-        for identity in _wheel_identities(wheelhouse)
-        if identity[0] != "loxberry-mcpserver"
+        identity for identity in wheel_identities if identity[0] != "loxberry-mcpserver"
     ]
     expected_runtime = {(name, version.lower()) for name, version in requirements.items()}
     missing = set(requirements) - _wheel_names(wheelhouse)
@@ -127,14 +130,28 @@ def main() -> int:
         if (name, version.lower()) not in wheel_versions
     }
     project_wheels = tuple(wheelhouse.glob("loxberry_mcpserver-0.1.0a1-*.whl"))
+    expected_project = [("loxberry-mcpserver", "0.1.0a1")]
     unexpected = set(runtime_wheels) - expected_runtime
     duplicates = len(runtime_wheels) != len(set(runtime_wheels))
-    if missing or mismatched or unexpected or duplicates or len(project_wheels) != 1:
+    invalid_wheel = len(wheel_files) != len(wheel_identities)
+    if (
+        missing
+        or mismatched
+        or unexpected
+        or duplicates
+        or invalid_wheel
+        or len(project_wheels) != 1
+        or project_identities != expected_project
+    ):
         detail = ", ".join(sorted(missing | mismatched)) or "project wheel"
         if unexpected:
             detail = ", ".join(sorted(name for name, _version in unexpected))
         if duplicates:
             detail = "duplicate runtime wheel"
+        if invalid_wheel:
+            detail = "invalid wheel filename"
+        if project_identities != expected_project:
+            detail = "unexpected project wheel"
         raise SystemExit(f"wheelhouse is incomplete: {detail}")
 
     entries: list[tuple[Path, str]] = []

--- a/tools/build_plugin.py
+++ b/tools/build_plugin.py
@@ -34,6 +34,20 @@ _EXECUTABLES: Final = {
     "bin/mcpserver-admin",
     "webfrontend/htmlauth/index.cgi",
 }
+_TEXT_SUFFIXES: Final = {
+    ".cfg",
+    ".cgi",
+    ".conf",
+    ".html",
+    ".ini",
+    ".json",
+    ".lock",
+    ".md",
+    ".sh",
+    ".svg",
+    ".txt",
+}
+_TEXT_NAMES: Final = {".gitattributes", "LICENSE", "bin/healthcheck", "bin/mcpserver-admin"}
 
 
 def _locked_requirements(lock: Path) -> dict[str, str]:
@@ -72,7 +86,11 @@ def _add(archive: zipfile.ZipFile, source: Path, target: str) -> None:
     info.compress_type = zipfile.ZIP_DEFLATED
     mode = 0o755 if target.replace("\\", "/") in _EXECUTABLES else 0o644
     info.external_attr = (mode | 0o100000) << 16
-    archive.writestr(info, source.read_bytes())
+    content = source.read_bytes()
+    target_path = Path(target)
+    if target_path.suffix.lower() in _TEXT_SUFFIXES or target.replace("\\", "/") in _TEXT_NAMES:
+        content = content.replace(b"\r\n", b"\n")
+    archive.writestr(info, content)
 
 
 def main() -> int:

--- a/tools/build_plugin.py
+++ b/tools/build_plugin.py
@@ -80,6 +80,15 @@ def _wheel_versions(wheelhouse: Path) -> set[tuple[str, str]]:
     return result
 
 
+def _wheel_identities(wheelhouse: Path) -> list[tuple[str, str]]:
+    result: list[tuple[str, str]] = []
+    for item in wheelhouse.glob("*.whl"):
+        parts = item.name.removesuffix(".whl").split("-")
+        if len(parts) >= 5:
+            result.append((re.sub(r"[-_.]+", "-", parts[0]).lower(), parts[1].lower()))
+    return result
+
+
 def _add(archive: zipfile.ZipFile, source: Path, target: str) -> None:
     info = zipfile.ZipInfo(target.replace("\\", "/"), _TIMESTAMP)
     info.create_system = 3
@@ -105,6 +114,12 @@ def main() -> int:
 
     requirements = _locked_requirements(lock)
     wheel_versions = _wheel_versions(wheelhouse)
+    runtime_wheels = [
+        identity
+        for identity in _wheel_identities(wheelhouse)
+        if identity[0] != "loxberry-mcpserver"
+    ]
+    expected_runtime = {(name, version.lower()) for name, version in requirements.items()}
     missing = set(requirements) - _wheel_names(wheelhouse)
     mismatched = {
         name
@@ -112,8 +127,14 @@ def main() -> int:
         if (name, version.lower()) not in wheel_versions
     }
     project_wheels = tuple(wheelhouse.glob("loxberry_mcpserver-0.1.0a1-*.whl"))
-    if missing or mismatched or len(project_wheels) != 1:
+    unexpected = set(runtime_wheels) - expected_runtime
+    duplicates = len(runtime_wheels) != len(set(runtime_wheels))
+    if missing or mismatched or unexpected or duplicates or len(project_wheels) != 1:
         detail = ", ".join(sorted(missing | mismatched)) or "project wheel"
+        if unexpected:
+            detail = ", ".join(sorted(name for name, _version in unexpected))
+        if duplicates:
+            detail = "duplicate runtime wheel"
         raise SystemExit(f"wheelhouse is incomplete: {detail}")
 
     entries: list[tuple[Path, str]] = []

--- a/tools/build_release_candidate.py
+++ b/tools/build_release_candidate.py
@@ -1,0 +1,130 @@
+"""Build and verify a reproducible Phase 1 LoxBerry release candidate."""
+
+from __future__ import annotations
+
+import argparse
+import configparser
+import hashlib
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from tools.verify_plugin import verify_archive
+
+
+def _run(*arguments: str, root: Path, environment: dict[str, str] | None = None) -> None:
+    subprocess.run(arguments, check=True, cwd=root, env=environment)
+
+
+def _version(root: Path) -> str:
+    parser = configparser.ConfigParser()
+    parser.read(root / "plugin.cfg", encoding="utf-8")
+    return parser["PLUGIN"]["VERSION"]
+
+
+def _copy_runtime_wheels(source: Path, destination: Path) -> None:
+    if not source.is_dir():
+        raise RuntimeError("runtime wheelhouse does not exist")
+    for wheel in source.glob("*.whl"):
+        if not wheel.name.startswith("loxberry_mcpserver-"):
+            shutil.copy2(wheel, destination / wheel.name)
+
+
+def _build_project_wheel(root: Path, wheelhouse: Path, environment: dict[str, str]) -> None:
+    _run(
+        sys.executable,
+        "-m",
+        "pip",
+        "wheel",
+        "--ignore-requires-python",
+        "--no-deps",
+        "--no-cache-dir",
+        "--wheel-dir",
+        str(wheelhouse),
+        ".",
+        root=root,
+        environment=environment,
+    )
+
+
+def _publish(candidate: Path, output: Path, digest: str) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    if output.exists() and hashlib.sha256(output.read_bytes()).hexdigest() != digest:
+        raise RuntimeError("release output already exists with different content")
+    if not output.exists():
+        temporary = output.with_name(f".{output.name}.tmp")
+        shutil.copy2(candidate, temporary)
+        os.replace(temporary, output)
+    output.with_suffix(output.suffix + ".sha256").write_text(
+        f"{digest}  {output.name}\n", encoding="ascii", newline="\n"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", type=Path, default=Path("dist"))
+    parser.add_argument(
+        "--runtime-wheelhouse",
+        type=Path,
+        help="Reuse cached arm64 dependency wheels; the project wheel is always rebuilt.",
+    )
+    args = parser.parse_args()
+    root = Path(__file__).resolve().parents[1]
+    output_dir = args.output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    environment = {
+        **os.environ,
+        "PIP_DISABLE_PIP_VERSION_CHECK": "1",
+        "PYTHONPATH": str(root / "src"),
+        "SOURCE_DATE_EPOCH": "1767225600",
+    }
+
+    _run(sys.executable, "tools/test.py", root=root, environment=environment)
+    with tempfile.TemporaryDirectory(prefix="mcpserver-release-", dir=output_dir) as temporary:
+        work = Path(temporary)
+        wheelhouse = work / "wheelhouse"
+        wheelhouse.mkdir()
+        if args.runtime_wheelhouse is None:
+            _run(
+                sys.executable,
+                "tools/prepare_wheelhouse.py",
+                str(wheelhouse),
+                root=root,
+                environment=environment,
+            )
+        else:
+            _copy_runtime_wheels(args.runtime_wheelhouse.resolve(), wheelhouse)
+            _build_project_wheel(root, wheelhouse, environment)
+
+        first = work / "candidate-a.zip"
+        second = work / "candidate-b.zip"
+        for candidate in (first, second):
+            _run(
+                sys.executable,
+                "tools/build_plugin.py",
+                "--wheelhouse",
+                str(wheelhouse),
+                "--output",
+                str(candidate),
+                root=root,
+                environment=environment,
+            )
+        first_digest = hashlib.sha256(first.read_bytes()).hexdigest()
+        second_digest = hashlib.sha256(second.read_bytes()).hexdigest()
+        if first_digest != second_digest:
+            raise RuntimeError("repeated plugin builds are not byte-identical")
+
+        output = output_dir / f"LoxBerry-MCP-Server-{_version(root)}.zip"
+        _publish(first, output, first_digest)
+        verify_archive(output)
+
+    print(f"RELEASE_CANDIDATE=pass path={output}")
+    print(f"SHA256={first_digest}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/build_release_candidate.py
+++ b/tools/build_release_candidate.py
@@ -12,8 +12,6 @@ import sys
 import tempfile
 from pathlib import Path
 
-from tools.verify_plugin import verify_archive
-
 
 def _run(*arguments: str, root: Path, environment: dict[str, str] | None = None) -> None:
     subprocess.run(arguments, check=True, cwd=root, env=environment)
@@ -25,12 +23,41 @@ def _version(root: Path) -> str:
     return parser["PLUGIN"]["VERSION"]
 
 
-def _copy_runtime_wheels(source: Path, destination: Path) -> None:
+def _normalized_name(value: str) -> str:
+    import re
+
+    return re.sub(r"[-_.]+", "-", value).lower()
+
+
+def _locked_requirements(path: Path) -> dict[str, str]:
+    import re
+
+    requirements: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        match = re.fullmatch(r"([A-Za-z0-9_.-]+)==([A-Za-z0-9_.+-]+)", line)
+        if match:
+            requirements[_normalized_name(match.group(1))] = match.group(2).lower()
+    return requirements
+
+
+def _wheel_identity(path: Path) -> tuple[str, str] | None:
+    parts = path.name.removesuffix(".whl").split("-")
+    if len(parts) < 5:
+        return None
+    return _normalized_name(parts[0]), parts[1].lower()
+
+
+def _copy_runtime_wheels(source: Path, destination: Path, requirements: dict[str, str]) -> None:
     if not source.is_dir():
         raise RuntimeError("runtime wheelhouse does not exist")
+    copied: list[tuple[str, str]] = []
     for wheel in source.glob("*.whl"):
-        if not wheel.name.startswith("loxberry_mcpserver-"):
+        identity = _wheel_identity(wheel)
+        if identity is not None and identity in requirements.items():
             shutil.copy2(wheel, destination / wheel.name)
+            copied.append(identity)
+    if len(copied) != len(set(copied)) or set(copied) != set(requirements.items()):
+        raise RuntimeError("runtime wheelhouse does not exactly satisfy the lock")
 
 
 def _build_project_wheel(root: Path, wheelhouse: Path, environment: dict[str, str]) -> None:
@@ -96,7 +123,8 @@ def main() -> int:
                 environment=environment,
             )
         else:
-            _copy_runtime_wheels(args.runtime_wheelhouse.resolve(), wheelhouse)
+            requirements = _locked_requirements(root / "requirements" / "runtime-arm64.lock")
+            _copy_runtime_wheels(args.runtime_wheelhouse.resolve(), wheelhouse, requirements)
             _build_project_wheel(root, wheelhouse, environment)
 
         first = work / "candidate-a.zip"
@@ -119,7 +147,13 @@ def main() -> int:
 
         output = output_dir / f"LoxBerry-MCP-Server-{_version(root)}.zip"
         _publish(first, output, first_digest)
-        verify_archive(output)
+        _run(
+            sys.executable,
+            "tools/verify_plugin.py",
+            str(output),
+            root=root,
+            environment=environment,
+        )
 
     print(f"RELEASE_CANDIDATE=pass path={output}")
     print(f"SHA256={first_digest}")

--- a/tools/prepare_wheelhouse.py
+++ b/tools/prepare_wheelhouse.py
@@ -1,0 +1,72 @@
+"""Build the project wheel and download exact Debian 13 arm64 runtime wheels."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("output", type=Path)
+    args = parser.parse_args()
+    root = Path(__file__).resolve().parents[1]
+    output = args.output.resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    build_environment = {
+        **os.environ,
+        "PIP_DISABLE_PIP_VERSION_CHECK": "1",
+        "SOURCE_DATE_EPOCH": "1767225600",
+    }
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "download",
+            "--only-binary=:all:",
+            "--no-deps",
+            "--no-cache-dir",
+            "--dest",
+            str(output),
+            "--platform=manylinux_2_34_aarch64",
+            "--platform=manylinux2014_aarch64",
+            "--platform=any",
+            "--implementation=cp",
+            "--python-version=313",
+            "--abi=cp313",
+            "--requirement",
+            str(root / "requirements" / "runtime-arm64.lock"),
+        ],
+        check=True,
+        cwd=root,
+        env=build_environment,
+    )
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "wheel",
+            "--ignore-requires-python",
+            "--no-deps",
+            "--no-cache-dir",
+            "--wheel-dir",
+            str(output),
+            ".",
+        ],
+        check=True,
+        cwd=root,
+        env=build_environment,
+    )
+    shutil.copy2(root / "requirements" / "runtime-arm64.lock", output / "runtime-arm64.lock")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_mcp_client.ps1
+++ b/tools/test_mcp_client.ps1
@@ -78,7 +78,13 @@ function Read-JsonRpc([int]$Id) {
     throw "Timed out waiting for MCP response $Id."
 }
 
-function Invoke-ReadTool([int]$Id, [string]$Name, [hashtable]$Arguments) {
+function Get-NextId {
+    $value = $script:nextId
+    $script:nextId += 1
+    return $value
+}
+
+function Invoke-ToolEnvelope([int]$Id, [string]$Name, [hashtable]$Arguments) {
     Send-JsonRpc @{
         jsonrpc = '2.0'
         id = $Id
@@ -91,9 +97,13 @@ function Invoke-ReadTool([int]$Id, [string]$Name, [hashtable]$Arguments) {
     if (-not $envelope -and $response.result.content[0].text) {
         $envelope = $response.result.content[0].text | ConvertFrom-Json
     }
-    if (-not $envelope -or -not $envelope.ok) {
-        throw "Read-only tool $Name returned an invalid envelope."
-    }
+    if (-not $envelope) { throw "Read-only tool $Name returned no envelope." }
+    return $envelope
+}
+
+function Invoke-ReadTool([int]$Id, [string]$Name, [hashtable]$Arguments) {
+    $envelope = Invoke-ToolEnvelope $Id $Name $Arguments
+    if (-not $envelope.ok) { throw "Read-only tool $Name returned an error envelope." }
     return $envelope
 }
 
@@ -128,29 +138,68 @@ try {
         }
     }
 
-    [void](Invoke-ReadTool 2 'loxone_get_system_status' @{})
-    [void](Invoke-ReadTool 3 'loxone_list_rooms' @{ limit = 100 })
-    [void](Invoke-ReadTool 4 'loxone_list_categories' @{ limit = 100 })
-    $controls = Invoke-ReadTool 5 'loxone_find_controls' @{ limit = 100 }
-    $visibleUuid = @($controls.data.items | ForEach-Object { $_.uuid }) | Select-Object -First 1
+    $script:nextId = 2
+    [void](Invoke-ReadTool (Get-NextId) 'loxone_get_system_status' @{})
+    [void](Invoke-ReadTool (Get-NextId) 'loxone_list_rooms' @{ limit = 100 })
+    [void](Invoke-ReadTool (Get-NextId) 'loxone_list_categories' @{ limit = 100 })
+
+    $allControls = [System.Collections.Generic.List[object]]::new()
+    $cursor = $null
+    $pageCount = 0
+    do {
+        $arguments = @{ limit = 100 }
+        if ($cursor) { $arguments.cursor = $cursor }
+        $page = Invoke-ReadTool (Get-NextId) 'loxone_find_controls' $arguments
+        foreach ($control in $page.data.items) { $allControls.Add($control) }
+        $cursor = $page.data.next_cursor
+        $pageCount += 1
+        if ($pageCount -gt 50) { throw 'Control pagination exceeded the safe test bound.' }
+    } while ($cursor)
+
+    $visibleUuid = @($allControls | ForEach-Object { $_.uuid }) | Select-Object -First 1
     $hiddenUuid = $null
+    $description = $null
     if ($VisibilityFixturePath) {
         $fixture = Get-Content -LiteralPath $VisibilityFixturePath -Raw | ConvertFrom-Json
         $visibleUuid = [string]$fixture.visible_control_uuid
         $hiddenUuid = [string]$fixture.hidden_control_uuid
-        $controlUuids = @($controls.data.items | ForEach-Object { $_.uuid })
+        $controlUuids = @($allControls | ForEach-Object { $_.uuid })
         if (-not $visibleUuid -or $visibleUuid -notin $controlUuids) {
             throw 'Expected visible control is absent.'
         }
         if ($hiddenUuid -and $hiddenUuid -in $controlUuids) {
             throw 'Expected hidden control leaked into the result.'
         }
+        if ($hiddenUuid) {
+            $hidden = Invoke-ToolEnvelope (Get-NextId) 'loxone_describe_control' @{
+                control_uuid = $hiddenUuid
+            }
+            if ($hidden.ok -or $hidden.data.error -ne 'not_found') {
+                throw 'Expected hidden control is directly describable.'
+            }
+        }
+        $description = Invoke-ReadTool (Get-NextId) 'loxone_describe_control' @{
+            control_uuid = $visibleUuid
+        }
+    } else {
+        $describeBudget = [Math]::Max(0, 50 - $pageCount)
+        foreach ($control in @($allControls | Select-Object -First $describeBudget)) {
+            $candidate = Invoke-ReadTool (Get-NextId) 'loxone_describe_control' @{
+                control_uuid = $control.uuid
+            }
+            if (@($candidate.data.states).Count -gt 0) {
+                $visibleUuid = $control.uuid
+                $description = $candidate
+                break
+            }
+        }
     }
-    if (-not $visibleUuid) { throw 'No visible control is available for the read-only probe.' }
-    $description = Invoke-ReadTool 6 'loxone_describe_control' @{ control_uuid = $visibleUuid }
+    if (-not $visibleUuid -or -not $description) {
+        throw 'No visible control with a readable state is available within the safe call budget.'
+    }
     $stateUuid = @($description.data.states | ForEach-Object { $_.uuid }) | Select-Object -First 1
     if (-not $stateUuid) { throw 'The selected visible control has no readable state.' }
-    [void](Invoke-ReadTool 7 'loxone_get_states' @{ state_uuids = @($stateUuid) })
+    [void](Invoke-ReadTool (Get-NextId) 'loxone_get_states' @{ state_uuids = @($stateUuid) })
 
     $visibleUuid = $null
     $hiddenUuid = $null

--- a/tools/test_mcp_client.ps1
+++ b/tools/test_mcp_client.ps1
@@ -1,0 +1,169 @@
+param(
+    [string]$ClaudeConfigPath = (Join-Path $env:APPDATA 'Claude\claude_desktop_config.json'),
+    [string]$ServerName = 'loxberry-mcp',
+    [string]$VisibilityFixturePath,
+    [int]$TimeoutSeconds = 120
+)
+
+$ErrorActionPreference = 'Stop'
+$config = Get-Content -LiteralPath $ClaudeConfigPath -Raw | ConvertFrom-Json
+$server = $config.mcpServers.$ServerName
+if (-not $server -or -not $server.command) {
+    throw 'Claude MCP configuration is missing.'
+}
+
+$startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+$startInfo.FileName = [string]$server.command
+foreach ($argument in $server.args) {
+    [void]$startInfo.ArgumentList.Add([string]$argument)
+}
+if ($server.env) {
+    foreach ($property in $server.env.PSObject.Properties) {
+        $startInfo.Environment[$property.Name] = [string]$property.Value
+    }
+}
+$startInfo.UseShellExecute = $false
+$startInfo.CreateNoWindow = $true
+$startInfo.RedirectStandardInput = $true
+$startInfo.RedirectStandardOutput = $true
+$startInfo.RedirectStandardError = $true
+
+$process = [System.Diagnostics.Process]::new()
+$process.StartInfo = $startInfo
+[void]$process.Start()
+$script:stderrLines = [System.Collections.Generic.List[string]]::new()
+$script:stderrReadTask = $process.StandardError.ReadLineAsync()
+$script:authorizationReported = $false
+$script:authorizationUrlFile = Join-Path ([IO.Path]::GetTempPath()) 'loxberry-mcp-oauth-url.tmp'
+Remove-Item -LiteralPath $script:authorizationUrlFile -Force -ErrorAction SilentlyContinue
+
+function Read-StderrProgress {
+    while ($script:stderrReadTask.IsCompleted) {
+        $line = $script:stderrReadTask.Result
+        if ($null -eq $line) { return }
+        $script:stderrLines.Add($line)
+        if (-not $script:authorizationReported -and $line -match '(https://\S+/authorize\?\S+)') {
+            $authorizationUrl = $Matches[1].TrimEnd('.', ',', ')')
+            [IO.File]::WriteAllText($script:authorizationUrlFile, $authorizationUrl)
+            $authorizationUrl = ''
+            Write-Output "MCP_AUTHORIZATION_REQUIRED=$script:authorizationUrlFile"
+            $script:authorizationReported = $true
+        }
+        $script:stderrReadTask = $process.StandardError.ReadLineAsync()
+    }
+}
+
+function Send-JsonRpc([hashtable]$Message) {
+    $line = $Message | ConvertTo-Json -Depth 20 -Compress
+    $process.StandardInput.WriteLine($line)
+    $process.StandardInput.Flush()
+}
+
+function Read-JsonRpc([int]$Id) {
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    $readTask = $null
+    while ([DateTime]::UtcNow -lt $deadline) {
+        Read-StderrProgress
+        if ($null -eq $readTask) { $readTask = $process.StandardOutput.ReadLineAsync() }
+        if (-not $readTask.Wait(500)) {
+            if ($process.HasExited) { throw "MCP proxy exited before response $Id." }
+            continue
+        }
+        $line = $readTask.Result
+        $readTask = $null
+        if ($null -eq $line) { throw "MCP proxy closed stdout before response $Id." }
+        try { $message = $line | ConvertFrom-Json } catch { continue }
+        if ($message.id -eq $Id) { return $message }
+    }
+    throw "Timed out waiting for MCP response $Id."
+}
+
+function Invoke-ReadTool([int]$Id, [string]$Name, [hashtable]$Arguments) {
+    Send-JsonRpc @{
+        jsonrpc = '2.0'
+        id = $Id
+        method = 'tools/call'
+        params = @{ name = $Name; arguments = $Arguments }
+    }
+    $response = Read-JsonRpc $Id
+    if ($response.error -or $response.result.isError) { throw "Read-only tool $Name failed." }
+    $envelope = $response.result.structuredContent
+    if (-not $envelope -and $response.result.content[0].text) {
+        $envelope = $response.result.content[0].text | ConvertFrom-Json
+    }
+    if (-not $envelope -or -not $envelope.ok) {
+        throw "Read-only tool $Name returned an invalid envelope."
+    }
+    return $envelope
+}
+
+try {
+    Send-JsonRpc @{
+        jsonrpc = '2.0'; id = 0; method = 'initialize'
+        params = @{
+            protocolVersion = '2025-11-25'; capabilities = @{}
+            clientInfo = @{ name = 'phase1-readonly-probe'; version = '0.1.0' }
+        }
+    }
+    if ((Read-JsonRpc 0).error) { throw 'MCP initialize failed.' }
+    Send-JsonRpc @{ jsonrpc = '2.0'; method = 'notifications/initialized'; params = @{} }
+    Send-JsonRpc @{ jsonrpc = '2.0'; id = 1; method = 'tools/list'; params = @{} }
+    $toolsResponse = Read-JsonRpc 1
+    if ($toolsResponse.error) { throw 'MCP tools/list failed.' }
+
+    $expected = @(
+        'loxone_get_system_status', 'loxone_list_rooms', 'loxone_list_categories',
+        'loxone_find_controls', 'loxone_describe_control', 'loxone_get_states'
+    )
+    $actual = @($toolsResponse.result.tools | ForEach-Object { $_.name } | Sort-Object)
+    if (($actual -join "`n") -ne (($expected | Sort-Object) -join "`n")) {
+        throw 'MCP tool inventory differs from the six-tool read-only contract.'
+    }
+    foreach ($tool in $toolsResponse.result.tools) {
+        if ($tool.annotations.readOnlyHint -ne $true -or $tool.annotations.destructiveHint -ne $false) {
+            throw 'MCP tool annotations violate the read-only contract.'
+        }
+        if (-not $tool.outputSchema.properties.data.anyOf) {
+            throw 'MCP tool output schema is not concrete.'
+        }
+    }
+
+    [void](Invoke-ReadTool 2 'loxone_get_system_status' @{})
+    [void](Invoke-ReadTool 3 'loxone_list_rooms' @{ limit = 100 })
+    [void](Invoke-ReadTool 4 'loxone_list_categories' @{ limit = 100 })
+    $controls = Invoke-ReadTool 5 'loxone_find_controls' @{ limit = 100 }
+    $visibleUuid = @($controls.data.items | ForEach-Object { $_.uuid }) | Select-Object -First 1
+    $hiddenUuid = $null
+    if ($VisibilityFixturePath) {
+        $fixture = Get-Content -LiteralPath $VisibilityFixturePath -Raw | ConvertFrom-Json
+        $visibleUuid = [string]$fixture.visible_control_uuid
+        $hiddenUuid = [string]$fixture.hidden_control_uuid
+        $controlUuids = @($controls.data.items | ForEach-Object { $_.uuid })
+        if (-not $visibleUuid -or $visibleUuid -notin $controlUuids) {
+            throw 'Expected visible control is absent.'
+        }
+        if ($hiddenUuid -and $hiddenUuid -in $controlUuids) {
+            throw 'Expected hidden control leaked into the result.'
+        }
+    }
+    if (-not $visibleUuid) { throw 'No visible control is available for the read-only probe.' }
+    $description = Invoke-ReadTool 6 'loxone_describe_control' @{ control_uuid = $visibleUuid }
+    $stateUuid = @($description.data.states | ForEach-Object { $_.uuid }) | Select-Object -First 1
+    if (-not $stateUuid) { throw 'The selected visible control has no readable state.' }
+    [void](Invoke-ReadTool 7 'loxone_get_states' @{ state_uuids = @($stateUuid) })
+
+    $visibleUuid = $null
+    $hiddenUuid = $null
+    $stateUuid = $null
+    'mcp_tool_contract=pass'
+    'mcp_six_read_tools=pass'
+    if ($VisibilityFixturePath) { 'mcp_visibility_filter=pass' }
+} finally {
+    try { $process.StandardInput.Close() } catch {}
+    if (-not $process.WaitForExit(3000)) {
+        $process.Kill($true)
+        [void]$process.WaitForExit(3000)
+    }
+    Remove-Item -LiteralPath $script:authorizationUrlFile -Force -ErrorAction SilentlyContinue
+    $process.Dispose()
+}

--- a/tools/verify_plugin.py
+++ b/tools/verify_plugin.py
@@ -12,8 +12,6 @@ import zipfile
 from pathlib import Path, PurePosixPath
 from typing import Final
 
-from tools.build_plugin import _EXECUTABLES
-
 _REQUIRED: Final = {
     "plugin.cfg",
     "preinstall.sh",
@@ -33,12 +31,43 @@ _REQUIRED: Final = {
     "templates/lang/language_de.ini",
     "templates/lang/language_en.ini",
 }
+_EXECUTABLES: Final = {
+    "preinstall.sh",
+    "preupgrade.sh",
+    "postinstall.sh",
+    "postroot.sh",
+    "postupgrade.sh",
+    "uninstall/uninstall.sh",
+    "bin/healthcheck",
+    "bin/mcpserver-admin",
+    "webfrontend/htmlauth/index.cgi",
+}
 _TEXT_SUFFIXES: Final = {".cfg", ".cgi", ".conf", ".html", ".ini", ".json", ".lock", ".sh", ".svg"}
 _TEXT_NAMES: Final = {"bin/healthcheck", "bin/mcpserver-admin"}
 
 
 class PackageVerificationError(RuntimeError):
     """The archive violates the Phase 1 package contract."""
+
+
+def _normalized_name(value: str) -> str:
+    return re.sub(r"[-_.]+", "-", value).lower()
+
+
+def _locked_requirements(content: str) -> dict[str, str]:
+    requirements: dict[str, str] = {}
+    for line in content.splitlines():
+        match = re.fullmatch(r"([A-Za-z0-9_.-]+)==([A-Za-z0-9_.+-]+)", line)
+        if match:
+            requirements[_normalized_name(match.group(1))] = match.group(2).lower()
+    return requirements
+
+
+def _wheel_identity(filename: str) -> tuple[str, str] | None:
+    parts = PurePosixPath(filename).name.removesuffix(".whl").split("-")
+    if len(parts) < 5:
+        return None
+    return _normalized_name(parts[0]), parts[1].lower()
 
 
 def _expected_project_version(plugin_version: str) -> str:
@@ -110,9 +139,20 @@ def verify_archive(archive: Path, *, require_checksum: bool = True) -> str:
         project_wheels = [name for name in names if name.startswith(expected_wheel)]
         if len(project_wheels) != 1:
             raise PackageVerificationError("exactly one matching project wheel is required")
-        runtime_wheels = [name for name in names if name.startswith("bin/wheelhouse/")]
-        if len(runtime_wheels) < 2:
-            raise PackageVerificationError("offline runtime wheelhouse is incomplete")
+        expected_runtime = _locked_requirements(
+            package.read("bin/runtime-arm64.lock").decode("utf-8")
+        )
+        runtime_wheels = [
+            identity
+            for name in names
+            if name.startswith("bin/wheelhouse/")
+            and not name.startswith("bin/wheelhouse/loxberry_mcpserver-")
+            if (identity := _wheel_identity(name)) is not None
+        ]
+        if len(runtime_wheels) != len(set(runtime_wheels)):
+            raise PackageVerificationError("offline runtime wheelhouse contains duplicates")
+        if set(runtime_wheels) != set(expected_runtime.items()):
+            raise PackageVerificationError("offline runtime wheelhouse does not match its lock")
 
     return digest
 

--- a/tools/verify_plugin.py
+++ b/tools/verify_plugin.py
@@ -1,0 +1,131 @@
+"""Verify a built LoxBerry plugin archive without extracting it."""
+
+from __future__ import annotations
+
+import argparse
+import configparser
+import hashlib
+import io
+import re
+import stat
+import zipfile
+from pathlib import Path, PurePosixPath
+from typing import Final
+
+from tools.build_plugin import _EXECUTABLES
+
+_REQUIRED: Final = {
+    "plugin.cfg",
+    "preinstall.sh",
+    "preupgrade.sh",
+    "postinstall.sh",
+    "postroot.sh",
+    "postupgrade.sh",
+    "uninstall/uninstall.sh",
+    "bin/healthcheck",
+    "bin/mcpserver-admin",
+    "bin/runtime-arm64.lock",
+    "config/default-config.json",
+    "config/apache/mcpserver.conf",
+    "config/systemd/loxberry-mcpserver.service.in",
+    "webfrontend/htmlauth/index.cgi",
+    "templates/index.html",
+    "templates/lang/language_de.ini",
+    "templates/lang/language_en.ini",
+}
+_TEXT_SUFFIXES: Final = {".cfg", ".cgi", ".conf", ".html", ".ini", ".json", ".lock", ".sh", ".svg"}
+_TEXT_NAMES: Final = {"bin/healthcheck", "bin/mcpserver-admin"}
+
+
+class PackageVerificationError(RuntimeError):
+    """The archive violates the Phase 1 package contract."""
+
+
+def _expected_project_version(plugin_version: str) -> str:
+    return re.sub(r"(?i)-alpha\.(\d+)$", r"a\1", plugin_version)
+
+
+def _verify_checksum(archive: Path, digest: str) -> None:
+    sidecar = archive.with_suffix(archive.suffix + ".sha256")
+    if not sidecar.exists():
+        raise PackageVerificationError("checksum sidecar is missing")
+    fields = sidecar.read_text(encoding="ascii").strip().split()
+    if fields != [digest, archive.name]:
+        raise PackageVerificationError("checksum sidecar does not match the archive")
+
+
+def verify_archive(archive: Path, *, require_checksum: bool = True) -> str:
+    """Validate layout, modes, LF text files, identity, wheels, and checksum."""
+    archive = archive.resolve()
+    if not archive.is_file():
+        raise PackageVerificationError("plugin archive does not exist")
+    digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+    if require_checksum:
+        _verify_checksum(archive, digest)
+
+    try:
+        package = zipfile.ZipFile(archive)
+    except zipfile.BadZipFile as exc:
+        raise PackageVerificationError("plugin archive is not a valid ZIP") from exc
+
+    with package:
+        entries = package.infolist()
+        names = [entry.filename for entry in entries]
+        if len(names) != len(set(names)):
+            raise PackageVerificationError("plugin archive contains duplicate paths")
+        for entry in entries:
+            path = PurePosixPath(entry.filename)
+            if (
+                entry.is_dir()
+                or entry.filename.startswith("/")
+                or "\\" in entry.filename
+                or ".." in path.parts
+                or not path.parts
+            ):
+                raise PackageVerificationError("plugin archive contains an unsafe path")
+            mode = entry.external_attr >> 16
+            if not stat.S_ISREG(mode):
+                raise PackageVerificationError("plugin archive contains a non-regular file")
+            expected_mode = 0o755 if entry.filename in _EXECUTABLES else 0o644
+            if stat.S_IMODE(mode) != expected_mode:
+                raise PackageVerificationError(f"unexpected file mode for {entry.filename}")
+            if (
+                path.suffix.lower() in _TEXT_SUFFIXES or entry.filename in _TEXT_NAMES
+            ) and b"\r\n" in package.read(entry):
+                raise PackageVerificationError(f"CRLF found in {entry.filename}")
+
+        missing = _REQUIRED - set(names)
+        if missing:
+            raise PackageVerificationError(f"required package entry is missing: {min(missing)}")
+
+        parser = configparser.ConfigParser()
+        parser.read_file(io.StringIO(package.read("plugin.cfg").decode("utf-8")))
+        if (
+            parser["PLUGIN"].get("NAME") != "mcpserver"
+            or parser["PLUGIN"].get("FOLDER") != "mcpserver"
+        ):
+            raise PackageVerificationError("plugin identity is invalid")
+        version = parser["PLUGIN"].get("VERSION", "")
+        expected_wheel = f"bin/wheelhouse/loxberry_mcpserver-{_expected_project_version(version)}-"
+        project_wheels = [name for name in names if name.startswith(expected_wheel)]
+        if len(project_wheels) != 1:
+            raise PackageVerificationError("exactly one matching project wheel is required")
+        runtime_wheels = [name for name in names if name.startswith("bin/wheelhouse/")]
+        if len(runtime_wheels) < 2:
+            raise PackageVerificationError("offline runtime wheelhouse is incomplete")
+
+    return digest
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("archive", type=Path)
+    parser.add_argument("--no-checksum", action="store_true")
+    args = parser.parse_args()
+    digest = verify_archive(args.archive, require_checksum=not args.no_checksum)
+    print(f"PLUGIN_ARCHIVE=pass sha256={digest}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/verify_plugin.py
+++ b/tools/verify_plugin.py
@@ -135,19 +135,30 @@ def verify_archive(archive: Path, *, require_checksum: bool = True) -> str:
         ):
             raise PackageVerificationError("plugin identity is invalid")
         version = parser["PLUGIN"].get("VERSION", "")
-        expected_wheel = f"bin/wheelhouse/loxberry_mcpserver-{_expected_project_version(version)}-"
-        project_wheels = [name for name in names if name.startswith(expected_wheel)]
-        if len(project_wheels) != 1:
+        expected_project = ("loxberry-mcpserver", _expected_project_version(version).lower())
+        wheelhouse_entries = [name for name in names if name.startswith("bin/wheelhouse/")]
+        if any(
+            PurePosixPath(name).parent != PurePosixPath("bin/wheelhouse")
+            or PurePosixPath(name).suffix != ".whl"
+            or _wheel_identity(name) is None
+            for name in wheelhouse_entries
+        ):
+            raise PackageVerificationError("wheelhouse contains an invalid entry")
+        wheel_identities = [_wheel_identity(name) for name in wheelhouse_entries]
+        project_wheels = [
+            identity
+            for identity in wheel_identities
+            if identity is not None and identity[0] == "loxberry-mcpserver"
+        ]
+        if project_wheels != [expected_project]:
             raise PackageVerificationError("exactly one matching project wheel is required")
         expected_runtime = _locked_requirements(
             package.read("bin/runtime-arm64.lock").decode("utf-8")
         )
         runtime_wheels = [
             identity
-            for name in names
-            if name.startswith("bin/wheelhouse/")
-            and not name.startswith("bin/wheelhouse/loxberry_mcpserver-")
-            if (identity := _wheel_identity(name)) is not None
+            for identity in wheel_identities
+            if identity is not None and identity[0] != "loxberry-mcpserver"
         ]
         if len(runtime_wheels) != len(set(runtime_wheels)):
             raise PackageVerificationError("offline runtime wheelhouse contains duplicates")

--- a/uninstall/uninstall.sh
+++ b/uninstall/uninstall.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -u
+
+marker="# Managed by the LoxBerry MCP Server plugin."
+unit=/etc/systemd/system/loxberry-mcpserver.service
+apache=/etc/apache2/conf-available/loxberry-mcpserver.conf
+sudoers=/etc/sudoers.d/loxberry-mcpserver
+
+systemctl disable --now loxberry-mcpserver.service >/dev/null 2>&1 || true
+a2disconf loxberry-mcpserver >/dev/null 2>&1 || true
+for target in "$unit" "$apache" "$sudoers"; do
+    if [ -f "$target" ] && grep -Fqx "$marker" "$target"; then
+        rm -f -- "$target"
+    fi
+done
+systemctl daemon-reload
+systemctl reload apache2 >/dev/null 2>&1 || true
+echo "<OK> External LoxBerry MCP Server artifacts removed."
+exit 0

--- a/webfrontend/htmlauth/index.cgi
+++ b/webfrontend/htmlauth/index.cgi
@@ -1,0 +1,169 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use CGI;
+use HTML::Template;
+use IPC::Open3;
+use JSON::PP qw(decode_json encode_json);
+use Symbol qw(gensym);
+use LoxBerry::System;
+use LoxBerry::Web;
+use LoxBerry::Log;
+
+my $cgi = CGI->new;
+my $q = $cgi->Vars;
+my $version = LoxBerry::System::pluginversion();
+my $log = LoxBerry::Log->new(name => 'admin-ui', package => $lbpplugindir, addtime => 1);
+$log->LOGSTART('index.cgi called');
+
+$ENV{LBPDATA} = $lbpdatadir;
+$ENV{MCPSERVER_CONFIG} = "$lbpconfigdir/mcpserver.json";
+$ENV{MCPSERVER_AUTH_STORE} = "$lbpdatadir/auth/sessions.json";
+$ENV{MCPSERVER_LOXONE_TOKEN_STORE} = "$lbpdatadir/auth/loxone-tokens.json.enc";
+$ENV{MCPSERVER_INSTALL_KEY} = "$lbpdatadir/auth/install.key";
+
+sub admin_call {
+    my ($action, $payload) = @_;
+    my ($child_in, $child_out);
+    my $child_err = gensym;
+    my $pid = open3($child_in, $child_out, $child_err, "$lbpbindir/mcpserver-admin");
+    print {$child_in} encode_json({action => $action, payload => ($payload // {})});
+    close $child_in;
+    local $/;
+    my $stdout = <$child_out> // '';
+    my $stderr = <$child_err> // '';
+    waitpid($pid, 0);
+    if ($? != 0 || $stdout eq '') {
+        LOGERR("admin helper failed");
+        return {ok => JSON::PP::false, error => {code => 'internal_error', message => 'Administrative action failed'}};
+    }
+    my $result = eval { decode_json($stdout) };
+    if (!$result || ref($result) ne 'HASH') {
+        LOGERR("admin helper returned invalid JSON");
+        return {ok => JSON::PP::false, error => {code => 'internal_error', message => 'Administrative action failed'}};
+    }
+    return $result;
+}
+
+sub same_origin_post {
+    return 0 if uc($ENV{REQUEST_METHOD} // '') ne 'POST';
+    my $origin = $ENV{HTTP_ORIGIN} // '';
+    my $host = $ENV{HTTP_HOST} // '';
+    return 0 if $origin eq '' || $host eq '';
+    return $origin =~ m{^https?://\Q$host\E$}i ? 1 : 0;
+}
+
+sub json_reply {
+    my ($result, $status) = @_;
+    print $cgi->header(-type => 'application/json', -charset => 'utf-8', -status => ($status // 200));
+    print encode_json($result);
+    exit;
+}
+
+my $action = $q->{action} // '';
+if ($action ne '') {
+    if (!same_origin_post()) {
+        my $failure = {ok => JSON::PP::false, error => {code => 'forbidden', message => 'Same-origin POST required'}};
+        json_reply($failure, 403) if $q->{ajax};
+        print $cgi->redirect('index.cgi?notice=forbidden');
+        exit;
+    }
+
+    my $result;
+    if ($action eq 'save_config') {
+        my $document = {
+            schema_version => 1,
+            server => {
+                enabled => $q->{enabled} ? JSON::PP::true : JSON::PP::false,
+                public_origin => $q->{public_origin} // '',
+            },
+            loxone => {
+                endpoint => $q->{endpoint} // '',
+                connection_timeout => 0 + ($q->{connection_timeout} // 10),
+            },
+            tools => {loxone_read_enabled => JSON::PP::true},
+            limits => {
+                requests_per_minute => 0 + ($q->{requests_per_minute} // 60),
+                max_parallel_calls => 0 + ($q->{max_parallel_calls} // 4),
+            },
+        };
+        $result = admin_call('save_config', $document);
+    } elsif ($action eq 'test_connection') {
+        $result = admin_call('test_connection', {endpoint => ($q->{endpoint} // '')});
+    } elsif ($action eq 'revoke_session') {
+        $result = admin_call('revoke_session', {id => ($q->{id} // '')});
+    } elsif ($action eq 'revoke_all') {
+        $result = admin_call('revoke_all', {});
+    } elsif ($action eq 'status') {
+        $result = admin_call('status', {});
+    } elsif ($action eq 'diagnostic') {
+        $result = admin_call('diagnostic', {});
+    } else {
+        $result = {ok => JSON::PP::false, error => {code => 'invalid_request', message => 'Unsupported action'}};
+    }
+    if ($action eq 'diagnostic' && $result->{ok}) {
+        print $cgi->header(
+            -type => 'application/json',
+            -charset => 'utf-8',
+            -attachment => 'mcpserver-diagnostic.json',
+        );
+        print encode_json($result->{data});
+        exit;
+    }
+    json_reply($result, $result->{ok} ? 200 : 400) if $q->{ajax};
+    my $notice = $result->{ok} ? 'success' : 'error';
+    print $cgi->redirect("index.cgi?notice=$notice");
+    exit;
+}
+
+my $template_text = LoxBerry::System::read_file("$lbptemplatedir/index.html");
+my $template = HTML::Template->new_scalar_ref(
+    \$template_text,
+    global_vars => 1,
+    loop_context_vars => 1,
+    die_on_bad_params => 0,
+);
+my %L = LoxBerry::System::readlanguage($template, 'language.ini');
+
+my $config_result = admin_call('get_config', {});
+my $status_result = admin_call('status', {});
+my $sessions_result = admin_call('list_sessions', {});
+my $config = $config_result->{ok} ? $config_result->{data}{configuration} : {};
+my $sessions = $sessions_result->{ok} ? $sessions_result->{data}{sessions} : [];
+$config->{server} = {} if ref($config->{server}) ne 'HASH';
+$config->{loxone} = {} if ref($config->{loxone}) ne 'HASH';
+$config->{limits} = {} if ref($config->{limits}) ne 'HASH';
+
+$template->param(
+    VERSION => $version,
+    ENABLED => $config->{server}{enabled} ? 1 : 0,
+    PUBLIC_ORIGIN => $config->{server}{public_origin} // '',
+    ENDPOINT => $config->{loxone}{endpoint} // '',
+    CONNECTION_TIMEOUT => $config->{loxone}{connection_timeout} // 10,
+    REQUESTS_PER_MINUTE => $config->{limits}{requests_per_minute} // 60,
+    MAX_PARALLEL_CALLS => $config->{limits}{max_parallel_calls} // 4,
+    SERVICE_ACTIVE => ($status_result->{ok} && $status_result->{data}{service_active}) ? 1 : 0,
+    SESSIONS => $sessions,
+    HAS_SESSIONS => scalar(@$sessions) ? 1 : 0,
+    NOTICE => $q->{notice} // '',
+    LOGLIST => LoxBerry::Web::loglist_html(),
+);
+
+our %navbar;
+$navbar{10}{Name} = $L{'NAV.SETUP'};
+$navbar{10}{URL} = '#setup';
+$navbar{20}{Name} = $L{'NAV.STATUS'};
+$navbar{20}{URL} = '#status';
+$navbar{30}{Name} = $L{'NAV.SESSIONS'};
+$navbar{30}{URL} = '#sessions';
+$navbar{40}{Name} = $L{'NAV.DIAGNOSTICS'};
+$navbar{40}{URL} = '#diagnostics';
+$navbar{50}{Name} = $L{'NAV.HELP'};
+$navbar{50}{URL} = '#help';
+
+LoxBerry::Web::lbheader($L{'BASIC.TITLE'} . " V$version", '', '', 'nojqm');
+print LoxBerry::Log::get_notifications_html($lbpplugindir);
+print $template->output();
+LoxBerry::Web::lbfooter();
+exit;


### PR DESCRIPTION
## Summary

- add the native LoxBerry V4 plugin layout, offline arm64 wheelhouse installation, systemd service, Apache proxy, lifecycle hooks, healthcheck, and uninstaller
- add schema-versioned atomic configuration, bounded OAuth sessions, encrypted Loxone JWT persistence, per-identity runtime isolation, and fail-closed disabled behavior
- publish the six Phase 1 read-only Loxone MCP tools with stable schemas, pagination, visibility filtering, limits, and read-only annotations
- add the responsive bilingual Perl CGI administration UI with server-side POST/Redirect/GET fallbacks and progressive AJAX
- harden failed-login cleanup, revoked-session visibility, unreadable historical token recovery, and native upgrade persistence of configuration, sessions, encrypted tokens, and the installation key
- add Gen. 2 experimental beta documentation, masked acceptance evidence, deterministic packaging, and lifecycle/UI regression coverage

## Why

Phase 0 established the protocol and security boundaries. This change turns that foundation into the installable `0.1.0-alpha.1` read-only LoxBerry plugin while retaining the protected-master and explicit hardware-evidence boundaries.

The disabled configuration fails closed: only loopback health remains available, while MCP, OAuth, and metadata routes return HTTP 503 until setup is enabled.

## Validation

- `PYTHONPATH=src .venv/Scripts/python.exe tools/test.py`: 172 passed; Ruff format/lint and mypy passed
- deterministic ZIP built twice from a fresh arm64 wheelhouse with identical SHA-256 `fe33a85aa52cae4e1cb4008d028f72b6abdd75fc811424b7d395e60fbd7329b5`
- native install and repeated upgrade through the LoxBerry Plugin Manager on LoxBerry 4.0.0.14, Debian 13/aarch64; final installer status 0 and healthcheck passed
- fresh Claude Desktop OAuth with `mcp-remote 0.1.38`, scope `loxone:read`, exact six-tool contract and all six real read-only calls passed
- real visibility boundary passed: a visible test control/state was readable and a control hidden from the dedicated user was absent
- the same OAuth session remained usable after reinstalling the final artifact, proving persistence of session, encrypted token, and installation key
- German and English responsive checks at 1280x800, 900x768, 390x844, 360x800, and 320x568; AJAX status and keyboard focus confirmed
- no control command was executed and no protected target data is included in the repository, logs, PR, or acceptance report

## Remaining boundaries

- the complete core flow was not repeated with JavaScript disabled browser-wide; server-side POST/Redirect/GET fallbacks are covered by automated tests
- Codex CLI was not rerun in the final pass because of the accepted local Windows execution issue; this does not block the server or Claude evidence
- Gen. 2 remains experimental until an independent complete hardware report exists
- external or cloud-hosted MCP access remains unsupported
