### PR TITLE
Implement Phase 2 controlled switch operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ Für jeden Assistenten sollte ein eigener Loxone-Benutzer mit den minimal erford
 
 ## Projektstatus
 
-Phase 1 ist abgeschlossen. `0.1.0-alpha.1` ist das installierbare Read-only-
-Prerelease mit nativem Pluginlayout, Dienst, responsiver Admin-UI, OAuth und
-sechs stabilen lesenden Tools. Die Referenzkombination wurde real auf LoxBerry
-4.0.0.14, Debian 13/aarch64 und einem Gen.-1-Miniserver abgenommen.
+Phase 1 ist abgeschlossen. Phase 2 ergänzt als nächstes optional genau ein
+kontrolliertes Schreibwerkzeug für Gen.-1-Controls vom Typ `Switch`. Es bleibt
+standardmäßig deaktiviert, akzeptiert ausschließlich `on` und `off` und benötigt
+den separat bestätigten Scope `loxone:control`. Die sechs stabilen lesenden
+Tools und bestehende Read-only-Sitzungen bleiben kompatibel.
 
 Bestätigte Kombinationen, Nachweise und bekannte Clientgrenzen stehen in der
 [Support-Matrix](docs/development/support-matrix.md) und im

--- a/config/default-config.json
+++ b/config/default-config.json
@@ -1,5 +1,6 @@
 {
   "limits": {
+    "control_requests_per_minute": 10,
     "max_parallel_calls": 4,
     "requests_per_minute": 60
   },
@@ -13,6 +14,7 @@
     "public_origin": ""
   },
   "tools": {
+    "loxone_control_enabled": false,
     "loxone_read_enabled": true
   }
 }

--- a/docs/development/adr/0003-phase-2-controlled-switch.md
+++ b/docs/development/adr/0003-phase-2-controlled-switch.md
@@ -1,0 +1,76 @@
+# ADR 0003: Phase-2 Controlled Switch Operations
+
+- **Status:** Proposed
+- **Date:** 2026-08-04
+- **Release candidate:** `0.2.0-alpha.1`
+
+## Context
+
+Phase 1 provides six stable read-only Loxone tools. Phase 2 adds the first
+state-changing capability without creating a generic command surface or
+widening LoxBerry authorization. The write path must remain disabled by
+default, user-bound, rate-limited and understandable to MCP clients.
+
+## Decision
+
+### Tool contract
+
+`loxone_operate_control` accepts only a visible Loxone control UUID and the
+enum action `on` or `off`. Phase 2 supports only Gen. 1 controls whose normalized
+type is exactly `Switch`, with an `action` UUID and an `active` state UUID.
+There is no free command, name-based target, bulk operation or expected-state
+parameter.
+
+The result reports the target, action, command acceptance, state confirmation
+and the observed state `on`, `off` or `unknown`. The server waits at most three
+seconds for a newer matching state event. An accepted command without a state
+event remains successful with a warning and `confirmed=false`. A transport
+failure after dispatch returns `outcome_unknown`; it is never retried.
+
+The tool annotations are `readOnlyHint=false`, `destructiveHint=true`,
+`idempotentHint=true` and `openWorldHint=false`.
+
+### Authorization and activation
+
+The supported scope sets are `loxone:read` and `loxone:read loxone:control`.
+Control alone is invalid. Existing sessions remain read-only and refresh never
+adds a scope. The consent page calls out control access explicitly.
+
+Configuration adds `tools.loxone_control_enabled`, default `false`, and
+`limits.control_requests_per_minute`, default `10` with range `1` to `60`,
+without changing `schema_version: 1`. The write tool is registered only while
+control is enabled. Disabling it revokes control-scoped families. Enabling
+control for HTTPS/Gen. 2 endpoints is rejected; Gen. 2 write support requires a
+later, separate opt-in decision and evidence.
+
+Loxone permissions are the only control allowlist. The server resolves the
+target in the structure delivered for the authenticated Loxone identity and
+requires the Miniserver-provided action UUID. It does not add a second UUID or
+client allowlist.
+
+### Runtime and logging
+
+Each command uses a short-lived authenticated WebSocket so its response cannot
+race the persistent state event stream. Gen. 1 commands use Loxone Command
+Encryption and the stored identity-bound JWT. Each OAuth family has at most one
+control call in progress and at most the configured number per minute.
+
+There is no separate audit database or UI. Every accepted operation writes one
+compact INFO record to the existing service log. Rejected or uncertain calls
+write WARN records, with identical failures limited to one record per identity
+and error code per minute. Records contain a trace ID, pseudonymized client and
+identity, target UUID, action and outcome; they contain no names, values,
+payloads or secrets.
+
+## Verification boundary
+
+The deterministic gate proves schemas, scope preservation, configuration
+compatibility, command construction, primary authorization failures and unknown
+outcomes. There is no coverage target and no requirement to mirror every
+defensive branch in a test.
+
+Manual acceptance is limited to the changed UI at the primary desktop and
+mobile viewports plus one native upgrade and one approved non-critical Gen. 1
+Switch toggled on and off, restoring its initial state. Gen. 2, external access,
+fresh installation, uninstall and exhaustive negative paths are outside this
+acceptance run.

--- a/docs/development/automation.md
+++ b/docs/development/automation.md
@@ -17,6 +17,11 @@ authorization, connection profiles, credentials, and private test fixtures outsi
   exercises all six read-only tools. Use `-VisibilityFixturePath <private-json>` to add
   a real visible/hidden-control boundary test. The private JSON contains only
   `visible_control_uuid` and `hidden_control_uuid` and remains outside Git.
+- `-ControlFixturePath <private-json>` is a separate explicit opt-in for the Phase 2
+  target smoke. It expects only `control_uuid` and `initial_state` (`on` or `off`),
+  switches once to the opposite state and restores the recorded initial state. Use it
+  only for a previously approved non-critical Gen. 1 Switch; keep the fixture outside
+  Git.
 
 `tools/build_plugin.py` and `tools/prepare_wheelhouse.py` remain useful low-level
 building blocks for focused development. Use the release-candidate wrapper for any

--- a/docs/development/plugin-concept.md
+++ b/docs/development/plugin-concept.md
@@ -725,11 +725,11 @@ Support-Matrix.
 
 ### Phase 2: Kontrollierte Loxone-Schreibaktionen
 
-- erste getestete Control-Typen
-- `loxone_operate_control`
-- Audit und Rate Limits
-- explizite Aktivierung von `loxone:control`
-- optionaler externer HTTPS-Betrieb nach Sicherheitstest
+- ausschließlich Gen.-1-`Switch` mit explizitem `on` und `off`
+- `loxone_operate_control` mit UUID-Ziel und beobachteter Zustandsbestätigung
+- kompaktes Audit im bestehenden Service-Log und separates Control-Rate-Limit
+- explizite Aktivierung und neuer OAuth-Consent für `loxone:control`
+- kein externer MCP-Betrieb und keine Gen.-2-Schreibfreigabe
 
 ### Phase 3: LoxBerry Read-only
 

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -1,9 +1,10 @@
-# LoxBerry MCP Server 0.1.0-alpha.1
+# LoxBerry MCP Server 0.2.0-alpha.1
 
 ## Voraussetzungen
 
 - LoxBerry 4.0.0 oder neuer; Referenzsystem ist 4.0.0.14 auf Debian 13/arm64.
-- Ein eigener Loxone-Benutzer mit möglichst kleinen Leserechten.
+- Ein eigener Loxone-Benutzer mit möglichst kleinen Lese- und, falls benötigt,
+  gezielt vergebenen Switch-Rechten.
 - Gen. 1: private lokale HTTP-Adresse. Gen. 2: gültige HTTPS-Adresse mit
   vertrauenswürdigem Zertifikat; derzeit experimentell.
 - Keine Zugangsdaten in URLs. Basic Auth wird nicht unterstützt.
@@ -21,16 +22,24 @@ alle Python-Wheels offline mit. Öffne danach **LoxBerry MCP Server**:
 4. Verbinde Codex CLI oder Claude Desktop mit
    `https://loxberry.local/plugins/mcpserver/mcp` und folge dem OAuth-Login.
 
+Die sechs Lesetools bleiben standardmäßig aktiv. Für die optionale Bedienung
+von Gen.-1-Switches aktiviere zusätzlich **Loxone-Steuerung**. Danach ist eine
+neue OAuth-Freigabe mit `loxone:control` erforderlich. Deaktivieren widerruft
+bestehende Control-Sitzungen; reine Lesesitzungen bleiben gültig. Bei einem
+Gen.-2-/HTTPS-Ziel kann die Steuerung nicht aktiviert werden.
+
 Speichern, Verbindungstest und Sitzungswiderruf funktionieren auch ohne
 JavaScript. Mit JavaScript werden Status, Test und Widerruf ohne Seitenwechsel
 aktualisiert.
 
 ## Umfang und Betrieb
 
-Die Alpha veröffentlicht ausschließlich die sechs dokumentierten
-`loxone_*`-Lesetools. Sie bietet keine Steuerbefehle, Historie, LoxBerry-Tools,
-Basic Auth oder generischen Kommandos. Ergebnisse entsprechen den Sichtrechten
-des angemeldeten Loxone-Benutzers.
+Die Alpha veröffentlicht sechs dokumentierte `loxone_*`-Lesetools und optional
+`loxone_operate_control`. Das Schreibtool akzeptiert ausschließlich eine
+sichtbare Control-UUID vom Typ `Switch` und die Aktion `on` oder `off`. Es bietet
+keine Namens-, Raum-, Bulk- oder freien Kommandos. Historie, LoxBerry-Tools und
+Basic Auth bleiben ausgeschlossen. Ergebnisse und Aktionen entsprechen den
+Rechten des angemeldeten Loxone-Benutzers.
 
 Der englische Healthcheck führt keine Reparatur aus:
 
@@ -42,6 +51,10 @@ Logs erscheinen im LoxBerry-Logviewer. Der Diagnoseexport enthält nur Version,
 Dienststatus, Transportart und maskierte Zähler. Sitzungen können einzeln oder
 gemeinsam widerrufen werden; ein erreichbarer Miniserver erhält zusätzlich
 best effort `killtoken`.
+
+Jeder Schreibversuch erzeugt einen kompakten maskierten Eintrag im bestehenden
+Service-Log. Wiederholte identische Ablehnungen werden gedrosselt; eine separate
+Auditdatei wird nicht angelegt.
 
 ## Rücksetzen
 

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -1,9 +1,10 @@
-# LoxBerry MCP Server 0.1.0-alpha.1
+# LoxBerry MCP Server 0.2.0-alpha.1
 
 ## Requirements
 
 - LoxBerry 4.0.0 or newer; the reference target is 4.0.0.14 on Debian 13/arm64.
-- A dedicated Loxone user with the smallest practical read permissions.
+- A dedicated Loxone user with the smallest practical read permissions and,
+  when needed, narrowly assigned Switch permissions.
 - Gen. 1: a private local HTTP address. Gen. 2: a valid HTTPS address with a
   trusted certificate; currently experimental.
 - Never put credentials in URLs. Basic Auth is unsupported.
@@ -21,14 +22,22 @@ all Python wheels for offline installation. Then open **LoxBerry MCP Server**:
 4. Connect Codex CLI or Claude Desktop to
    `https://loxberry.local/plugins/mcpserver/mcp` and complete OAuth login.
 
+The six read tools remain enabled by default. To operate Gen. 1 switches,
+additionally enable **Loxone control**. A new OAuth grant with `loxone:control`
+is then required. Disabling control revokes existing control sessions while
+read-only sessions remain valid. Control cannot be enabled for a Gen. 2/HTTPS
+target.
+
 Save, connection test and session revocation remain usable without JavaScript.
 With JavaScript, status, test and revocation update without a page navigation.
 
 ## Scope and operation
 
