### PR TITLE
Fix Claude Desktop setup detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ Bestätigte Kombinationen, Nachweise und bekannte Clientgrenzen stehen in der
 [Support-Matrix](docs/development/support-matrix.md) und im
 [Phase-1-Abnahmebericht](docs/development/phase-1-acceptance.md).
 
+## Nutzung
+
+- [Benutzeranleitung (Deutsch)](docs/user-guide.de.md)
+- [User guide (English)](docs/user-guide.en.md)
+- [Claude Desktop einrichten](docs/clients/claude-desktop.de.md)
+- [Connect Claude Desktop](docs/clients/claude-desktop.en.md)
+
 ## Entwicklung
 
 - [Implementierungsrichtlinien](docs/development/implementation-guidelines.md)

--- a/docs/clients/claude-desktop.de.md
+++ b/docs/clients/claude-desktop.de.md
@@ -1,0 +1,79 @@
+# Claude Desktop verbinden
+
+Diese Anleitung richtet Claude Desktop unter Windows für den LoxBerry MCP
+Server ein. Claude verwendet dabei eine kleine lokale Bridge. Die Verbindung
+zum LoxBerry bleibt im lokalen Netzwerk und wird nicht über einen
+Claude-Cloud-Connector hergestellt.
+
+## Vorher prüfen
+
+- Das Plugin ist eingerichtet, aktiviert und der Verbindungstest ist
+  erfolgreich.
+- Claude Desktop ist installiert.
+- Node.js mit `npx` ist installiert. Öffne bei Bedarf PowerShell und prüfe dies
+  mit `npx --version`. Wird der Befehl nicht gefunden, installiere zuerst eine
+  aktuelle LTS-Version von [Node.js](https://nodejs.org/). Beim ersten Start
+  lädt `npx` die festgelegte Bridge-Version einmalig aus dem npm-Register.
+- Halte die im Plugin eingetragene HTTPS-Adresse des LoxBerry bereit. Ergänzt
+  um `/plugins/mcpserver/mcp` ergibt sie die MCP-Adresse. Dafür ist keine
+  Veröffentlichung des LoxBerry im Internet erforderlich.
+
+Benutzernamen, Passwörter und Tokens gehören **nicht** in die Konfigurationsdatei.
+Die Anmeldung erfolgt später geschützt im Browser.
+
+## MCP-Server hinzufügen
+
+1. Öffne in Claude Desktop **Einstellungen → Entwickler** und wähle
+   **Konfiguration bearbeiten**.
+2. Ergänze den Eintrag `loxberry-mcp` in der geöffneten Datei. Ersetze nur die
+   Beispieladresse durch deine vollständige MCP-Adresse:
+
+   ```json
+   {
+     "mcpServers": {
+       "loxberry-mcp": {
+         "command": "npx",
+         "args": [
+           "-y",
+           "mcp-remote@0.1.38",
+           "https://loxberry.example/plugins/mcpserver/mcp",
+           "--transport",
+           "http-only"
+         ]
+       }
+     }
+   }
+   ```
+
+   Sind bereits andere MCP-Server eingetragen, behalte diese und füge nur den
+   neuen Block hinzu. Achte auf gültiges JSON und die notwendigen Kommas.
+3. Speichere die Datei und beende Claude Desktop vollständig. Öffne Claude
+   danach erneut.
+4. Beim ersten Verbindungsaufbau öffnet sich die Anmeldung im Browser. Melde
+   dich mit dem dafür vorgesehenen Loxone-Benutzer an und bestätige den Zugriff.
+5. Öffne in einem Claude-Chat über **+ → Connectors** die Liste der Verbindungen.
+   `loxberry-mcp` und seine Werkzeuge müssen dort verfügbar sein. Den Status und
+   die MCP-Logs findest du zusätzlich unter **Einstellungen → Entwickler**.
+
+## Wenn es nicht funktioniert
+
+- **`npx` wurde nicht gefunden:** Installiere Node.js und starte Claude danach
+  neu.
+- **Der Server erscheint nicht:** Öffne die Konfiguration erneut über Claude.
+  Prüfe Schreibweise, Kommas und Klammern. Beende anschließend wirklich alle
+  Claude-Fenster und starte die App neu.
+- **Microsoft-Store-Version:** Verwende immer **Konfiguration bearbeiten** in
+  Claude. Diese Version kann ihre aktive Datei in einem Store-Profil statt im
+  klassischen `%APPDATA%`-Ordner ablegen.
+- **Keine Anmeldung oder keine Verbindung:** Prüfe, ob die MCP-Adresse im
+  Browser grundsätzlich zum LoxBerry führt und ob der Dienst in der
+  Plugin-Oberfläche aktiv ist. Veröffentliche die Adresse oder Fehlermeldungen
+  nicht unmaskiert.
+- **Zugriff neu erteilen:** Widerrufe die betroffene Sitzung in der
+  Plugin-Oberfläche und verbinde Claude erneut.
+
+Getestete Versionen und bekannte Einschränkungen stehen in der
+[Support-Matrix](../development/support-matrix.md).
+
+Weiterführend: [Claude-Dokumentation zu lokalen MCP-Servern](https://support.claude.com/en/articles/10949351-getting-started-with-local-mcp-servers-on-claude-desktop)
+und [`mcp-remote`](https://github.com/geelen/mcp-remote).

--- a/docs/clients/claude-desktop.en.md
+++ b/docs/clients/claude-desktop.en.md
@@ -1,0 +1,73 @@
+# Connect Claude Desktop
+
+This guide connects Claude Desktop on Windows to the LoxBerry MCP Server. Claude
+uses a small local bridge, so the connection to the LoxBerry stays on the local
+network instead of using a Claude cloud connector.
+
+## Before you start
+
+- The plugin is configured and enabled, and its connection test succeeds.
+- Claude Desktop is installed.
+- Node.js with `npx` is installed. If needed, open PowerShell and run
+  `npx --version`. If the command is unavailable, install a current LTS release
+  of [Node.js](https://nodejs.org/) first. On first use, `npx` downloads the
+  pinned bridge version once from the npm registry.
+- Have the LoxBerry HTTPS address entered in the plugin ready. Append
+  `/plugins/mcpserver/mcp` to obtain the MCP address. The LoxBerry does not need
+  to be published on the Internet for this setup.
+
+User names, passwords, and tokens do **not** belong in the configuration file.
+Authentication takes place securely in the browser later.
+
+## Add the MCP server
+
+1. In Claude Desktop, open **Settings → Developer** and select **Edit Config**.
+2. Add the `loxberry-mcp` entry to the file that Claude opens. Replace only the
+   example address with your complete MCP address:
+
+   ```json
+   {
+     "mcpServers": {
+       "loxberry-mcp": {
+         "command": "npx",
+         "args": [
+           "-y",
+           "mcp-remote@0.1.38",
+           "https://loxberry.example/plugins/mcpserver/mcp",
+           "--transport",
+           "http-only"
+         ]
+       }
+     }
+   }
+   ```
+
+   Keep any existing MCP server entries and add only the new block. Make sure
+   the result is valid JSON with the required commas.
+3. Save the file and quit Claude Desktop completely. Then open Claude again.
+4. On the first connection, authentication opens in your browser. Sign in with
+   the dedicated Loxone user and approve access.
+5. In a Claude chat, open **+ → Connectors**. `loxberry-mcp` and its tools must
+   be available there. Connection status and MCP logs are also available under
+   **Settings → Developer**.
+
+## Troubleshooting
+
+- **`npx` was not found:** Install Node.js and restart Claude afterwards.
+- **The server is missing:** Open the configuration through Claude again. Check
+  spelling, commas, and brackets. Then quit every Claude window before
+  restarting the app.
+- **Microsoft Store version:** Always use **Edit Config** in Claude. This version
+  may store its active file in a Store profile instead of the classic
+  `%APPDATA%` directory.
+- **No login or connection:** Check that the MCP address reaches the LoxBerry in
+  a browser and that the service is enabled in the plugin UI. Do not publish the
+  address or error details without masking them.
+- **Grant access again:** Revoke the affected session in the plugin UI and
+  reconnect Claude.
+
+Tested versions and known limitations are listed in the
+[support matrix](../development/support-matrix.md).
+
+Further reading: [Claude documentation for local MCP servers](https://support.claude.com/en/articles/10949351-getting-started-with-local-mcp-servers-on-claude-desktop)
+and [`mcp-remote`](https://github.com/geelen/mcp-remote).

--- a/docs/development/automation.md
+++ b/docs/development/automation.md
@@ -13,7 +13,8 @@ authorization, connection profiles, credentials, and private test fixtures outsi
 - `python tools/verify_plugin.py <archive.zip>` verifies checksum, paths, file modes,
   LF text files, plugin identity, required entries, and the offline wheelhouse without
   extracting or installing the archive.
-- `pwsh -File tools/test_mcp_client.ps1` starts the configured Claude MCP proxy and
+- `pwsh -File tools/test_mcp_client.ps1` detects the active Microsoft Store or
+  classic Claude profile, starts its configured MCP proxy, and
   exercises all six read-only tools. Use `-VisibilityFixturePath <private-json>` to add
   a real visible/hidden-control boundary test. The private JSON contains only
   `visible_control_uuid` and `hidden_control_uuid` and remains outside Git.

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -22,6 +22,10 @@ alle Python-Wheels offline mit. Öffne danach **LoxBerry MCP Server**:
 4. Verbinde Codex CLI oder Claude Desktop mit
    `https://loxberry.local/plugins/mcpserver/mcp` und folge dem OAuth-Login.
 
+Für Claude Desktop steht eine kurze
+[Schritt-für-Schritt-Anleitung](clients/claude-desktop.de.md) mit fertigem
+Konfigurationsbeispiel und Fehlerhilfe bereit.
+
 Die sechs Lesetools bleiben standardmäßig aktiv. Für die optionale Bedienung
 von Gen.-1-Switches aktiviere zusätzlich **Loxone-Steuerung**. Danach ist eine
 neue OAuth-Freigabe mit `loxone:control` erforderlich. Deaktivieren widerruft

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -22,6 +22,10 @@ all Python wheels for offline installation. Then open **LoxBerry MCP Server**:
 4. Connect Codex CLI or Claude Desktop to
    `https://loxberry.local/plugins/mcpserver/mcp` and complete OAuth login.
 
+For Claude Desktop, follow the short
+[step-by-step guide](clients/claude-desktop.en.md), which includes a ready-to-use
+configuration example and troubleshooting help.
+
 The six read tools remain enabled by default. To operate Gen. 1 switches,
 additionally enable **Loxone control**. A new OAuth grant with `loxone:control`
 is then required. Disabling control revokes existing control sessions while

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import configparser
 import hashlib
+import json
 import os
 import re
 import shutil
@@ -363,6 +364,106 @@ def test_mcp_client_probe_has_valid_powershell_syntax() -> None:
         check=True,
         env={**os.environ, "MCPSERVER_POWERSHELL_TEST_SCRIPT": str(script)},
     )
+
+
+def _write_claude_config(path: Path, *, configured: bool) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    document = (
+        {"mcpServers": {"loxberry-mcp": {"command": "node", "args": []}}}
+        if configured
+        else {"preferences": {}}
+    )
+    path.write_text(json.dumps(document), encoding="utf-8")
+
+
+def _run_claude_config_check(tmp_path: Path, *extra_args: str) -> subprocess.CompletedProcess[str]:
+    pwsh = shutil.which("pwsh")
+    if pwsh is None:
+        pytest.skip("PowerShell is unavailable")
+    app_data = tmp_path / "Roaming"
+    local_app_data = tmp_path / "Local"
+    return subprocess.run(
+        [
+            pwsh,
+            "-NoProfile",
+            "-File",
+            str(ROOT / "tools" / "test_mcp_client.ps1"),
+            "-CheckConfigurationOnly",
+            *extra_args,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "APPDATA": str(app_data),
+            "LOCALAPPDATA": str(local_app_data),
+        },
+    )
+
+
+def test_mcp_client_probe_prefers_active_store_profile(tmp_path: Path) -> None:
+    store_config = (
+        tmp_path
+        / "Local"
+        / "Packages"
+        / "Claude_test"
+        / "LocalCache"
+        / "Roaming"
+        / "Claude"
+        / "claude_desktop_config.json"
+    )
+    classic_config = tmp_path / "Roaming" / "Claude" / "claude_desktop_config.json"
+    _write_claude_config(store_config, configured=False)
+    _write_claude_config(classic_config, configured=True)
+
+    result = _run_claude_config_check(tmp_path)
+
+    assert result.returncode != 0
+    assert "missing from the active configuration" in result.stderr
+
+
+def test_mcp_client_probe_accepts_configured_store_profile(tmp_path: Path) -> None:
+    store_config = (
+        tmp_path
+        / "Local"
+        / "Packages"
+        / "Claude_test"
+        / "LocalCache"
+        / "Roaming"
+        / "Claude"
+        / "claude_desktop_config.json"
+    )
+    _write_claude_config(store_config, configured=True)
+
+    result = _run_claude_config_check(tmp_path)
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "claude_mcp_configuration=pass"
+
+
+def test_mcp_client_probe_falls_back_to_classic_profile(tmp_path: Path) -> None:
+    classic_config = tmp_path / "Roaming" / "Claude" / "claude_desktop_config.json"
+    _write_claude_config(classic_config, configured=True)
+
+    result = _run_claude_config_check(tmp_path)
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "claude_mcp_configuration=pass"
+
+
+def test_mcp_client_probe_respects_explicit_config_path(tmp_path: Path) -> None:
+    explicit_config = tmp_path / "explicit" / "claude.json"
+    _write_claude_config(explicit_config, configured=True)
+
+    result = _run_claude_config_check(
+        tmp_path,
+        "-ClaudeConfigPath",
+        str(explicit_config),
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "claude_mcp_configuration=pass"
 
 
 def test_plugin_archive_verifier_rejects_checksum_mismatch(tmp_path: Path) -> None:

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -420,7 +420,7 @@ def test_mcp_client_probe_prefers_active_store_profile(tmp_path: Path) -> None:
     result = _run_claude_config_check(tmp_path)
 
     assert result.returncode != 0
-    assert "missing from the active configuration" in result.stderr
+    assert "claude_mcp_configuration=pass" not in result.stdout
 
 
 def test_mcp_client_probe_accepts_configured_store_profile(tmp_path: Path) -> None:

--- a/tools/test_mcp_client.ps1
+++ b/tools/test_mcp_client.ps1
@@ -1,16 +1,58 @@
 param(
-    [string]$ClaudeConfigPath = (Join-Path $env:APPDATA 'Claude\claude_desktop_config.json'),
+    [string]$ClaudeConfigPath,
     [string]$ServerName = 'loxberry-mcp',
     [string]$VisibilityFixturePath,
     [string]$ControlFixturePath,
-    [int]$TimeoutSeconds = 120
+    [int]$TimeoutSeconds = 120,
+    [switch]$CheckConfigurationOnly
 )
 
 $ErrorActionPreference = 'Stop'
+
+function Resolve-ClaudeConfigPath([string]$RequestedPath) {
+    if ($RequestedPath) {
+        if (-not (Test-Path -LiteralPath $RequestedPath -PathType Leaf)) {
+            throw 'The requested Claude configuration file does not exist.'
+        }
+        return (Get-Item -LiteralPath $RequestedPath).FullName
+    }
+
+    if ($env:LOCALAPPDATA) {
+        $packagesPath = Join-Path $env:LOCALAPPDATA 'Packages'
+        if (Test-Path -LiteralPath $packagesPath -PathType Container) {
+            $storeCandidates = @(
+                Get-ChildItem -LiteralPath $packagesPath -Directory -Filter 'Claude_*' -ErrorAction SilentlyContinue |
+                    ForEach-Object {
+                        Join-Path $_.FullName 'LocalCache\Roaming\Claude\claude_desktop_config.json'
+                    } |
+                    Where-Object { Test-Path -LiteralPath $_ -PathType Leaf } |
+                    Sort-Object { (Get-Item -LiteralPath $_).LastWriteTimeUtc } -Descending
+            )
+            if ($storeCandidates.Count -gt 0) {
+                return $storeCandidates[0]
+            }
+        }
+    }
+
+    if ($env:APPDATA) {
+        $classicPath = Join-Path $env:APPDATA 'Claude\claude_desktop_config.json'
+        if (Test-Path -LiteralPath $classicPath -PathType Leaf) {
+            return $classicPath
+        }
+    }
+
+    throw 'No active Claude Desktop configuration file was found.'
+}
+
+$ClaudeConfigPath = Resolve-ClaudeConfigPath $ClaudeConfigPath
 $config = Get-Content -LiteralPath $ClaudeConfigPath -Raw | ConvertFrom-Json
 $server = $config.mcpServers.$ServerName
 if (-not $server -or -not $server.command) {
-    throw 'Claude MCP configuration is missing.'
+    throw "Claude MCP server '$ServerName' is missing from the active configuration."
+}
+if ($CheckConfigurationOnly) {
+    'claude_mcp_configuration=pass'
+    return
 }
 
 $startInfo = [System.Diagnostics.ProcessStartInfo]::new()


### PR DESCRIPTION
## Summary
- detect the active Microsoft Store/MSIX Claude profile before the classic roaming profile
- retain explicit-path support and add a configuration-only diagnostic
- add regression coverage for Store, classic, and explicit configurations
- add concise German and English Claude Desktop setup guides and link them from the user guides and README

## Verification
- full local gate: 200 tests passed, format/lint/type checks passed
- active Claude configuration detection: passed
- local documentation links and git diff checks: passed
- optional live six-tool retry: incomplete because the configured test endpoint returned Service Unavailable; no plugin or Miniserver state was changed

## Scope
This changes client-side test automation and documentation only. It does not change the plugin runtime, MCP contracts, authorization, or Miniserver state.