### PR TITLE
Complete Phase 1 acceptance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,25 @@
 # LoxBerry MCP Server
 
-Das McpServer-Plugin betreibt einen [Model Context Protocol (MCP)](https://modelcontextprotocol.io/)-Server direkt auf dem LoxBerry. KI-Assistenten und Agenten können damit den Zustand einer Loxone-Miniserver-Installation abfragen und Befehle an Steuerungen senden. Dabei verwendet das Plugin die vorhandenen Räume, Kategorien und Steuerungsnamen – ohne eigenen Cloud-Dienst.
+Das McpServer-Plugin betreibt einen [Model Context Protocol (MCP)](https://modelcontextprotocol.io/)-Server direkt auf dem LoxBerry. Die aktuelle Alpha erlaubt KI-Assistenten und Agenten ausschließlich, den Zustand einer Loxone-Miniserver-Installation zu lesen. Dabei verwendet das Plugin die vorhandenen Räume, Kategorien und Steuerungsnamen – ohne eigenen Cloud-Dienst.
 
-Zusätzlich stellt der MCP-Server ausgewählte Informationen und Funktionen der lokalen LoxBerry-Installation für KI-Assistenten und Agenten bereit.
+Schreibaktionen und LoxBerry-Werkzeuge sind nicht Bestandteil dieser Version.
 
 ## Sicherheit und Berechtigungen
 
-Der Zugriff auf Loxone-Funktionen ist durch den Loxone-Login geschützt. Ein verbindender Assistent muss sich mit einem Loxone-Benutzerkonto anmelden und kann nur die Elemente sehen und bedienen, für die dieses Konto berechtigt ist.
+Der Zugriff auf Loxone-Funktionen ist durch den Loxone-Login geschützt. Ein verbindender Assistent muss sich mit einem Loxone-Benutzerkonto anmelden und kann nur die Elemente lesen, für die dieses Konto berechtigt ist.
 
 Für jeden Assistenten sollte ein eigener Loxone-Benutzer mit den minimal erforderlichen Rechten angelegt werden. Zugangsdaten und andere Geheimnisse dürfen nicht im Repository gespeichert werden.
 
 ## Projektstatus
 
-Phase 0 ist abgeschlossen. Runtime, Apache-Transport, OAuth-Server sowie die
-Gen.-1-Loxone-/WebSocket-Anbindung sind auf der dokumentierten Referenzplattform
-bestätigt. Der nächste Meilenstein ist Phase 1, die lokale Read-only Alpha mit
-Pluginlayout, Dienst, Admin-UI und den ersten stabilen lesenden Tools.
+Phase 1 ist abgeschlossen. `0.1.0-alpha.1` ist das installierbare Read-only-
+Prerelease mit nativem Pluginlayout, Dienst, responsiver Admin-UI, OAuth und
+sechs stabilen lesenden Tools. Die Referenzkombination wurde real auf LoxBerry
+4.0.0.14, Debian 13/aarch64 und einem Gen.-1-Miniserver abgenommen.
 
-Es gibt noch kein installierbares Testpaket. Die bestätigten Kombinationen und
-bekannten Clientgrenzen stehen in der [Support-Matrix](docs/development/support-matrix.md).
+Bestätigte Kombinationen, Nachweise und bekannte Clientgrenzen stehen in der
+[Support-Matrix](docs/development/support-matrix.md) und im
+[Phase-1-Abnahmebericht](docs/development/phase-1-acceptance.md).
 
 ## Entwicklung
 

--- a/docs/development/phase-1-acceptance.md
+++ b/docs/development/phase-1-acceptance.md
@@ -2,75 +2,99 @@
 
 - **Stand:** 2026-08-04
 - **Releasekandidat:** `0.1.0-alpha.1`
-- **SHA-256:** `fe33a85aa52cae4e1cb4008d028f72b6abdd75fc811424b7d395e60fbd7329b5`
+- **SHA-256:** `d024cde3a497cdacef1e6dc6e10d6e396dd13cc8468272c4b74e6aeac9d27e37`
+- **Ergebnis:** Phase 1 abgenommen
 
-Dieser Nachweis trennt lokale Regressionen, reale Zielsystemtests und weiterhin
-offene Grenzen. Er enthält keine Zugangsdaten, internen Adressen, Identitäten,
-Steuerungsnamen, UUIDs oder Zustandswerte.
+Dieser Nachweis trennt lokale Regressionen, reale Zielsystemtests und bewusst
+verbleibende Produktgrenzen. Er enthält keine Zugangsdaten, internen Adressen,
+Identitäten, Steuerungsnamen, UUIDs oder Zustandswerte.
 
-## Automatisiertes Gate
+## Automatisiertes Gate und Reproduzierbarkeit
 
-`PYTHONPATH=src .venv/Scripts/python.exe tools/test.py` wurde für den finalen
-Quellstand vollständig ausgeführt:
+Das vollständige Gate wurde für den finalen Quellstand ausgeführt:
 
 - Ruff-Formatierung und Ruff-Lint erfolgreich
 - mypy für 19 Quelldateien erfolgreich
-- 172 Pytest-Tests erfolgreich
+- 184 Pytest-Tests erfolgreich
 - bekannte, nicht blockierende Warnungen: Starlette-`httpx`-Deprecation und ein
   lokal nicht beschreibbarer Pytest-Cache
 
-Die ergänzten Regressionen decken insbesondere ab:
+Der Releasekandidat wurde in zwei getrennten vollständigen Läufen aus dem
+arm64-Wheelhouse gebaut. Beide ZIP-Dateien waren bytegleich. Paketmanifest,
+LF-Zeilenenden, ausführbare Hooks, Offline-Wheels und Prüfsumme wurden zusätzlich
+mit `tools/verify_plugin.py` geprüft.
 
-- lokales Aufräumen eines Login-Tokens, wenn das entfernte `killtoken` nicht
-  erreichbar ist
-- Ausblenden bereits widerrufener Familien in der Administration
-- administrativen Widerruf bei einem nicht mehr entschlüsselbaren historischen
-  Tokenstore
-- Erhalt von Konfiguration, Sessions, verschlüsselten Tokens und
-  Installationsschlüssel über den nativen Upgradepfad
+## Reales LoxBerry-Ergebnis
 
-## Reales LoxBerry- und Gen.-1-Ergebnis
+Getestet wurde LoxBerry `4.0.0.14` auf Debian 13/aarch64 über den nativen
+Plugin-Manager-Lifecycle. Lokale und entfernte SHA-256 stimmten überein.
 
-Getestet wurde LoxBerry `4.0.0.14` auf Debian 13/aarch64 über die native
-Plugin-Verwaltung. Das reproduzierbare ZIP wurde unverändert übertragen; lokale
-und entfernte SHA-256 stimmten überein.
-
-- Offline-Venv wurde vollständig aus dem Paket aufgebaut.
 - Der native Installer beendete das finale Upgrade mit Status 0 und
   `Everything seems to be OK`.
-- systemd-Dienst und Loopback-Healthcheck waren aktiv.
-- `schema_version: 1`, Aktivierung und Read-only-Toolfreigabe blieben erhalten.
-- Installationsschlüssel, Sessionstore und verschlüsselter Tokenstore behielten
-  ihre restriktiven Eigentümer- und Dateirechte.
-- Eine neue OAuth-Anmeldung mit Claude Desktop und `mcp-remote 0.1.38` erhielt
-  ausschließlich `loxone:read`.
-- Genau die sechs Phase-1-Tools mit `readOnlyHint=true` und
-  `destructiveHint=false` wurden veröffentlicht und real aufgerufen.
-- Eine sichtbare Teststeuerung war auffindbar und beschreibbar; eine für den
-  Testbenutzer unsichtbare Steuerung erschien nicht. Ein sichtbarer Zustand
-  wurde lesend abgefragt.
-- Nach einem weiteren nativen Upgrade desselben Artefakts funktionierten
-  Toolliste und alle sechs Aufrufe ohne erneute Anmeldung. Damit sind der
-  gemeinsame Erhalt von OAuth-Sitzung, Installationsschlüssel und
-  verschlüsseltem Loxone-Token praktisch bestätigt.
+- Das Python-3.13-Venv wurde ausschließlich aus dem Offline-Wheelhouse aufgebaut;
+  `pip check` meldete keine defekten Abhängigkeiten.
+- systemd-Dienst und Autostart sind aktiv. Der Dienst läuft als `loxberry`, mit
+  `UMask=0077` und ausschließlich auf `127.0.0.1:8765`.
+- Loopback-Healthcheck und Apache-Konfiguration (`Syntax OK`) waren erfolgreich.
+- `schema_version: 1`, Aktivierung, Ziel und Read-only-Toolfreigabe blieben über
+  die Upgrades erhalten.
+- Konfiguration, Sessionstore, verschlüsselter Tokenstore und
+  Installationsschlüssel behielten ihre vorgesehenen restriktiven Rechte.
+- Eine gültige OAuth-Sitzung und der zugehörige verschlüsselte Loxone-Token
+  blieben nach dem finalen nativen Upgrade ohne Neuanmeldung nutzbar.
+
+## Reale MCP- und Gen.-1-Abnahme
+
+Claude Desktop blieb mit der vorhandenen `mcp-remote 0.1.38`-Konfiguration
+eingerichtet. Für die Abnahme wurde OAuth bei Bedarf neu autorisiert; der Scope
+blieb ausschließlich `loxone:read`.
+
+- Genau die sechs Phase-1-Tools wurden veröffentlicht.
+- Alle Tools tragen `readOnlyHint=true` und `destructiveHint=false` sowie
+  konkrete Eingabe- und Ausgabeschemas.
+- Alle sechs Tools wurden real aufgerufen, einschließlich Pagination,
+  Beschreibung und lesender Zustandsabfrage.
+- Eine für den Testbenutzer sichtbare Steuerung war auffindbar und
+  beschreibbar. Eine nicht sichtbare Steuerung erschien weder in der Suche noch
+  über den direkten Beschreibungsaufruf.
+- Einzel- und Gesamtwiderruf wurden real geprüft. Danach wurde eine
+  funktionsfähige Claude-Sitzung wiederhergestellt und auf dem Testsystem
+  belassen.
 
 Es wurden keine Steuerbefehle ausgeführt und keine Nutzsteuerung verändert.
-Tokenanlage und Tokenlebenszyklus waren für die OAuth-Abnahme ausdrücklich
-freigegeben.
 
-## Reproduzierbarkeit
+## Admin-UI-Abnahme
 
-Das ZIP wurde zweimal aus demselben frisch aufgebauten arm64-Wheelhouse erzeugt.
-Beide Dateien waren bytegleich und hatten die oben genannte SHA-256-Prüfsumme.
+Deutsch und Englisch wurden request-lokal real gerendert. Die englische
+Sprachvorschau wurde während der Abnahme korrigiert, erneut paketiert und über
+den nativen Upgradepfad installiert.
 
-## Noch offene Grenzen
+- Die Viewports `1280x800`, `900x768`, `390x844`, `360x800` und `320x568`
+  bestanden in beiden Sprachen ohne horizontales Seitenoverflow oder außerhalb
+  liegende Aktionen.
+- Tastaturnavigation erzeugte einen sichtbaren `:focus-visible`-Zustand.
+- AJAX-Status und Verbindungstest sperrten die Schaltfläche, setzten
+  `aria-busy`, zeigten Fortschritt und endeten mit einer strukturierten
+  Erfolgsmeldung.
+- AJAX-Einzel- und Gesamtwiderruf funktionierten real; die Sitzung wurde danach
+  wiederhergestellt.
+- Der serverseitige Speichervorgang und der maskierte Diagnoseexport liefen als
+  native Formularaktionen ohne AJAX.
+- Status, Verbindungstest und Einzelwiderruf wurden zusätzlich als echte
+  serverseitige POST/Redirect/GET-Abläufe ohne AJAX ausgeführt.
 
-- Der vollständige Kernablauf wurde nicht mit browserweit deaktiviertem
-  JavaScript real wiederholt. Die serverseitigen POST/Redirect/GET-Fallbacks
-  sind automatisiert geprüft.
-- Codex CLI wurde in diesem Abschlusslauf wegen der lokalen
-  Windows-Ausführungsstörung nicht erneut abgenommen; dies blockiert den Server-
-  und Claude-Nachweis nicht.
-- Gen. 2 bleibt ohne unabhängigen vollständigen Hardwarebericht
+Die Browsersteuerung durfte die globale Chrome-JavaScript-Berechtigung aus
+Sicherheitsgründen nicht ändern. Der funktionale No-JavaScript-Vertrag wurde
+daher durch die realen nativen Formular-/PRG-Pfade sowie die automatisierten
+Fallbacktests abgenommen, nicht durch eine dauerhafte Browser-Einstellung.
+
+## Verbleibende Produktgrenzen
+
+- Codex CLI wurde wegen der bekannten lokalen Windows-Ausführungsstörung nicht
+  erneut abgenommen. Dies ist als externe Clientgrenze akzeptiert und lockert
+  keine Serverprüfung.
+- Gen. 2 bleibt ohne vollständigen unabhängigen Hardwarebericht
   `experimental`.
 - Externer oder cloudbasierter MCP-Zugriff ist nicht freigegeben.
+- Schreibende Tools, Historie, LoxBerry-Tools, Basic Auth und generische
+  Kommandos bleiben außerhalb von Phase 1.

--- a/docs/development/support-matrix.md
+++ b/docs/development/support-matrix.md
@@ -1,11 +1,12 @@
 # Support-Matrix
 
 - **Stand:** Abnahmestand Phase 1, 2026-08-04
-- **Nächster Meilenstein:** Review und Prerelease-Veröffentlichung `0.1.0-alpha.1`
+- **Nächster Meilenstein:** Phase 2 nur nach separater Freigabe; bis dahin Pflege
+  der Read-only Alpha
 
 Diese Matrix unterscheidet reale Nachweise von implementierten, aber noch nicht
-real bestätigten Kombinationen. Das Alpha-Paket bleibt ein Prerelease, bis alle
-unten genannten Phase-1-Abnahmepunkte abgeschlossen sind.
+real bestätigten Kombinationen. Phase 1 ist abgenommen; das Alpha-Paket bleibt
+wegen seines Vorabversionsstatus ein Prerelease.
 
 ## Plattformen und Geräte
 
@@ -48,7 +49,8 @@ Der vollständige maskierte Nachweis steht im
   fail-safe mit HTTP 503.
 - Die responsive deutsche und englische Admin-UI wurde bei `1280x800`,
   `900x768`, `390x844`, `360x800` und `320x568` ohne Seitenoverflow geprüft.
-  AJAX-Status und sichtbarer Tastaturfokus wurden ebenfalls real bestätigt.
+  AJAX-Status, Verbindungstest, Widerrufe und sichtbarer Tastaturfokus wurden
+  ebenfalls real bestätigt.
 - Das ZIP wurde zweimal byteidentisch gebaut und durch seine SHA-256-Prüfsumme
   abgesichert.
 - Eine frische Claude-OAuth-Anmeldung mit ausschließlich `loxone:read`, exakt
@@ -57,11 +59,15 @@ Der vollständige maskierte Nachweis steht im
 - Nach dem nativen Upgrade desselben finalen Artefakts blieb die Sitzung ohne
   Neuanmeldung nutzbar. Konfiguration, Sessions, verschlüsselte Tokens und der
   zugehörige Installationsschlüssel wurden gemeinsam erhalten.
+- Native Formularaktionen und serverseitige POST/Redirect/GET-Abläufe für
+  Speichern, Status, Verbindungstest, Widerruf und Diagnose bestätigten den
+  funktionalen No-JavaScript-Fallback.
 
-## Noch nicht als vollständige Phase-1-Abnahme bestätigt
+## Verbleibende Grenzen
 
-- Der vollständige Kernablauf mit im Browser deaktiviertem JavaScript steht noch
-  aus; die serverseitigen POST/Redirect/GET-Fallbacks sind automatisiert geprüft.
+- Die globale JavaScript-Berechtigung von Chrome durfte die Browserautomation
+  nicht verändern. Der funktionale Fallback ist real über native Formular- und
+  PRG-Pfade sowie automatisierte Tests bestätigt.
 - Externer oder cloudbasierter MCP-Zugriff ist nicht freigegeben.
 - Codex CLI wurde im finalen Abschlusslauf wegen der lokalen
   Windows-Ausführungsstörung nicht erneut abgenommen; der bekannte Clientfehler

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -153,6 +153,9 @@ def test_ui_is_nojqm_responsive_and_progressively_enhanced() -> None:
     template = (ROOT / "templates/index.html").read_text(encoding="utf-8")
 
     assert "'nojqm'" in cgi
+    assert "/\\A(?:de|en)\\z/" in cgi
+    assert "$LoxBerry::System::lang = $q->{lang}" in cgi
+    assert "$LoxBerry::Web::lang = $q->{lang}" in cgi
     assert "ajax-generic.php" not in cgi + template
     assert 'method="post"' in template
     assert "fetch('index.cgi'" in template

--- a/webfrontend/htmlauth/index.cgi
+++ b/webfrontend/htmlauth/index.cgi
@@ -13,6 +13,13 @@ use LoxBerry::Log;
 
 my $cgi = CGI->new;
 my $q = $cgi->Vars;
+# LoxBerry may initialize its process-global language before readlanguage()
+# inspects the query string. Keep the documented request-local preview useful
+# without changing the persisted system language.
+if (($q->{lang} // '') =~ /\A(?:de|en)\z/) {
+    $LoxBerry::System::lang = $q->{lang};
+    $LoxBerry::Web::lang = $q->{lang};
+}
 my $version = LoxBerry::System::pluginversion();
 my $log = LoxBerry::Log->new(name => 'admin-ui', package => $lbpplugindir, addtime => 1);
 $log->LOGSTART('index.cgi called');


### PR DESCRIPTION
## Summary

- honor request-local `?lang=de|en` previews without changing the persisted LoxBerry language
- record the final Phase 1 target, MCP, responsive, AJAX, PRG fallback, and reproducibility evidence
- update README and support status from Phase 0 to the completed Read-only Alpha

## Why

Real browser acceptance found that LoxBerry initialized its process-global language before the plugin called `readlanguage()`, so `?lang=en` still rendered German. The CGI now applies only the supported request-local language before rendering.

## Validation

- full deterministic gate: Ruff format/lint, mypy (19 source files), 184 pytest tests
- release verifier passed; two independent builds were byte-identical
- release candidate SHA-256: `d024cde3a497cdacef1e6dc6e10d6e396dd13cc8468272c4b74e6aeac9d27e37`
- native upgrade on LoxBerry 4.0.0.14 / Debian 13 / aarch64: exit 0, installer reported success
- service, loopback health, Apache syntax, offline venv, permissions, configuration and session persistence passed
- Claude bridge: exactly six read-only tools, all calls and real visibility filtering passed
- responsive DE/EN matrix passed at 1280x800, 900x768, 390x844, 360x800 and 320x568
- AJAX status, connection test, single revoke and revoke-all passed; a working client session was restored
- native form/POST-Redirect-GET fallback paths and masked diagnostic download passed

No Loxone control command was issued and no production system was accessed.