-The alpha publishes only the six documented `loxone_*` read tools. It provides
-no controls, history, LoxBerry tools, Basic Auth or generic commands. Results
-are limited to the permissions of the authenticated Loxone user.
+The alpha publishes six documented `loxone_*` read tools and optionally
+`loxone_operate_control`. The control tool accepts only a visible `Switch`
+control UUID and the action `on` or `off`. It provides no name-, room-, bulk- or
+free-form commands. History, LoxBerry tools and Basic Auth remain excluded.
+Results and actions are limited to the authenticated Loxone user's permissions.
 
 The English healthcheck never repairs the system:
 
@@ -40,6 +49,10 @@ Logs appear in the LoxBerry log viewer. Diagnostic export contains only the
 version, service state, transport kind and masked counts. Sessions can be
 revoked individually or together; an available Miniserver also receives a
 best-effort `killtoken`.
+
+Every control attempt creates one compact masked record in the existing service
+log. Repeated identical rejections are limited; no separate audit file is
+created.
 
 ## Rollback
 

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -3,7 +3,7 @@ NAME=Miraculix2050
 EMAIL=198097126+Miraculix2050@users.noreply.github.com
 
 [PLUGIN]
-VERSION=0.1.0-alpha.1
+VERSION=0.2.0-alpha.1
 NAME=mcpserver
 FOLDER=mcpserver
 TITLE=LoxBerry MCP Server

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -52,7 +52,7 @@ fi
 
 python3.13 -m venv "$new_venv" || exit 2
 "$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" -r "$plugin_bin/runtime-arm64.lock" || exit 2
-"$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" loxberry-mcpserver==0.1.0a1 || exit 2
+"$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" loxberry-mcpserver==0.2.0a1 || exit 2
 if [ -d "$venv" ]; then
     mv "$venv" "$old_venv" || exit 2
 fi

--- a/prerelease.cfg
+++ b/prerelease.cfg
@@ -1,4 +1,4 @@
 [AUTOUPDATE]
-VERSION=0.1.0-alpha.1
+VERSION=0.2.0-alpha.1
 ARCHIVEURL=
 INFOURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loxberry-mcpserver"
-version = "0.1.0-alpha.1"
+version = "0.2.0-alpha.1"
 description = "Local MCP server for LoxBerry and Loxone"
 requires-python = ">=3.13,<3.14"
 license = "Apache-2.0"

--- a/src/mcpserver/__init__.py
+++ b/src/mcpserver/__init__.py
@@ -5,6 +5,6 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("loxberry-mcpserver")
 except PackageNotFoundError:  # pragma: no cover - source tree without installation
-    __version__ = "0.1.0-alpha.1"
+    __version__ = "0.2.0-alpha.1"
 
 __all__ = ["__version__"]

--- a/src/mcpserver/admin.py
+++ b/src/mcpserver/admin.py
@@ -14,6 +14,7 @@ from uuid import UUID
 
 from mcpserver import __version__
 from mcpserver.auth.loxone_store import EncryptedLoxoneTokenStore, LoxoneTokenStoreError
+from mcpserver.auth.provider import CONTROL_SCOPE
 from mcpserver.auth.store import AtomicJsonAuthStore
 from mcpserver.config import AtomicConfigStore, ConfigError, PluginConfig
 from mcpserver.loxone.client import LoxoneClient, LoxoneConnectionError, MiniserverEndpoint
@@ -85,6 +86,15 @@ def _save(payload: object) -> dict[str, Any]:
     config = PluginConfig.from_document(payload)
     store = _config_store()
     previous = store.load()
+    control_families: list[str] = []
+    if previous.loxone_control_enabled and not config.loxone_control_enabled:
+        document = _auth_store().snapshot()
+        control_families = [
+            family_id
+            for family_id, record in document["families"].items()
+            if CONTROL_SCOPE in str(record.get("scope", "")).split()
+            and not record.get("revoked", False)
+        ]
     store.save(config)
     try:
         _restart_service()
@@ -97,6 +107,12 @@ def _save(payload: object) -> dict[str, Any]:
         raise AdminError(
             "configuration was not applied; previous configuration restored"
         ) from apply_error
+    for family_id in control_families:
+        _revoke(
+            family_id,
+            endpoint=previous.loxone_endpoint,
+            timeout_seconds=previous.connection_timeout,
+        )
     return {"configuration": config.to_document(), "applied": True}
 
 
@@ -126,6 +142,7 @@ def _sessions() -> list[dict[str, Any]]:
                 "id": family_id,
                 "client": str(record.get("client_id", ""))[:12],
                 "identity": str(record.get("identity_id", ""))[:12],
+                "scopes": str(record.get("scope", "loxone:read")),
                 "expires_at": record.get("expires_at"),
                 "revoked": bool(record.get("revoked", False)),
             }
@@ -133,7 +150,12 @@ def _sessions() -> list[dict[str, Any]]:
     return sorted(result, key=lambda item: str(item["id"]))
 
 
-def _revoke(family_id: str | None) -> int:
+def _revoke(
+    family_id: str | None,
+    *,
+    endpoint: str | None = None,
+    timeout_seconds: float | None = None,
+) -> int:
     revoked: list[str] = []
     bindings: list[tuple[str, str, str]] = []
 
@@ -167,11 +189,13 @@ def _revoke(family_id: str | None) -> int:
     except LoxoneTokenStoreError:
         token_store = None
     config = _config_store().load()
-    if config.loxone_endpoint and token_store is not None:
+    selected_endpoint = endpoint if endpoint is not None else config.loxone_endpoint
+    selected_timeout = timeout_seconds if timeout_seconds is not None else config.connection_timeout
+    if selected_endpoint and token_store is not None:
         client = LoxoneClient(
-            MiniserverEndpoint.parse(config.loxone_endpoint),
+            MiniserverEndpoint.parse(selected_endpoint),
             client_uuid=_CLIENT_UUID,
-            timeout_seconds=config.connection_timeout,
+            timeout_seconds=selected_timeout,
         )
 
         async def kill_tokens() -> None:

--- a/src/mcpserver/auth/provider.py
+++ b/src/mcpserver/auth/provider.py
@@ -23,7 +23,11 @@ from pydantic import AnyUrl
 
 from mcpserver.auth.store import AtomicJsonAuthStore, token_digest
 
-SCOPE: Final = "loxone:read"
+READ_SCOPE: Final = "loxone:read"
+CONTROL_SCOPE: Final = "loxone:control"
+# Retained as the Phase 1 source-level alias used by existing integrations.
+SCOPE: Final = READ_SCOPE
+SUPPORTED_SCOPES: Final = (READ_SCOPE, CONTROL_SCOPE)
 _LOGGER = logging.getLogger("mcpserver.auth.provider")
 AUTHORIZATION_CODE_TTL: Final = 5 * 60
 ACCESS_TOKEN_TTL: Final = 10 * 60
@@ -55,6 +59,20 @@ class StoredAccessToken(AccessToken):
 
 def _opaque_token() -> str:
     return secrets.token_urlsafe(32)
+
+
+def normalize_scopes(value: str | None, *, control_enabled: bool) -> tuple[str, ...]:
+    """Return the canonical supported scope set without allowing control alone."""
+    requested = value.split() if value else [READ_SCOPE]
+    if len(requested) != len(set(requested)) or set(requested) - set(SUPPORTED_SCOPES):
+        raise ValueError("unsupported scope")
+    if READ_SCOPE not in requested or (CONTROL_SCOPE in requested and not control_enabled):
+        raise ValueError("unsupported scope")
+    return tuple(scope for scope in SUPPORTED_SCOPES if scope in requested)
+
+
+def scope_text(scopes: tuple[str, ...] | list[str]) -> str:
+    return " ".join(scopes)
 
 
 def redirect_uri_is_allowed(value: str) -> bool:
@@ -97,12 +115,14 @@ class Phase0OAuthProvider(
         resource: str,
         clock: Callable[[], float] = time.time,
         on_family_revoked: Callable[[str], None] | None = None,
+        control_enabled: bool = False,
     ) -> None:
         self.store = store
         self.issuer = issuer
         self.resource = resource
         self._clock = clock
         self._on_family_revoked = on_family_revoked
+        self.control_enabled = control_enabled
 
     def now(self) -> int:
         return int(self._clock())
@@ -119,6 +139,10 @@ class Phase0OAuthProvider(
         return OAuthClientInformationFull.model_validate(record) if record is not None else None
 
     async def register_client(self, client_info: OAuthClientInformationFull) -> None:
+        try:
+            scopes = normalize_scopes(client_info.scope, control_enabled=self.control_enabled)
+        except ValueError:
+            scopes = ()
         if (
             not client_info.client_id
             or client_info.client_secret is not None
@@ -129,11 +153,12 @@ class Phase0OAuthProvider(
             or set(client_info.grant_types) != {"authorization_code", "refresh_token"}
             or len(client_info.grant_types) != 2
             or client_info.response_types != ["code"]
-            or client_info.scope != SCOPE
+            or not scopes
         ):
             raise RegistrationError("invalid_client_metadata", "Unsupported public client metadata")
 
         record = client_info.model_dump(mode="json", exclude_none=True)
+        record["scope"] = scope_text(list(scopes))
 
         def insert(document: dict[str, Any]) -> None:
             self._garbage_collect(document)
@@ -202,10 +227,19 @@ class Phase0OAuthProvider(
         resource: str,
         identity_id: str,
         miniserver_id: str,
+        scopes: tuple[str, ...] = (READ_SCOPE,),
         family_id: str | None = None,
     ) -> str:
         if resource != self.resource:
             raise TokenError("invalid_grant", "Resource mismatch")
+        try:
+            validated_scopes = normalize_scopes(
+                scope_text(list(scopes)), control_enabled=self.control_enabled
+            )
+        except ValueError as exc:
+            raise TokenError("invalid_scope", "Unsupported authorization scope") from exc
+        if validated_scopes != scopes:
+            raise TokenError("invalid_scope", "Authorization scopes must be canonical")
         raw_code = _opaque_token()
         digest = token_digest(raw_code)
         now = self.now()
@@ -215,7 +249,7 @@ class Phase0OAuthProvider(
             "redirect_uri": redirect_uri,
             "code_challenge": code_challenge,
             "resource": resource,
-            "scopes": [SCOPE],
+            "scopes": list(validated_scopes),
             "expires_at": now + AUTHORIZATION_CODE_TTL,
             "family_id": family_id,
             "identity_id": identity_id,
@@ -242,7 +276,7 @@ class Phase0OAuthProvider(
                 "client_id": client_id,
                 "identity_id": identity_id,
                 "miniserver_id": miniserver_id,
-                "scope": SCOPE,
+                "scope": scope_text(list(validated_scopes)),
                 "resource": resource,
                 "expires_at": now + REFRESH_FAMILY_TTL,
                 "revoked": False,
@@ -290,13 +324,14 @@ class Phase0OAuthProvider(
         miniserver_id: str,
         resource: str,
         family_expires_at: int,
+        scopes: list[str],
     ) -> tuple[str, str, dict[str, Any], dict[str, Any]]:
         now = self.now()
         raw_access = _opaque_token()
         raw_refresh = _opaque_token()
         access_record = {
             "client_id": client_id,
-            "scopes": [SCOPE],
+            "scopes": scopes,
             "expires_at": min(now + ACCESS_TOKEN_TTL, family_expires_at),
             "resource": resource,
             "family_id": family_id,
@@ -306,7 +341,7 @@ class Phase0OAuthProvider(
         }
         refresh_record = {
             "client_id": client_id,
-            "scopes": [SCOPE],
+            "scopes": scopes,
             "expires_at": family_expires_at,
             "resource": resource,
             "family_id": family_id,
@@ -348,6 +383,7 @@ class Phase0OAuthProvider(
                 miniserver_id=record["miniserver_id"],
                 resource=record["resource"],
                 family_expires_at=family["expires_at"],
+                scopes=list(record["scopes"]),
             )
             document["access_tokens"][token_digest(raw_access)] = access
             document["refresh_tokens"][token_digest(raw_refresh)] = refresh
@@ -358,7 +394,7 @@ class Phase0OAuthProvider(
             access_token=raw_access,
             token_type="Bearer",
             expires_in=max(0, access_expires_at - self.now()),
-            scope=SCOPE,
+            scope=scope_text(list(authorization_code.scopes)),
             refresh_token=raw_refresh,
         )
 
@@ -427,8 +463,8 @@ class Phase0OAuthProvider(
         refresh_token: StoredRefreshToken,
         scopes: list[str],
     ) -> OAuthToken:
-        if scopes != [SCOPE]:
-            raise TokenError("invalid_scope", "Only loxone:read is supported")
+        if scopes != list(refresh_token.scopes):
+            raise TokenError("invalid_scope", "Refresh cannot change the authorized scopes")
         raw_access = ""
         raw_refresh = ""
         access_expires_at = 0
@@ -457,6 +493,7 @@ class Phase0OAuthProvider(
                 miniserver_id=record["miniserver_id"],
                 resource=record["resource"],
                 family_expires_at=family["expires_at"],
+                scopes=list(record["scopes"]),
             )
             document["access_tokens"][token_digest(raw_access)] = access
             document["refresh_tokens"][token_digest(raw_refresh)] = refresh
@@ -469,7 +506,7 @@ class Phase0OAuthProvider(
             access_token=raw_access,
             token_type="Bearer",
             expires_in=max(0, access_expires_at - self.now()),
-            scope=SCOPE,
+            scope=scope_text(scopes),
             refresh_token=raw_refresh,
         )
 
@@ -525,3 +562,24 @@ class Phase0OAuthProvider(
                     return
 
         self.store.mutate(revoke)
+
+    def revoke_scope_locally(self, scope: str) -> int:
+        """Fail closed for a disabled scope without discarding remote token material."""
+        revoked: list[str] = []
+
+        def revoke(document: dict[str, Any]) -> None:
+            for family_id, family in document["families"].items():
+                if (
+                    family.get("revoked", False)
+                    or scope not in str(family.get("scope", "")).split()
+                ):
+                    continue
+                family["revoked"] = True
+                revoked.append(family_id)
+                for collection in ("codes", "access_tokens", "refresh_tokens"):
+                    for record in document[collection].values():
+                        if record.get("family_id") == family_id:
+                            record["status"] = "revoked"
+
+        self.store.mutate(revoke)
+        return len(revoked)

--- a/src/mcpserver/auth/web.py
+++ b/src/mcpserver/auth/web.py
@@ -29,7 +29,13 @@ from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 
 from mcpserver.auth.loxone_store import EncryptedLoxoneTokenStore
-from mcpserver.auth.provider import SCOPE, Phase0OAuthProvider
+from mcpserver.auth.provider import (
+    CONTROL_SCOPE,
+    READ_SCOPE,
+    Phase0OAuthProvider,
+    normalize_scopes,
+    scope_text,
+)
 from mcpserver.loxone.client import (
     LoxoneClient,
     LoxoneConnectionError,
@@ -65,6 +71,7 @@ class LoginTransaction:
     code_challenge: str
     resource: str
     created_at: int
+    scopes: tuple[str, ...] = (READ_SCOPE,)
     attempts: int = 0
     loxone_token: LoxoneToken | None = None
     identity_name: str | None = None
@@ -333,9 +340,17 @@ class Phase0OAuthWeb:
                 "<h1>Invalid authorization request</h1>",
                 status=400,
             )
+        try:
+            scopes = normalize_scopes(
+                query.get("scope"), control_enabled=self.provider.control_enabled
+            )
+        except ValueError:
+            return _redirect(
+                redirect_uri,
+                {"error": "invalid_scope", "state": query.get("state", ""), "iss": self.issuer},
+            )
         if (
             query.get("response_type") != "code"
-            or query.get("scope") != SCOPE
             or query.get("resource") != self.resource
             or query.get("code_challenge_method") != "S256"
             or not _PKCE_CHALLENGE.fullmatch(query.get("code_challenge", ""))
@@ -360,6 +375,7 @@ class Phase0OAuthWeb:
             state=query["state"],
             code_challenge=query["code_challenge"],
             resource=query["resource"],
+            scopes=scopes,
             created_at=int(time.time()),
         )
         self.transactions[transaction.transaction_id] = transaction
@@ -391,11 +407,22 @@ class Phase0OAuthWeb:
         return _html_page("Connect Loxone", body, callback_uri=transaction.redirect_uri)
 
     def _consent_page(self, transaction: LoginTransaction) -> HTMLResponse:
-        body = f"""<h1>Allow read-only access? / Lesezugriff erlauben?</h1><dl>
+        control = CONTROL_SCOPE in transaction.scopes
+        heading = (
+            "Allow Loxone control? / Loxone-Steuerung erlauben?"
+            if control
+            else "Allow read-only access? / Lesezugriff erlauben?"
+        )
+        warning = (
+            '<p class="error"><strong>This client can switch permitted Loxone controls on and off. / Dieser Client darf freigegebene Loxone-Steuerungen ein- und ausschalten.</strong></p>'
+            if control
+            else ""
+        )
+        body = f"""<h1>{heading}</h1>{warning}<dl>
 <dt>Client</dt><dd>{html.escape(transaction.client_name)}</dd>
 <dt>Miniserver</dt><dd>{html.escape(transaction.miniserver_name or "")}</dd>
 <dt>Loxone identity / Loxone-Identität</dt><dd>{html.escape(transaction.identity_name or "")}</dd>
-<dt>Scope / Berechtigung</dt><dd>{SCOPE}</dd></dl>
+<dt>Scope / Berechtigung</dt><dd>{html.escape(scope_text(list(transaction.scopes)))}</dd></dl>
 <form method="post" action="{html.escape(self.issuer)}/authorize">{self._hidden(transaction, "approve")}
 <div class="actions"><button type="submit">Allow / Erlauben</button></div></form>
 <form method="post" action="{html.escape(self.issuer)}/authorize">{self._hidden(transaction, "deny")}
@@ -470,6 +497,7 @@ class Phase0OAuthWeb:
                         resource=transaction.resource,
                         identity_id=transaction.identity_id,
                         miniserver_id=transaction.miniserver_id,
+                        scopes=transaction.scopes,
                         family_id=family_id,
                     )
                 except TokenError:
@@ -624,10 +652,16 @@ class Phase0OAuthWeb:
         refresh = await self.provider.load_refresh_token(client, form.get("refresh_token", ""))
         if refresh is None or refresh.resource != form.get("resource"):
             return _oauth_error("invalid_grant")
-        scope = form.get("scope", SCOPE)
-        if scope != SCOPE:
+        requested = form.get("scope")
+        try:
+            scopes = (
+                normalize_scopes(requested, control_enabled=self.provider.control_enabled)
+                if requested is not None
+                else tuple(refresh.scopes)
+            )
+        except ValueError:
             return _oauth_error("invalid_scope")
-        token = await self.provider.exchange_refresh_token(client, refresh, [SCOPE])
+        token = await self.provider.exchange_refresh_token(client, refresh, list(scopes))
         return _json(token.model_dump(mode="json", exclude_none=True))
 
     async def register(self, request: Request) -> Response:
@@ -655,16 +689,20 @@ class Phase0OAuthWeb:
             reason = "Only public clients are supported"
             if payload.get("token_endpoint_auth_method") not in {None, "none"}:
                 raise ValueError
-            reason = "Only loxone:read is supported"
-            if payload.get("scope") not in {None, SCOPE}:
-                raise ValueError
+            reason = "Unsupported scope"
+            try:
+                scopes = normalize_scopes(
+                    payload.get("scope"), control_enabled=self.provider.control_enabled
+                )
+            except (AttributeError, ValueError):
+                raise ValueError from None
             reason = "Client metadata schema is invalid"
             sdk_payload = {
                 key: value for key, value in payload.items() if key != "application_type"
             }
             metadata = OAuthClientMetadata.model_validate(sdk_payload)
             normalized = metadata.model_dump()
-            normalized["scope"] = SCOPE
+            normalized["scope"] = scope_text(list(scopes))
             normalized["token_endpoint_auth_method"] = "none"
             normalized["client_id"] = _opaque()
             normalized["client_id_issued_at"] = self.provider.now()
@@ -703,7 +741,8 @@ class Phase0OAuthWeb:
                 "token_endpoint": f"{self.issuer}/token",
                 "registration_endpoint": f"{self.issuer}/register",
                 "revocation_endpoint": f"{self.issuer}/revoke",
-                "scopes_supported": [SCOPE],
+                "scopes_supported": [READ_SCOPE]
+                + ([CONTROL_SCOPE] if self.provider.control_enabled else []),
                 "response_types_supported": ["code"],
                 "grant_types_supported": ["authorization_code", "refresh_token"],
                 "token_endpoint_auth_methods_supported": ["none"],

--- a/src/mcpserver/config.py
+++ b/src/mcpserver/config.py
@@ -21,6 +21,7 @@ SCHEMA_VERSION: Final = 1
 DEFAULT_CONNECTION_TIMEOUT: Final = 10.0
 DEFAULT_REQUESTS_PER_MINUTE: Final = 60
 DEFAULT_MAX_PARALLEL_CALLS: Final = 4
+DEFAULT_CONTROL_REQUESTS_PER_MINUTE: Final = 10
 
 
 class ConfigError(ValueError):
@@ -63,7 +64,9 @@ class PluginConfig:
     loxone_endpoint: str = ""
     connection_timeout: float = DEFAULT_CONNECTION_TIMEOUT
     loxone_read_enabled: bool = True
+    loxone_control_enabled: bool = False
     requests_per_minute: int = DEFAULT_REQUESTS_PER_MINUTE
+    control_requests_per_minute: int = DEFAULT_CONTROL_REQUESTS_PER_MINUTE
     max_parallel_calls: int = DEFAULT_MAX_PARALLEL_CALLS
     _source: dict[str, Any] | None = None
 
@@ -133,13 +136,24 @@ class PluginConfig:
         read_enabled = _boolean(
             tools.get("loxone_read_enabled", True), name="tools.loxone_read_enabled"
         )
+        control_enabled = _boolean(
+            tools.get("loxone_control_enabled", False), name="tools.loxone_control_enabled"
+        )
         if enabled and not read_enabled:
             raise ConfigError("the Phase 1 service requires tools.loxone_read_enabled")
+        if control_enabled and endpoint and MiniserverEndpoint.parse(endpoint).secure:
+            raise ConfigError("Loxone control is supported only for Gen. 1 HTTP endpoints")
         requests = _integer(
             limits.get("requests_per_minute", DEFAULT_REQUESTS_PER_MINUTE),
             name="limits.requests_per_minute",
             minimum=1,
             maximum=600,
+        )
+        control_requests = _integer(
+            limits.get("control_requests_per_minute", DEFAULT_CONTROL_REQUESTS_PER_MINUTE),
+            name="limits.control_requests_per_minute",
+            minimum=1,
+            maximum=60,
         )
         parallel = _integer(
             limits.get("max_parallel_calls", DEFAULT_MAX_PARALLEL_CALLS),
@@ -153,7 +167,9 @@ class PluginConfig:
             loxone_endpoint=endpoint,
             connection_timeout=timeout,
             loxone_read_enabled=read_enabled,
+            loxone_control_enabled=control_enabled,
             requests_per_minute=requests,
+            control_requests_per_minute=control_requests,
             max_parallel_calls=parallel,
             _source=copy.deepcopy(root),
         )
@@ -170,7 +186,9 @@ class PluginConfig:
         document["loxone"]["endpoint"] = self.loxone_endpoint
         document["loxone"]["connection_timeout"] = self.connection_timeout
         document["tools"]["loxone_read_enabled"] = self.loxone_read_enabled
+        document["tools"]["loxone_control_enabled"] = self.loxone_control_enabled
         document["limits"]["requests_per_minute"] = self.requests_per_minute
+        document["limits"]["control_requests_per_minute"] = self.control_requests_per_minute
         document["limits"]["max_parallel_calls"] = self.max_parallel_calls
         return document
 

--- a/src/mcpserver/loxone/client.py
+++ b/src/mcpserver/loxone/client.py
@@ -51,6 +51,10 @@ class LoxoneConnectionError(RuntimeError):
     """Sanitized error raised when the Miniserver cannot be used securely."""
 
 
+class LoxoneCommandRejected(LoxoneConnectionError):
+    """Raised when an authenticated Miniserver rejects a control command."""
+
+
 class _WebSocketIdleTimeout(TimeoutError):
     """No WebSocket header arrived within the configured idle interval."""
 
@@ -188,7 +192,7 @@ def _response_value(document: Mapping[str, Any]) -> Any:
         raise LoxoneConnectionError("Miniserver returned an invalid response")
     code = wrapper.get("Code", wrapper.get("code"))
     if str(code) != "200":
-        raise LoxoneConnectionError("Miniserver rejected the request")
+        raise LoxoneCommandRejected("Miniserver rejected the request")
     return wrapper.get("value")
 
 
@@ -585,6 +589,15 @@ class LoxoneWebSocketSession:
             # after invalidating the connection token. A normal close is the
             # successful terminal response in that case.
             return
+
+    async def operate_switch(self, action_uuid: str, action: str) -> None:
+        """Execute the only Phase 2 control command through this authenticated session."""
+        if not action_uuid or len(action_uuid) > 128 or action not in {"on", "off"}:
+            raise ValueError("invalid Switch operation")
+        await self._command(
+            f"jdev/sps/io/{quote(action_uuid, safe='')}/{action}",
+            encrypted=not self._secure_transport,
+        )
 
     async def state_events(self) -> AsyncIterator[tuple[StateEvent, ...]]:
         await self._command("jdev/sps/enablebinstatusupdate")

--- a/src/mcpserver/loxone/runtime.py
+++ b/src/mcpserver/loxone/runtime.py
@@ -1,4 +1,4 @@
-"""User-isolated Loxone connection and cache lifecycle for read-only tools."""
+"""User-isolated Loxone connection, cache, and bounded control lifecycle."""
 
 from __future__ import annotations
 
@@ -11,15 +11,17 @@ from dataclasses import dataclass
 from uuid import NAMESPACE_URL, uuid5
 
 from mcpserver.auth.loxone_store import EncryptedLoxoneTokenStore, LoxoneTokenStoreError
-from mcpserver.auth.provider import StoredAccessToken
+from mcpserver.auth.provider import CONTROL_SCOPE, READ_SCOPE, StoredAccessToken
 from mcpserver.loxone.cache import UserStateCache
 from mcpserver.loxone.client import (
     LoxoneClient,
+    LoxoneCommandRejected,
     LoxoneConnectionError,
     LoxoneToken,
     LoxoneWebSocketSession,
 )
-from mcpserver.loxone.models import Control, LoxoneStructure, StateRecord
+from mcpserver.loxone.events import LoxoneProtocolError
+from mcpserver.loxone.models import Control, Freshness, LoxoneStructure, StateRecord
 
 _LOXONE_EPOCH_UNIX = 1_230_768_000
 _REFRESH_BEFORE_SECONDS = 24 * 60 * 60
@@ -27,6 +29,23 @@ _REFRESH_BEFORE_SECONDS = 24 * 60 * 60
 
 class RuntimeUnavailable(RuntimeError):
     """The identity-bound Loxone runtime is not currently available."""
+
+
+class ControlOperationError(RuntimeError):
+    """A stable control failure that can be returned through the MCP contract."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+@dataclass(frozen=True, slots=True)
+class ControlOperation:
+    control_uuid: str
+    action: str
+    accepted: bool
+    confirmed: bool
+    observed_state: str
 
 
 def _state_uuids(controls: tuple[Control, ...]) -> frozenset[str]:
@@ -64,6 +83,8 @@ class LoxoneRuntime:
         timeout_seconds: float = 10.0,
         requests_per_minute: int = 60,
         max_parallel_calls: int = 4,
+        control_requests_per_minute: int = 10,
+        control_confirmation_seconds: float = 3.0,
     ) -> None:
         from mcpserver.loxone.client import MiniserverEndpoint
 
@@ -81,11 +102,15 @@ class LoxoneRuntime:
         self._locks: defaultdict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
         self._rate: defaultdict[str, deque[float]] = defaultdict(deque)
         self._rate_limit = requests_per_minute
+        self._control_rate: defaultdict[str, deque[float]] = defaultdict(deque)
+        self._control_rate_limit = control_requests_per_minute
+        self._control_locks: defaultdict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
+        self._control_confirmation_seconds = control_confirmation_seconds
         self._parallel = asyncio.Semaphore(max_parallel_calls)
 
     @asynccontextmanager
     async def call_slot(self, access: StoredAccessToken) -> AsyncIterator[None]:
-        if "loxone:read" not in access.scopes:
+        if READ_SCOPE not in access.scopes:
             raise PermissionError("loxone:read scope is required")
         now = time.monotonic()
         values = self._rate[access.family_id]
@@ -96,6 +121,127 @@ class LoxoneRuntime:
         values.append(now)
         async with self._parallel:
             yield
+
+    @staticmethod
+    def _consume_rate(values: deque[float], limit: int, now: float) -> bool:
+        while values and values[0] <= now - 60:
+            values.popleft()
+        if len(values) >= limit:
+            return False
+        values.append(now)
+        return True
+
+    @staticmethod
+    def _control(structure: LoxoneStructure, uuid: str) -> Control | None:
+        pending = list(structure.controls)
+        while pending:
+            control = pending.pop()
+            if control.uuid == uuid:
+                return control
+            pending.extend(control.subcontrols)
+        return None
+
+    async def operate_switch(
+        self, access: StoredAccessToken, control_uuid: str, action: str
+    ) -> ControlOperation:
+        """Execute a bounded Switch operation for the immutable OAuth identity."""
+        if READ_SCOPE not in access.scopes or CONTROL_SCOPE not in access.scopes:
+            raise ControlOperationError("permission_denied", "loxone:control is required")
+        if not control_uuid or len(control_uuid) > 128 or action not in {"on", "off"}:
+            raise ControlOperationError("invalid_input", "invalid Switch operation")
+
+        now = time.monotonic()
+        if not self._consume_rate(self._rate[access.family_id], self._rate_limit, now):
+            raise ControlOperationError("rate_limited", "request rate limit exceeded")
+        if not self._consume_rate(
+            self._control_rate[access.family_id], self._control_rate_limit, now
+        ):
+            raise ControlOperationError("rate_limited", "control rate limit exceeded")
+
+        async with self._parallel, self._control_locks[access.family_id]:
+            try:
+                snapshot = await self.snapshot(access)
+            except RuntimeUnavailable as exc:
+                raise ControlOperationError("temporarily_unavailable", str(exc)) from exc
+            try:
+                token = self.token_store.get(
+                    access.family_id, access.miniserver_id, access.identity_id
+                )
+            except LoxoneTokenStoreError as exc:
+                raise ControlOperationError(
+                    "temporarily_unavailable", "Loxone authorization is unavailable"
+                ) from exc
+            if token is None:
+                raise ControlOperationError(
+                    "temporarily_unavailable", "Loxone authorization is unavailable"
+                )
+            try:
+                command_session = await self.client.open_session(token)
+            except LoxoneConnectionError as exc:
+                raise ControlOperationError(
+                    "loxone_unreachable", "Miniserver connection failed"
+                ) from exc
+            try:
+                try:
+                    structure = await command_session.load_structure()
+                except (LoxoneConnectionError, LoxoneProtocolError) as exc:
+                    raise ControlOperationError(
+                        "temporarily_unavailable",
+                        "Current Loxone permissions could not be verified",
+                    ) from exc
+                control = self._control(structure, control_uuid)
+                if control is None:
+                    raise ControlOperationError("not_found", "control is not visible")
+                if control.control_type != "Switch":
+                    raise ControlOperationError(
+                        "unsupported_control", "only Switch controls are supported"
+                    )
+                if control.action_uuid is None:
+                    raise ControlOperationError(
+                        "permission_denied", "control is not operable for this identity"
+                    )
+                if not 1 <= len(control.action_uuid) <= 128:
+                    raise ControlOperationError(
+                        "unsupported_control", "Switch control has an invalid action target"
+                    )
+                active_uuid = dict(control.state_uuids).get("active")
+                if active_uuid is None:
+                    raise ControlOperationError(
+                        "unsupported_control", "Switch control has no active state"
+                    )
+                before = self.cache.get(snapshot.subject, active_uuid).observed_at
+                await command_session.operate_switch(control.action_uuid, action)
+            except ControlOperationError:
+                raise
+            except LoxoneCommandRejected as exc:
+                raise ControlOperationError(
+                    "permission_denied", "Miniserver rejected the control action"
+                ) from exc
+            except Exception as exc:
+                raise ControlOperationError(
+                    "outcome_unknown",
+                    "Control outcome is unknown; read the state before retrying",
+                ) from exc
+            finally:
+                await command_session.close()
+
+            target = 1.0 if action == "on" else 0.0
+            deadline = time.monotonic() + self._control_confirmation_seconds
+            observed = self.cache.get(snapshot.subject, active_uuid)
+            while time.monotonic() < deadline:
+                observed = self.cache.get(snapshot.subject, active_uuid)
+                if (
+                    observed.freshness is Freshness.CURRENT
+                    and observed.observed_at is not None
+                    and (before is None or observed.observed_at > before)
+                    and observed.value == target
+                ):
+                    return ControlOperation(control_uuid, action, True, True, action)
+                await asyncio.sleep(0.05)
+            state = "unknown"
+            if observed.freshness is Freshness.CURRENT and observed.value in {0.0, 1.0}:
+                state = "on" if observed.value == 1.0 else "off"
+            return ControlOperation(control_uuid, action, True, False, state)
 
     async def snapshot(self, access: StoredAccessToken) -> RuntimeSnapshot:
         subject = access.family_id

--- a/src/mcpserver/server.py
+++ b/src/mcpserver/server.py
@@ -18,12 +18,12 @@ from starlette.types import ASGIApp
 
 from mcpserver import __version__
 from mcpserver.auth.loxone_store import EncryptedLoxoneTokenStore
-from mcpserver.auth.provider import SCOPE, Phase0OAuthProvider
+from mcpserver.auth.provider import CONTROL_SCOPE, READ_SCOPE, Phase0OAuthProvider
 from mcpserver.auth.store import AtomicJsonAuthStore
 from mcpserver.auth.web import Phase0OAuthWeb
 from mcpserver.loxone.runtime import LoxoneRuntime
 from mcpserver.settings import ServerSettings
-from mcpserver.tools import register_read_tools
+from mcpserver.tools import register_control_tool, register_read_tools
 
 SERVER_NAME: Final = "LoxBerry MCP Server"
 _TRANSPORT_LOGGER_NAME: Final = "mcp.server.transport_security"
@@ -164,7 +164,13 @@ def create_server(settings: ServerSettings) -> FastMCP:
             issuer=settings.phase0_auth.issuer_url,
             resource=settings.phase0_auth.resource_url,
             on_family_revoked=loxone_store.delete if loxone_store is not None else None,
+            control_enabled=bool(
+                settings.phase0_auth.plugin_config
+                and settings.phase0_auth.plugin_config.loxone_control_enabled
+            ),
         )
+        if not provider.control_enabled:
+            provider.revoke_scope_locally(CONTROL_SCOPE)
         oauth_web = Phase0OAuthWeb(
             provider,
             endpoint=settings.phase0_auth.loxone_endpoint,
@@ -175,7 +181,7 @@ def create_server(settings: ServerSettings) -> FastMCP:
         oauth_auth = AuthSettings(
             issuer_url=AnyHttpUrl(settings.phase0_auth.issuer_url),
             resource_server_url=AnyHttpUrl(settings.phase0_auth.resource_url),
-            required_scopes=[SCOPE],
+            required_scopes=[READ_SCOPE],
         )
         token_verifier = _Phase0TokenVerifier(provider)
         if loxone_store is not None:
@@ -186,6 +192,9 @@ def create_server(settings: ServerSettings) -> FastMCP:
                 timeout_seconds=config.connection_timeout if config is not None else 10.0,
                 requests_per_minute=config.requests_per_minute if config is not None else 60,
                 max_parallel_calls=config.max_parallel_calls if config is not None else 4,
+                control_requests_per_minute=(
+                    config.control_requests_per_minute if config is not None else 10
+                ),
             )
 
     server = _ForwardedHostFastMCP(
@@ -202,7 +211,14 @@ def create_server(settings: ServerSettings) -> FastMCP:
     server.forwarded_allowed_hosts = settings.allowed_hosts
     server.transport_guard = transport_guard
     server.service_enabled = settings.service_enabled
-    register_read_tools(server, runtime)
+    control_enabled = bool(
+        settings.phase0_auth
+        and settings.phase0_auth.plugin_config
+        and settings.phase0_auth.plugin_config.loxone_control_enabled
+    )
+    register_read_tools(server, runtime, control_enabled=control_enabled)
+    if control_enabled:
+        register_control_tool(server, runtime)
 
     if oauth_web is not None:
         server.custom_route("/authorize", methods=["GET", "POST"], include_in_schema=False)(

--- a/src/mcpserver/tools.py
+++ b/src/mcpserver/tools.py
@@ -8,8 +8,10 @@ import hmac
 import json
 import logging
 import secrets
+import time
+from collections import OrderedDict
 from datetime import UTC, datetime
-from typing import Any, Final
+from typing import Any, Final, Literal
 from uuid import uuid4
 
 from mcp.server.auth.middleware.auth_context import get_access_token
@@ -17,14 +19,22 @@ from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 from pydantic import BaseModel, Field, JsonValue
 
-from mcpserver.auth.provider import StoredAccessToken
+from mcpserver.auth.provider import CONTROL_SCOPE, StoredAccessToken
 from mcpserver.loxone.models import Control, Freshness, NamedGroup
-from mcpserver.loxone.runtime import LoxoneRuntime, RuntimeSnapshot, RuntimeUnavailable
+from mcpserver.loxone.runtime import (
+    ControlOperationError,
+    LoxoneRuntime,
+    RuntimeSnapshot,
+    RuntimeUnavailable,
+)
 
 DEFAULT_PAGE_SIZE: Final = 50
 MAX_PAGE_SIZE: Final = 100
 MAX_STATE_UUIDS: Final = 100
 _LOGGER = logging.getLogger("mcpserver.tools")
+_AUDIT_SUPPRESSION_SECONDS: Final = 60.0
+_MAX_AUDIT_SUPPRESSION_KEYS: Final = 512
+_AUDIT_LAST: OrderedDict[tuple[str, str], float] = OrderedDict()
 
 
 class ErrorData(BaseModel):
@@ -117,6 +127,18 @@ class StatesEnvelope(ToolEnvelope):
     data: StatesData | ErrorData
 
 
+class ControlOperationData(BaseModel):
+    control_uuid: str
+    action: Literal["on", "off"]
+    accepted: bool
+    confirmed: bool
+    observed_state: Literal["on", "off", "unknown"]
+
+
+class ControlOperationEnvelope(ToolEnvelope):
+    data: ControlOperationData | ErrorData
+
+
 def _now() -> str:
     return datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
@@ -152,6 +174,65 @@ def _error[EnvelopeT: ToolEnvelope](
     return envelope_type(
         ok=False,
         data={"error": code, "message": message},
+        observed_at=_now(),
+        stale=False,
+        trace_id=trace_id,
+    )
+
+
+def _audit_identity(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:12]
+
+
+def _control_envelope(
+    access: StoredAccessToken | None,
+    control_uuid: str,
+    action: str,
+    *,
+    result: dict[str, Any] | None = None,
+    error: tuple[str, str] | None = None,
+    warnings: list[str] | None = None,
+) -> ControlOperationEnvelope:
+    trace_id = str(uuid4())
+    outcome = (
+        ("accepted_confirmed" if result and result.get("confirmed") else "accepted_unconfirmed")
+        if error is None
+        else error[0]
+    )
+    should_log = True
+    if error is not None:
+        identity = access.identity_id if access is not None else "unauthenticated"
+        key = (_audit_identity(identity), outcome)
+        now = time.monotonic()
+        previous = _AUDIT_LAST.get(key)
+        if previous is not None and previous > now - _AUDIT_SUPPRESSION_SECONDS:
+            should_log = False
+        else:
+            _AUDIT_LAST[key] = now
+            _AUDIT_LAST.move_to_end(key)
+            while len(_AUDIT_LAST) > _MAX_AUDIT_SUPPRESSION_KEYS:
+                _AUDIT_LAST.popitem(last=False)
+    if should_log:
+        log = _LOGGER.info if error is None else _LOGGER.warning
+        log(
+            "component=control_audit trace_id=%s client=%s identity=%s "
+            "target=%s action=%s outcome=%s",
+            trace_id,
+            _audit_identity(str(access.client_id)) if access is not None else "unknown",
+            _audit_identity(access.identity_id) if access is not None else "unknown",
+            json.dumps(control_uuid[:128]),
+            action if action in {"on", "off"} else "invalid",
+            outcome,
+        )
+    data = (
+        ControlOperationData.model_validate(result)
+        if error is None
+        else ErrorData(error=error[0], message=error[1])
+    )
+    return ControlOperationEnvelope(
+        ok=error is None,
+        data=data,
+        warnings=warnings or [],
         observed_at=_now(),
         stale=False,
         trace_id=trace_id,
@@ -249,7 +330,9 @@ async def _snapshot(runtime: LoxoneRuntime | None) -> tuple[StoredAccessToken, R
         return access, await runtime.snapshot(access)
 
 
-def register_read_tools(server: FastMCP, runtime: LoxoneRuntime | None) -> None:
+def register_read_tools(
+    server: FastMCP, runtime: LoxoneRuntime | None, *, control_enabled: bool = False
+) -> None:
     """Publish exactly the six stable Phase 1 read-only tools."""
     annotations = ToolAnnotations(readOnlyHint=True, destructiveHint=False, openWorldHint=False)
     cursors = _CursorCodec()
@@ -391,7 +474,7 @@ def register_read_tools(server: FastMCP, runtime: LoxoneRuntime | None) -> None:
     )
     async def describe_control(control_uuid: str) -> ControlDescriptionEnvelope:
         try:
-            _access_token, snapshot = await _snapshot(runtime)
+            access_token, snapshot = await _snapshot(runtime)
             control = next(
                 (
                     item
@@ -404,7 +487,17 @@ def register_read_tools(server: FastMCP, runtime: LoxoneRuntime | None) -> None:
                 return _error(ControlDescriptionEnvelope, "not_found", "control is not visible")
             value = _control_summary(control, snapshot)
             value["states"] = [{"name": name, "uuid": uuid} for name, uuid in control.state_uuids]
-            value["capabilities"] = {"readable": True, "allowed_actions": []}
+            value["capabilities"] = {
+                "readable": True,
+                "allowed_actions": (
+                    ["on", "off"]
+                    if control_enabled
+                    and CONTROL_SCOPE in access_token.scopes
+                    and control.control_type == "Switch"
+                    and control.action_uuid is not None
+                    else []
+                ),
+            }
             return _result(ControlDescriptionEnvelope, value)
         except PermissionError:
             return _error(
@@ -467,3 +560,61 @@ def register_read_tools(server: FastMCP, runtime: LoxoneRuntime | None) -> None:
             )
         except RuntimeUnavailable as exc:
             return _error(StatesEnvelope, "temporarily_unavailable", str(exc))
+
+
+def register_control_tool(server: FastMCP, runtime: LoxoneRuntime | None) -> None:
+    """Publish the single explicitly enabled Phase 2 Switch operation."""
+    annotations = ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=True,
+        idempotentHint=True,
+        openWorldHint=False,
+    )
+
+    @server.tool(
+        name="loxone_operate_control",
+        description=(
+            "Switch one visible and operable Loxone Switch control explicitly on or off. "
+            "Requires loxone:control. Never retries an uncertain command."
+        ),
+        annotations=annotations,
+        structured_output=True,
+    )
+    async def operate_control(
+        control_uuid: str, action: Literal["on", "off"]
+    ) -> ControlOperationEnvelope:
+        access: StoredAccessToken | None = None
+        try:
+            access = _access()
+            if runtime is None:
+                raise ControlOperationError(
+                    "temporarily_unavailable", "the service is not configured"
+                )
+            operation = await runtime.operate_switch(access, control_uuid, action)
+            warnings = (
+                []
+                if operation.confirmed
+                else ["The command was accepted but the resulting state was not confirmed."]
+            )
+            return _control_envelope(
+                access,
+                control_uuid,
+                action,
+                result={
+                    "control_uuid": operation.control_uuid,
+                    "action": operation.action,
+                    "accepted": operation.accepted,
+                    "confirmed": operation.confirmed,
+                    "observed_state": operation.observed_state,
+                },
+                warnings=warnings,
+            )
+        except PermissionError:
+            return _control_envelope(
+                access,
+                control_uuid,
+                action,
+                error=("unauthenticated", "Authentication is required"),
+            )
+        except ControlOperationError as exc:
+            return _control_envelope(access, control_uuid, action, error=(exc.code, str(exc)))

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,6 +10,7 @@
   .mcp-status { padding: .65rem; border-left: .3rem solid #6b7280; background: #f3f4f6; }
   .mcp-status[data-kind="success"] { border-color: #198754; }
   .mcp-status[data-kind="error"] { border-color: #b91c1c; }
+  .mcp-warning { padding: .65rem; border-left: .3rem solid #b45309; background: #fff7ed; }
   .mcp-table-wrap { max-width: 100%; overflow-x: auto; }
   .mcp-table { width: 100%; border-collapse: collapse; }
   .mcp-table th, .mcp-table td { padding: .5rem; text-align: left; border-bottom: 1px solid #ddd; }
@@ -42,9 +43,12 @@
       <div class="mcp-grid">
         <label class="mcp-field"><span><TMPL_VAR SETUP.TIMEOUT></span><input name="connection_timeout" type="number" min="1" max="60" value="<TMPL_VAR CONNECTION_TIMEOUT ESCAPE=HTML>"></label>
         <label class="mcp-field"><span><TMPL_VAR SETUP.RATE></span><input name="requests_per_minute" type="number" min="1" max="600" value="<TMPL_VAR REQUESTS_PER_MINUTE ESCAPE=HTML>"></label>
+        <label class="mcp-field"><span><TMPL_VAR SETUP.CONTROL_RATE></span><input name="control_requests_per_minute" type="number" min="1" max="60" value="<TMPL_VAR CONTROL_REQUESTS_PER_MINUTE ESCAPE=HTML>"></label>
         <label class="mcp-field"><span><TMPL_VAR SETUP.PARALLEL></span><input name="max_parallel_calls" type="number" min="1" max="32" value="<TMPL_VAR MAX_PARALLEL_CALLS ESCAPE=HTML>"></label>
       </div>
       <label><input name="enabled" type="checkbox" value="1" <TMPL_IF ENABLED>checked</TMPL_IF>> <TMPL_VAR SETUP.ENABLED></label>
+      <label><input name="loxone_control_enabled" type="checkbox" value="1" <TMPL_IF LOXONE_CONTROL_ENABLED>checked</TMPL_IF>> <TMPL_VAR SETUP.CONTROL_ENABLED></label>
+      <p class="mcp-warning"><TMPL_VAR SETUP.CONTROL_WARNING></p>
       <div class="mcp-actions">
         <button class="lb-button" type="submit"><TMPL_VAR ACTION.SAVE></button>
       </div>
@@ -66,7 +70,7 @@
 
     <section id="help" class="mcp-card" aria-labelledby="help-title">
       <h2 id="help-title"><TMPL_VAR HELP.TITLE></h2>
-      <p><TMPL_VAR HELP.READ_ONLY></p>
+      <p><TMPL_VAR HELP.TOOL_ACCESS></p>
       <p><code>/plugins/mcpserver/mcp</code></p>
       <p><a href="https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server" target="_blank" rel="noopener"><TMPL_VAR HELP.PROJECT></a></p>
     </section>
@@ -75,8 +79,8 @@
   <section id="sessions" class="mcp-card" aria-labelledby="sessions-title">
     <h2 id="sessions-title"><TMPL_VAR SESSIONS.TITLE></h2>
     <TMPL_IF HAS_SESSIONS>
-      <div class="mcp-table-wrap"><table class="mcp-table"><thead><tr><th><TMPL_VAR SESSIONS.CLIENT></th><th><TMPL_VAR SESSIONS.IDENTITY></th><th><TMPL_VAR SESSIONS.EXPIRES></th><th><TMPL_VAR SESSIONS.ACTION></th></tr></thead><tbody>
-      <TMPL_LOOP SESSIONS><tr><td><code><TMPL_VAR client ESCAPE=HTML></code></td><td><code><TMPL_VAR identity ESCAPE=HTML></code></td><td><TMPL_VAR expires_at ESCAPE=HTML></td><td><form method="post" action="index.cgi" data-ajax="revoke_session"><input type="hidden" name="action" value="revoke_session"><input type="hidden" name="id" value="<TMPL_VAR id ESCAPE=HTML>"><button class="lb-button" type="submit"><TMPL_VAR ACTION.REVOKE></button></form></td></tr></TMPL_LOOP>
+      <div class="mcp-table-wrap"><table class="mcp-table"><thead><tr><th><TMPL_VAR SESSIONS.CLIENT></th><th><TMPL_VAR SESSIONS.IDENTITY></th><th><TMPL_VAR SESSIONS.SCOPES></th><th><TMPL_VAR SESSIONS.EXPIRES></th><th><TMPL_VAR SESSIONS.ACTION></th></tr></thead><tbody>
+      <TMPL_LOOP SESSIONS><tr><td><code><TMPL_VAR client ESCAPE=HTML></code></td><td><code><TMPL_VAR identity ESCAPE=HTML></code></td><td><code><TMPL_VAR scopes ESCAPE=HTML></code></td><td><TMPL_VAR expires_at ESCAPE=HTML></td><td><form method="post" action="index.cgi" data-ajax="revoke_session"><input type="hidden" name="action" value="revoke_session"><input type="hidden" name="id" value="<TMPL_VAR id ESCAPE=HTML>"><button class="lb-button" type="submit"><TMPL_VAR ACTION.REVOKE></button></form></td></tr></TMPL_LOOP>
       </tbody></table></div>
       <form method="post" action="index.cgi" data-ajax="revoke_all"><input type="hidden" name="action" value="revoke_all"><button class="lb-button" type="submit"><TMPL_VAR ACTION.REVOKE_ALL></button></form>
     <TMPL_ELSE><p><TMPL_VAR SESSIONS.EMPTY></p></TMPL_IF>

--- a/templates/lang/language_de.ini
+++ b/templates/lang/language_de.ini
@@ -14,8 +14,11 @@ PUBLIC_ORIGIN=Öffentliche lokale HTTPS-Origin
 ENDPOINT=Miniserver-Endpunkt
 TIMEOUT=Verbindungs-Timeout (Sekunden)
 RATE=Aufrufe pro Minute
+CONTROL_RATE=Schreibaktionen pro Minute
 PARALLEL=Parallele Aufrufe
 ENABLED=Dienst aktivieren
+CONTROL_ENABLED=Loxone-Steuerung mit separater Berechtigung aktivieren
+CONTROL_WARNING=Schreibzugriff ist standardmäßig aus. Aktivierte Clients dürfen sichtbare Switch-Steuerungen mit ihren Loxone-Benutzerrechten ein- und ausschalten.
 
 [STATUS]
 TITLE=Status
@@ -28,6 +31,7 @@ STOPPED=gestoppt
 TITLE=Clients und Sitzungen
 CLIENT=Client
 IDENTITY=Identität
+SCOPES=Berechtigungen
 EXPIRES=Läuft ab
 ACTION=Aktion
 EMPTY=Keine Sitzungen vorhanden.
@@ -38,7 +42,7 @@ TEXT=Logs werden maskiert über den integrierten LoxBerry-Logviewer angezeigt.
 
 [HELP]
 TITLE=Hilfe
-READ_ONLY=Diese Alpha veröffentlicht ausschließlich sechs lesende Loxone-Werkzeuge mit Scope loxone:read.
+TOOL_ACCESS=Sechs lesende Werkzeuge verwenden loxone:read. Das optionale Switch-Werkzeug benötigt zusätzlich loxone:control.
 PROJECT=Projekt und Anleitungen öffnen
 
 [ACTION]

--- a/templates/lang/language_en.ini
+++ b/templates/lang/language_en.ini
@@ -14,8 +14,11 @@ PUBLIC_ORIGIN=Public local HTTPS origin
 ENDPOINT=Miniserver endpoint
 TIMEOUT=Connection timeout (seconds)
 RATE=Calls per minute
+CONTROL_RATE=Control actions per minute
 PARALLEL=Parallel calls
 ENABLED=Enable service
+CONTROL_ENABLED=Enable Loxone control with separate authorization
+CONTROL_WARNING=Write access is disabled by default. Authorized clients may switch visible Switch controls on and off with their Loxone user permissions.
 
 [STATUS]
 TITLE=Status
@@ -28,6 +31,7 @@ STOPPED=stopped
 TITLE=Clients and sessions
 CLIENT=Client
 IDENTITY=Identity
+SCOPES=Scopes
 EXPIRES=Expires
 ACTION=Action
 EMPTY=No sessions exist.
@@ -38,7 +42,7 @@ TEXT=Masked logs are shown through the integrated LoxBerry log viewer.
 
 [HELP]
 TITLE=Help
-READ_ONLY=This alpha publishes exactly six read-only Loxone tools with the loxone:read scope.
+TOOL_ACCESS=Six read-only tools use loxone:read. The optional Switch tool additionally requires loxone:control.
 PROJECT=Open project and guides
 
 [ACTION]

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -79,6 +79,52 @@ def test_failed_config_apply_restores_previous_configuration(
     assert store.load().to_document() == previous.to_document()
 
 
+def test_disabling_control_revokes_control_sessions_after_successful_restart(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = AtomicConfigStore((tmp_path / "config" / "mcpserver.json").resolve())
+    previous_document = PluginConfig.defaults().to_document()
+    previous_document["tools"]["loxone_control_enabled"] = True
+    previous_document["loxone"]["endpoint"] = "http://192.168.10.20"
+    previous = PluginConfig.from_document(previous_document)
+    store.save(previous)
+    next_document = previous.to_document()
+    next_document["tools"]["loxone_control_enabled"] = False
+    next_document["loxone"]["endpoint"] = "http://192.168.10.30"
+    events: list[str] = []
+    revocations: list[tuple[str, str | None, float | None]] = []
+
+    class AuthStore:
+        def snapshot(self) -> dict[str, object]:
+            return {
+                "families": {
+                    "control-family": {
+                        "scope": "loxone:read loxone:control",
+                        "revoked": False,
+                    },
+                    "read-family": {"scope": "loxone:read", "revoked": False},
+                }
+            }
+
+    monkeypatch.setattr("mcpserver.admin._config_store", lambda: store)
+    monkeypatch.setattr("mcpserver.admin._auth_store", lambda: AuthStore())
+    monkeypatch.setattr("mcpserver.admin._restart_service", lambda: events.append("restart"))
+
+    def revoke(
+        family_id: str, *, endpoint: str | None = None, timeout_seconds: float | None = None
+    ) -> int:
+        events.append(f"revoke:{family_id}")
+        revocations.append((family_id, endpoint, timeout_seconds))
+        return 1
+
+    monkeypatch.setattr("mcpserver.admin._revoke", revoke)
+
+    _save(next_document)
+
+    assert events == ["restart", "revoke:control-family"]
+    assert revocations == [("control-family", "http://192.168.10.20", previous.connection_timeout)]
+
+
 def test_session_list_excludes_revoked_families(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,8 +14,10 @@ def test_defaults_are_disabled_and_bounded() -> None:
     assert config.enabled is False
     assert config.loxone_endpoint == ""
     assert config.loxone_read_enabled is True
+    assert config.loxone_control_enabled is False
     assert config.connection_timeout == 10
     assert config.requests_per_minute == 60
+    assert config.control_requests_per_minute == 10
     assert config.max_parallel_calls == 4
 
 
@@ -59,6 +61,17 @@ def test_configuration_round_trip_preserves_unknown_keys(tmp_path: Path) -> None
 def test_invalid_configuration_is_rejected(document: object) -> None:
     with pytest.raises(ConfigError):
         PluginConfig.from_document(document)
+
+
+def test_gen2_control_configuration_is_rejected() -> None:
+    with pytest.raises(ConfigError, match="only for Gen. 1"):
+        PluginConfig.from_document(
+            {
+                "schema_version": 1,
+                "loxone": {"endpoint": "https://miniserver.example"},
+                "tools": {"loxone_control_enabled": True},
+            }
+        )
 
 
 def test_failed_save_keeps_previous_valid_configuration(

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import pytest
+
+from mcpserver.auth.provider import CONTROL_SCOPE, READ_SCOPE, StoredAccessToken
+from mcpserver.loxone.client import LoxoneToken, MiniserverEndpoint
+from mcpserver.loxone.events import StateEvent
+from mcpserver.loxone.models import Control, LoxoneIdentity, LoxoneStructure
+from mcpserver.loxone.runtime import (
+    ControlOperationError,
+    LoxoneRuntime,
+    RuntimeSnapshot,
+)
+
+
+def _access(*scopes: str) -> StoredAccessToken:
+    return StoredAccessToken(
+        token="opaque",
+        client_id="client",
+        scopes=list(scopes),
+        expires_at=2_000_000_000,
+        resource="https://loxberry.local/plugins/mcpserver/mcp",
+        subject="identity",
+        claims={},
+        family_id="family",
+        identity_id="identity",
+        miniserver_id="miniserver",
+    )
+
+
+def _structure(control_type: str = "Switch") -> LoxoneStructure:
+    return LoxoneStructure(
+        identity=LoxoneIdentity("user", "serial"),
+        last_modified="1",
+        rooms=(),
+        categories=(),
+        controls=(
+            Control(
+                uuid="control-1",
+                name="Light",
+                control_type=control_type,
+                room_uuid=None,
+                category_uuid=None,
+                action_uuid="action-1",
+                state_uuids=(("active", "state-1"),),
+            ),
+        ),
+    )
+
+
+class _TokenStore:
+    def get(self, *_args: object) -> LoxoneToken:
+        return LoxoneToken("jwt", "user", "key", "SHA256", 2_000_000_000)
+
+
+@pytest.mark.asyncio
+async def test_switch_operation_is_sent_and_confirmed(monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime = LoxoneRuntime(
+        MiniserverEndpoint.parse_gen1("http://192.168.1.10"),
+        _TokenStore(),  # type: ignore[arg-type]
+        control_confirmation_seconds=0.2,
+    )
+    runtime.cache.begin_connection("family")
+
+    async def snapshot(_access: StoredAccessToken) -> RuntimeSnapshot:
+        return RuntimeSnapshot("family", _structure(), True)
+
+    class Session:
+        async def load_structure(self) -> LoxoneStructure:
+            return _structure()
+
+        async def operate_switch(self, action_uuid: str, action: str) -> None:
+            assert (action_uuid, action) == ("action-1", "on")
+            runtime.cache.apply("family", [StateEvent("state-1", 1.0)], allowed_uuids={"state-1"})
+
+        async def close(self) -> None:
+            return None
+
+    class Client:
+        async def open_session(self, _token: LoxoneToken) -> Session:
+            return Session()
+
+    monkeypatch.setattr(runtime, "snapshot", snapshot)
+    runtime.client = Client()  # type: ignore[assignment]
+
+    result = await runtime.operate_switch(_access(READ_SCOPE, CONTROL_SCOPE), "control-1", "on")
+
+    assert result.accepted is True
+    assert result.confirmed is True
+    assert result.observed_state == "on"
+
+
+@pytest.mark.asyncio
+async def test_control_requires_scope_and_supported_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = LoxoneRuntime(
+        MiniserverEndpoint.parse_gen1("http://192.168.1.10"),
+        _TokenStore(),  # type: ignore[arg-type]
+    )
+
+    with pytest.raises(ControlOperationError, match="loxone:control"):
+        await runtime.operate_switch(_access(READ_SCOPE), "control-1", "on")
+
+    async def snapshot(_access: StoredAccessToken) -> RuntimeSnapshot:
+        return RuntimeSnapshot("family", _structure(), True)
+
+    class Session:
+        async def load_structure(self) -> LoxoneStructure:
+            return _structure("Dimmer")
+
+        async def close(self) -> None:
+            return None
+
+    class Client:
+        async def open_session(self, _token: LoxoneToken) -> Session:
+            return Session()
+
+    monkeypatch.setattr(runtime, "snapshot", snapshot)
+    runtime.client = Client()  # type: ignore[assignment]
+    with pytest.raises(ControlOperationError) as captured:
+        await runtime.operate_switch(_access(READ_SCOPE, CONTROL_SCOPE), "control-1", "on")
+    assert captured.value.code == "unsupported_control"
+
+
+@pytest.mark.asyncio
+async def test_transport_failure_after_dispatch_has_unknown_outcome(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = LoxoneRuntime(
+        MiniserverEndpoint.parse_gen1("http://192.168.1.10"),
+        _TokenStore(),  # type: ignore[arg-type]
+    )
+
+    async def snapshot(_access: StoredAccessToken) -> RuntimeSnapshot:
+        return RuntimeSnapshot("family", _structure(), True)
+
+    class Session:
+        async def load_structure(self) -> LoxoneStructure:
+            return _structure()
+
+        async def operate_switch(self, _action_uuid: str, _action: str) -> None:
+            raise TimeoutError
+
+        async def close(self) -> None:
+            return None
+
+    class Client:
+        async def open_session(self, _token: LoxoneToken) -> Session:
+            return Session()
+
+    monkeypatch.setattr(runtime, "snapshot", snapshot)
+    runtime.client = Client()  # type: ignore[assignment]
+
+    with pytest.raises(ControlOperationError) as captured:
+        await runtime.operate_switch(_access(READ_SCOPE, CONTROL_SCOPE), "control-1", "off")
+    assert captured.value.code == "outcome_unknown"

--- a/tests/test_loxone_client.py
+++ b/tests/test_loxone_client.py
@@ -50,6 +50,30 @@ async def test_websocket_close_is_bounded() -> None:
 
 
 @pytest.mark.asyncio
+async def test_switch_operation_uses_encrypted_explicit_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = LoxoneWebSocketSession(
+        cast(Any, object()),
+        public_key="",
+        token=LoxoneToken("jwt", "user", "key", "SHA256", 1),
+        timeout_seconds=1,
+        max_payload_bytes=1024,
+    )
+    commands: list[tuple[str, bool]] = []
+
+    async def command(value: str, *, encrypted: bool = False) -> object:
+        commands.append((value, encrypted))
+        return None
+
+    monkeypatch.setattr(session, "_command", command)
+
+    await session.operate_switch("action-1", "off")
+
+    assert commands == [("jdev/sps/io/action-1/off", True)]
+
+
+@pytest.mark.asyncio
 async def test_websocket_receive_returns_complete_payload_without_waiting_again() -> None:
     class FakeWebSocket:
         def __init__(self) -> None:

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -16,7 +16,13 @@ from starlette.requests import Request
 from starlette.routing import Route
 from starlette.testclient import TestClient
 
-from mcpserver.auth.provider import SCOPE, Phase0OAuthProvider
+from mcpserver.auth.provider import (
+    CONTROL_SCOPE,
+    READ_SCOPE,
+    SCOPE,
+    Phase0OAuthProvider,
+    normalize_scopes,
+)
 from mcpserver.auth.store import AtomicJsonAuthStore
 from mcpserver.auth.web import LoginTransaction, Phase0OAuthWeb, _limited_body
 from mcpserver.loxone.client import (
@@ -29,6 +35,52 @@ from mcpserver.loxone.events import LoxoneProtocolError
 
 ISSUER = "https://public.example/plugins/mcpserver/oauth"
 RESOURCE = "https://public.example/plugins/mcpserver/mcp"
+
+
+def test_control_scope_is_additive_and_never_granted_alone() -> None:
+    assert normalize_scopes(None, control_enabled=False) == (READ_SCOPE,)
+    assert normalize_scopes(f"{CONTROL_SCOPE} {READ_SCOPE}", control_enabled=True) == (
+        READ_SCOPE,
+        CONTROL_SCOPE,
+    )
+    with pytest.raises(ValueError):
+        normalize_scopes(CONTROL_SCOPE, control_enabled=True)
+    with pytest.raises(ValueError):
+        normalize_scopes(f"{READ_SCOPE} {CONTROL_SCOPE}", control_enabled=False)
+
+
+def test_disabled_control_scope_is_locally_revoked_without_deleting_remote_token(
+    tmp_path: Path,
+) -> None:
+    deleted: list[str] = []
+    store = AtomicJsonAuthStore(tmp_path / "auth" / "sessions.json")
+    provider = Phase0OAuthProvider(
+        store,
+        issuer=ISSUER,
+        resource=RESOURCE,
+        on_family_revoked=deleted.append,
+    )
+
+    def add_control_family(document: dict[str, object]) -> None:
+        families = document["families"]
+        access_tokens = document["access_tokens"]
+        assert isinstance(families, dict)
+        assert isinstance(access_tokens, dict)
+        families["family"] = {
+            "scope": f"{READ_SCOPE} {CONTROL_SCOPE}",
+            "revoked": False,
+        }
+        access_tokens["access"] = {"family_id": "family", "status": "active"}
+
+    store.mutate(add_control_family)
+
+    assert provider.revoke_scope_locally(CONTROL_SCOPE) == 1
+    snapshot = store.snapshot()
+    assert snapshot["families"]["family"]["revoked"] is True
+    assert snapshot["access_tokens"]["access"]["status"] == "revoked"
+    assert deleted == []
+
+
 REDIRECT = "http://127.0.0.1:48765/callback"
 VERIFIER = "v" * 43
 CHALLENGE = (
@@ -64,6 +116,48 @@ async def _client(provider: Phase0OAuthProvider) -> OAuthClientInformationFull:
     )
     await provider.register_client(client)
     return client
+
+
+@pytest.mark.asyncio
+async def test_control_scope_survives_code_exchange_and_refresh(tmp_path: Path) -> None:
+    provider = Phase0OAuthProvider(
+        AtomicJsonAuthStore(tmp_path / "auth" / "sessions.json"),
+        issuer=ISSUER,
+        resource=RESOURCE,
+        clock=Clock(),
+        control_enabled=True,
+    )
+    scopes = (READ_SCOPE, CONTROL_SCOPE)
+    client = OAuthClientInformationFull(
+        client_id="control-client",
+        redirect_uris=[AnyUrl(REDIRECT)],
+        token_endpoint_auth_method="none",
+        grant_types=["authorization_code", "refresh_token"],
+        response_types=["code"],
+        scope=" ".join(scopes),
+    )
+    await provider.register_client(client)
+    raw_code = provider.issue_authorization_code(
+        client_id="control-client",
+        redirect_uri=REDIRECT,
+        code_challenge=CHALLENGE,
+        resource=RESOURCE,
+        identity_id="identity",
+        miniserver_id="miniserver",
+        scopes=scopes,
+    )
+    code = await provider.load_authorization_code(client, raw_code)
+    assert code is not None
+
+    first = await provider.exchange_authorization_code(client, code)
+    access = await provider.load_access_token(first.access_token)
+    refresh = await provider.load_refresh_token(client, first.refresh_token or "")
+    assert access is not None and access.scopes == list(scopes)
+    assert refresh is not None
+
+    rotated = await provider.exchange_refresh_token(client, refresh, list(scopes))
+
+    assert rotated.scope == " ".join(scopes)
 
 
 def _client_info(client_id: str, *, grants: list[str] | None = None) -> OAuthClientInformationFull:

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import configparser
 import hashlib
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -112,6 +113,15 @@ def test_postinstall_rewrites_moved_venv_entrypoints() -> None:
     assert 'sed -i "1c\\\\#!$venv/bin/python"' in hook
     assert 'rm -rf -- "$venv"' in hook
     assert 'mv "$old_venv" "$venv"' in hook
+
+
+def test_postinstall_project_pin_matches_plugin_version() -> None:
+    parser = configparser.ConfigParser()
+    parser.read(ROOT / "plugin.cfg", encoding="utf-8")
+    project_version = re.sub(r"(?i)-alpha\.(\d+)$", r"a\1", parser["PLUGIN"]["VERSION"])
+    hook = (ROOT / "postinstall.sh").read_text(encoding="utf-8")
+
+    assert f"loxberry-mcpserver=={project_version}" in hook
 
 
 def test_package_builder_includes_plugin_icon() -> None:

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -25,7 +25,7 @@ def test_plugin_identity_and_platform_contract() -> None:
     assert parser["PLUGIN"]["NAME"] == "mcpserver"
     assert parser["PLUGIN"]["FOLDER"] == "mcpserver"
     assert parser["PLUGIN"]["TITLE"] == "LoxBerry MCP Server"
-    assert parser["PLUGIN"]["VERSION"] == "0.1.0-alpha.1"
+    assert parser["PLUGIN"]["VERSION"] == "0.2.0-alpha.1"
     assert parser["SYSTEM"]["LB_MINIMUM"] == "4.0.0"
     assert parser["SYSTEM"]["INTERFACE"] == "2.0"
     for name in ("release.cfg", "prerelease.cfg"):
@@ -214,7 +214,7 @@ def test_plugin_archive_verifier_accepts_builder_output(tmp_path: Path) -> None:
     for name, version in _locked_requirements(ROOT / "requirements" / "runtime-arm64.lock").items():
         wheel_name = name.replace("-", "_")
         (wheelhouse / f"{wheel_name}-{version}-py3-none-any.whl").write_bytes(b"wheel")
-    (wheelhouse / "loxberry_mcpserver-0.1.0a1-py3-none-any.whl").write_bytes(b"project")
+    (wheelhouse / "loxberry_mcpserver-0.2.0a1-py3-none-any.whl").write_bytes(b"project")
     output = tmp_path / "plugin.zip"
 
     subprocess.run(

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
 import pytest
+from mcp.server.fastmcp import FastMCP
 
-from mcpserver.tools import _CursorCodec, _page
+import mcpserver.tools as tools_module
+from mcpserver.auth.provider import CONTROL_SCOPE, READ_SCOPE, StoredAccessToken
+from mcpserver.loxone.models import Control, LoxoneIdentity, LoxoneStructure
+from mcpserver.loxone.runtime import RuntimeSnapshot
+from mcpserver.tools import _CursorCodec, _page, register_control_tool, register_read_tools
 
 
 def test_opaque_cursor_paginates_without_exposing_offset() -> None:
@@ -30,3 +35,73 @@ def test_cursor_cannot_cross_scope_or_be_modified() -> None:
 def test_page_limit_is_bounded(limit: int) -> None:
     with pytest.raises(ValueError, match="between 1 and 100"):
         _page(_CursorCodec(), "rooms", [], None, limit)
+
+
+def test_control_tool_contract_is_explicitly_mutating_and_idempotent() -> None:
+    server = FastMCP("control-contract")
+    register_control_tool(server, None)
+
+    tool = server._tool_manager.list_tools()[0]
+
+    assert tool.name == "loxone_operate_control"
+    assert tool.annotations is not None
+    assert tool.annotations.readOnlyHint is False
+    assert tool.annotations.destructiveHint is True
+    assert tool.annotations.idempotentHint is True
+    assert set(tool.parameters["properties"]["action"]["enum"]) == {"on", "off"}
+
+
+@pytest.mark.asyncio
+async def test_describe_control_only_advertises_actions_to_control_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server = FastMCP("capability-contract")
+    register_read_tools(server, None, control_enabled=True)
+    scopes = [READ_SCOPE]
+    access = StoredAccessToken(
+        token="opaque",
+        client_id="client",
+        scopes=scopes,
+        expires_at=2_000_000_000,
+        resource="https://loxberry.local/plugins/mcpserver/mcp",
+        subject="identity",
+        claims={},
+        family_id="family",
+        identity_id="identity",
+        miniserver_id="miniserver",
+    )
+    structure = LoxoneStructure(
+        identity=LoxoneIdentity("user", "serial"),
+        last_modified="1",
+        rooms=(),
+        categories=(),
+        controls=(
+            Control(
+                uuid="control-1",
+                name="Light",
+                control_type="Switch",
+                room_uuid=None,
+                category_uuid=None,
+                action_uuid="action-1",
+                state_uuids=(("active", "state-1"),),
+            ),
+        ),
+    )
+
+    async def snapshot(_runtime: object) -> tuple[StoredAccessToken, RuntimeSnapshot]:
+        return access, RuntimeSnapshot("family", structure, True)
+
+    monkeypatch.setattr(tools_module, "_snapshot", snapshot)
+    tool = next(
+        item for item in server._tool_manager.list_tools() if item.name == "loxone_describe_control"
+    )
+
+    read_only = await tool.fn("control-1")
+    assert read_only.data.capabilities.allowed_actions == []  # type: ignore[union-attr]
+
+    access.scopes.append(CONTROL_SCOPE)
+    controlled = await tool.fn("control-1")
+    assert controlled.data.capabilities.allowed_actions == [  # type: ignore[union-attr]
+        "on",
+        "off",
+    ]

--- a/tools/build_plugin.py
+++ b/tools/build_plugin.py
@@ -129,8 +129,8 @@ def main() -> int:
         for name, version in requirements.items()
         if (name, version.lower()) not in wheel_versions
     }
-    project_wheels = tuple(wheelhouse.glob("loxberry_mcpserver-0.1.0a1-*.whl"))
-    expected_project = [("loxberry-mcpserver", "0.1.0a1")]
+    project_wheels = tuple(wheelhouse.glob("loxberry_mcpserver-0.2.0a1-*.whl"))
+    expected_project = [("loxberry-mcpserver", "0.2.0a1")]
     unexpected = set(runtime_wheels) - expected_runtime
     duplicates = len(runtime_wheels) != len(set(runtime_wheels))
     invalid_wheel = len(wheel_files) != len(wheel_identities)

--- a/tools/build_release_candidate.py
+++ b/tools/build_release_candidate.py
@@ -1,4 +1,4 @@
-"""Build and verify a reproducible Phase 1 LoxBerry release candidate."""
+"""Build and verify a reproducible LoxBerry MCP Server release candidate."""
 
 from __future__ import annotations
 

--- a/tools/test_mcp_client.ps1
+++ b/tools/test_mcp_client.ps1
@@ -2,6 +2,7 @@ param(
     [string]$ClaudeConfigPath = (Join-Path $env:APPDATA 'Claude\claude_desktop_config.json'),
     [string]$ServerName = 'loxberry-mcp',
     [string]$VisibilityFixturePath,
+    [string]$ControlFixturePath,
     [int]$TimeoutSeconds = 120
 )
 
@@ -92,12 +93,12 @@ function Invoke-ToolEnvelope([int]$Id, [string]$Name, [hashtable]$Arguments) {
         params = @{ name = $Name; arguments = $Arguments }
     }
     $response = Read-JsonRpc $Id
-    if ($response.error -or $response.result.isError) { throw "Read-only tool $Name failed." }
+    if ($response.error -or $response.result.isError) { throw "MCP tool $Name failed." }
     $envelope = $response.result.structuredContent
     if (-not $envelope -and $response.result.content[0].text) {
         $envelope = $response.result.content[0].text | ConvertFrom-Json
     }
-    if (-not $envelope) { throw "Read-only tool $Name returned no envelope." }
+    if (-not $envelope) { throw "MCP tool $Name returned no envelope." }
     return $envelope
 }
 
@@ -125,12 +126,19 @@ try {
         'loxone_get_system_status', 'loxone_list_rooms', 'loxone_list_categories',
         'loxone_find_controls', 'loxone_describe_control', 'loxone_get_states'
     )
+    if ($ControlFixturePath) { $expected += 'loxone_operate_control' }
     $actual = @($toolsResponse.result.tools | ForEach-Object { $_.name } | Sort-Object)
     if (($actual -join "`n") -ne (($expected | Sort-Object) -join "`n")) {
-        throw 'MCP tool inventory differs from the six-tool read-only contract.'
+        throw 'MCP tool inventory differs from the expected enabled contract.'
     }
     foreach ($tool in $toolsResponse.result.tools) {
-        if ($tool.annotations.readOnlyHint -ne $true -or $tool.annotations.destructiveHint -ne $false) {
+        if ($tool.name -eq 'loxone_operate_control') {
+            if ($tool.annotations.readOnlyHint -ne $false -or
+                $tool.annotations.destructiveHint -ne $true -or
+                $tool.annotations.idempotentHint -ne $true) {
+                throw 'MCP control tool annotations violate the control contract.'
+            }
+        } elseif ($tool.annotations.readOnlyHint -ne $true -or $tool.annotations.destructiveHint -ne $false) {
             throw 'MCP tool annotations violate the read-only contract.'
         }
         if (-not $tool.outputSchema.properties.data.anyOf) {
@@ -201,11 +209,45 @@ try {
     if (-not $stateUuid) { throw 'The selected visible control has no readable state.' }
     [void](Invoke-ReadTool (Get-NextId) 'loxone_get_states' @{ state_uuids = @($stateUuid) })
 
+    if ($ControlFixturePath) {
+        $controlFixture = Get-Content -LiteralPath $ControlFixturePath -Raw | ConvertFrom-Json
+        $controlUuid = [string]$controlFixture.control_uuid
+        $initialState = [string]$controlFixture.initial_state
+        if (-not $controlUuid -or $initialState -notin @('on', 'off')) {
+            throw 'Control fixture must contain control_uuid and initial_state on/off.'
+        }
+        $testState = if ($initialState -eq 'on') { 'off' } else { 'on' }
+        $changed = $false
+        try {
+            $operation = Invoke-ToolEnvelope (Get-NextId) 'loxone_operate_control' @{
+                control_uuid = $controlUuid; action = $testState
+            }
+            if (-not $operation.ok -or -not $operation.data.accepted -or
+                -not $operation.data.confirmed -or $operation.data.observed_state -ne $testState) {
+                throw 'The test Switch action was not confirmed.'
+            }
+            $changed = $true
+        } finally {
+            if ($changed) {
+                $restore = Invoke-ToolEnvelope (Get-NextId) 'loxone_operate_control' @{
+                    control_uuid = $controlUuid; action = $initialState
+                }
+                if (-not $restore.ok -or -not $restore.data.accepted -or
+                    -not $restore.data.confirmed -or $restore.data.observed_state -ne $initialState) {
+                    throw 'The test Switch initial state was not restored and confirmed.'
+                }
+            }
+        }
+        $controlUuid = $null
+        'mcp_switch_control=pass'
+    }
+
     $visibleUuid = $null
     $hiddenUuid = $null
     $stateUuid = $null
     'mcp_tool_contract=pass'
-    'mcp_six_read_tools=pass'
+    if ($ControlFixturePath) { 'mcp_six_read_tools_plus_control=pass' }
+    else { 'mcp_six_read_tools=pass' }
     if ($VisibilityFixturePath) { 'mcp_visibility_filter=pass' }
 } finally {
     try { $process.StandardInput.Close() } catch {}

--- a/webfrontend/htmlauth/index.cgi
+++ b/webfrontend/htmlauth/index.cgi
@@ -89,9 +89,13 @@ if ($action ne '') {
                 endpoint => $q->{endpoint} // '',
                 connection_timeout => 0 + ($q->{connection_timeout} // 10),
             },
-            tools => {loxone_read_enabled => JSON::PP::true},
+            tools => {
+                loxone_read_enabled => JSON::PP::true,
+                loxone_control_enabled => $q->{loxone_control_enabled} ? JSON::PP::true : JSON::PP::false,
+            },
             limits => {
                 requests_per_minute => 0 + ($q->{requests_per_minute} // 60),
+                control_requests_per_minute => 0 + ($q->{control_requests_per_minute} // 10),
                 max_parallel_calls => 0 + ($q->{max_parallel_calls} // 4),
             },
         };
@@ -140,6 +144,7 @@ my $config = $config_result->{ok} ? $config_result->{data}{configuration} : {};
 my $sessions = $sessions_result->{ok} ? $sessions_result->{data}{sessions} : [];
 $config->{server} = {} if ref($config->{server}) ne 'HASH';
 $config->{loxone} = {} if ref($config->{loxone}) ne 'HASH';
+$config->{tools} = {} if ref($config->{tools}) ne 'HASH';
 $config->{limits} = {} if ref($config->{limits}) ne 'HASH';
 
 $template->param(
@@ -148,7 +153,9 @@ $template->param(
     PUBLIC_ORIGIN => $config->{server}{public_origin} // '',
     ENDPOINT => $config->{loxone}{endpoint} // '',
     CONNECTION_TIMEOUT => $config->{loxone}{connection_timeout} // 10,
+    LOXONE_CONTROL_ENABLED => $config->{tools}{loxone_control_enabled} ? 1 : 0,
     REQUESTS_PER_MINUTE => $config->{limits}{requests_per_minute} // 60,
+    CONTROL_REQUESTS_PER_MINUTE => $config->{limits}{control_requests_per_minute} // 10,
     MAX_PARALLEL_CALLS => $config->{limits}{max_parallel_calls} // 4,
     SERVICE_ACTIVE => ($status_result->{ok} && $status_result->{data}{service_active}) ? 1 : 0,
     SESSIONS => $sessions,


### PR DESCRIPTION
## Summary

- add the opt-in `loxone:control` OAuth scope and bilingual consent/configuration UI
- publish one bounded `loxone_operate_control` tool for explicit Switch `on`/`off` operations
- validate current Loxone visibility and permissions immediately before each write
- add per-family serialization, rate limiting, confirmation, unknown-outcome handling, and privacy-safe audit logs
- revoke control-capable sessions fail-closed when the feature is disabled
- document the Phase 2 contract and bump the prerelease version to `0.2.0-alpha.1`

## Validation

- local deterministic gate: 196 passed; Ruff formatting/lint and mypy passed
- reproducible double build, archive verification, and local/remote SHA-256 comparison passed
- native LoxBerry Plugin Manager recovery upgrade passed after fixing a stale postinstall project-version pin found by the first target attempt
- installed runtime version, active service, loopback health, Apache syntax/proxy authentication boundary, configuration defaults, ownership, and restrictive secret-file modes passed
- configured Claude proxy: six read-only MCP tools and contracts passed
- responsive admin UI: German desktop `1280x800` and English mobile `390x844` passed with no horizontal overflow or console warnings/errors
- three phase-aware review iterations completed; final review found no relevant security, correctness, or contract findings

## Deliberate limitation

- no real Miniserver control command was executed because the authorized target-test workflow explicitly excludes control commands
