### PR TITLE
Speed up admin UI actions

### DIFF
--- a/src/mcpserver/admin.py
+++ b/src/mcpserver/admin.py
@@ -9,16 +9,16 @@ import subprocess
 import sys
 from contextlib import suppress
 from pathlib import Path
-from typing import Any, Final
+from typing import TYPE_CHECKING, Any, Final
 from uuid import UUID
 
 from mcpserver import __version__
-from mcpserver.auth.loxone_store import EncryptedLoxoneTokenStore, LoxoneTokenStoreError
-from mcpserver.auth.provider import CONTROL_SCOPE
-from mcpserver.auth.store import AtomicJsonAuthStore
-from mcpserver.config import AtomicConfigStore, ConfigError, PluginConfig
-from mcpserver.loxone.client import LoxoneClient, LoxoneConnectionError, MiniserverEndpoint
-from mcpserver.loxone.events import LoxoneProtocolError
+
+if TYPE_CHECKING:
+    from mcpserver.auth.loxone_store import EncryptedLoxoneTokenStore
+    from mcpserver.auth.store import AtomicJsonAuthStore
+    from mcpserver.config import AtomicConfigStore
+    from mcpserver.loxone.client import LoxoneClient, MiniserverEndpoint
 
 _MAX_REQUEST_BYTES: Final = 32 * 1024
 _SERVICE: Final = "loxberry-mcpserver.service"
@@ -38,18 +38,32 @@ def _path(name: str, *, suffix: str | None = None) -> Path:
 
 
 def _config_store() -> AtomicConfigStore:
+    from mcpserver.config import AtomicConfigStore
+
     return AtomicConfigStore(_path("MCPSERVER_CONFIG", suffix=".json"))
 
 
 def _auth_store() -> AtomicJsonAuthStore:
+    from mcpserver.auth.store import AtomicJsonAuthStore
+
     return AtomicJsonAuthStore(_path("MCPSERVER_AUTH_STORE", suffix=".json"))
 
 
 def _token_store() -> EncryptedLoxoneTokenStore:
+    from mcpserver.auth.loxone_store import EncryptedLoxoneTokenStore
+
     return EncryptedLoxoneTokenStore(
         _path("MCPSERVER_LOXONE_TOKEN_STORE", suffix=".enc"),
         _path("MCPSERVER_INSTALL_KEY", suffix=".key"),
     )
+
+
+def _loxone_client(
+    endpoint: MiniserverEndpoint, *, client_uuid: UUID, timeout_seconds: float
+) -> LoxoneClient:
+    from mcpserver.loxone.client import LoxoneClient
+
+    return LoxoneClient(endpoint, client_uuid=client_uuid, timeout_seconds=timeout_seconds)
 
 
 def _service_active() -> bool:
@@ -81,6 +95,9 @@ def _restart_service() -> None:
 
 
 def _save(payload: object) -> dict[str, Any]:
+    from mcpserver.auth.provider import CONTROL_SCOPE
+    from mcpserver.config import ConfigError, PluginConfig
+
     if not isinstance(payload, dict):
         raise AdminError("configuration payload is invalid")
     config = PluginConfig.from_document(payload)
@@ -113,15 +130,24 @@ def _save(payload: object) -> dict[str, Any]:
             endpoint=previous.loxone_endpoint,
             timeout_seconds=previous.connection_timeout,
         )
-    return {"configuration": config.to_document(), "applied": True}
+    return {
+        "configuration": config.to_document(),
+        "applied": True,
+        "service_active": _service_active(),
+        "sessions": _sessions(),
+    }
 
 
 async def _test_connection(payload: object) -> dict[str, Any]:
+    from mcpserver.loxone.client import LoxoneConnectionError, MiniserverEndpoint
+
     if not isinstance(payload, dict) or not isinstance(payload.get("endpoint"), str):
         raise AdminError("endpoint is required")
     endpoint = MiniserverEndpoint.parse(payload["endpoint"])
     try:
-        result = await LoxoneClient(endpoint, client_uuid=_CLIENT_UUID, timeout_seconds=10).probe()
+        result = await _loxone_client(
+            endpoint, client_uuid=_CLIENT_UUID, timeout_seconds=10
+        ).probe()
     except LoxoneConnectionError as exc:
         raise AdminError(str(exc)) from None
     return {
@@ -156,6 +182,10 @@ def _revoke(
     endpoint: str | None = None,
     timeout_seconds: float | None = None,
 ) -> int:
+    from mcpserver.auth.loxone_store import LoxoneTokenStoreError
+    from mcpserver.loxone.client import LoxoneConnectionError, MiniserverEndpoint
+    from mcpserver.loxone.events import LoxoneProtocolError
+
     revoked: list[str] = []
     bindings: list[tuple[str, str, str]] = []
 
@@ -192,7 +222,7 @@ def _revoke(
     selected_endpoint = endpoint if endpoint is not None else config.loxone_endpoint
     selected_timeout = timeout_seconds if timeout_seconds is not None else config.connection_timeout
     if selected_endpoint and token_store is not None:
-        client = LoxoneClient(
+        client = _loxone_client(
             MiniserverEndpoint.parse(selected_endpoint),
             client_uuid=_CLIENT_UUID,
             timeout_seconds=selected_timeout,
@@ -217,6 +247,8 @@ def _revoke(
 
 
 def _diagnostic() -> dict[str, Any]:
+    from mcpserver.loxone.client import MiniserverEndpoint
+
     config = _config_store().load()
     endpoint = MiniserverEndpoint.parse(config.loxone_endpoint) if config.loxone_endpoint else None
     return {
@@ -236,6 +268,13 @@ def dispatch(request: object) -> dict[str, Any]:
         raise AdminError("request is invalid")
     action = request["action"]
     payload = request.get("payload", {})
+    if action == "page_state":
+        return {
+            "configuration": _config_store().load().to_document(),
+            "version": __version__,
+            "service_active": _service_active(),
+            "sessions": _sessions(),
+        }
     if action == "get_config":
         return {"configuration": _config_store().load().to_document()}
     if action == "save_config":
@@ -250,9 +289,9 @@ def dispatch(request: object) -> dict[str, Any]:
         family_id = payload.get("id") if isinstance(payload, dict) else None
         if not isinstance(family_id, str) or len(family_id) > 128:
             raise AdminError("session identifier is invalid")
-        return {"revoked": _revoke(family_id)}
+        return {"revoked": _revoke(family_id), "sessions": _sessions()}
     if action == "revoke_all":
-        return {"revoked": _revoke(None)}
+        return {"revoked": _revoke(None), "sessions": _sessions()}
     if action == "diagnostic":
         return _diagnostic()
     raise AdminError("action is not supported")
@@ -264,7 +303,7 @@ def main() -> None:
         if len(raw) > _MAX_REQUEST_BYTES:
             raise AdminError("request is too large")
         response = {"ok": True, "data": dispatch(json.loads(raw))}
-    except (AdminError, ConfigError, ValueError, json.JSONDecodeError) as exc:
+    except (AdminError, ValueError, json.JSONDecodeError) as exc:
         response = {"ok": False, "error": {"code": "invalid_request", "message": str(exc)}}
     except Exception:
         response = {

--- a/templates/index.html
+++ b/templates/index.html
@@ -31,12 +31,12 @@
 </style>
 
 <main class="mcp-page">
-  <TMPL_IF NOTICE><div class="mcp-status" role="status"><TMPL_VAR NOTICE ESCAPE=HTML></div></TMPL_IF>
+  <TMPL_IF NOTICE><div id="page-notice" class="mcp-status" role="status" data-kind="<TMPL_VAR NOTICE_KIND ESCAPE=HTML>"><TMPL_VAR NOTICE ESCAPE=HTML></div></TMPL_IF>
   <div id="ajax-status" class="mcp-status" role="status" aria-live="polite" hidden></div>
 
   <section id="setup" class="mcp-card" aria-labelledby="setup-title">
     <h2 id="setup-title"><TMPL_VAR SETUP.TITLE></h2>
-    <form class="mcp-form" method="post" action="index.cgi">
+    <form class="mcp-form" method="post" action="index.cgi" data-ajax="save_config">
       <input type="hidden" name="action" value="save_config">
       <label class="mcp-field"><span><TMPL_VAR SETUP.PUBLIC_ORIGIN></span><input name="public_origin" type="url" value="<TMPL_VAR PUBLIC_ORIGIN ESCAPE=HTML>" placeholder="https://loxberry.local" required></label>
       <label class="mcp-field"><span><TMPL_VAR SETUP.ENDPOINT></span><input name="endpoint" type="url" value="<TMPL_VAR ENDPOINT ESCAPE=HTML>" placeholder="http://192.168.1.20" required></label>
@@ -76,14 +76,16 @@
     </section>
   </div>
 
-  <section id="sessions" class="mcp-card" aria-labelledby="sessions-title">
+  <section id="sessions" class="mcp-card" aria-labelledby="sessions-title" data-empty-label="<TMPL_VAR SESSIONS.EMPTY ESCAPE=HTML>">
     <h2 id="sessions-title"><TMPL_VAR SESSIONS.TITLE></h2>
+    <div id="session-list">
     <TMPL_IF HAS_SESSIONS>
       <div class="mcp-table-wrap"><table class="mcp-table"><thead><tr><th><TMPL_VAR SESSIONS.CLIENT></th><th><TMPL_VAR SESSIONS.IDENTITY></th><th><TMPL_VAR SESSIONS.SCOPES></th><th><TMPL_VAR SESSIONS.EXPIRES></th><th><TMPL_VAR SESSIONS.ACTION></th></tr></thead><tbody>
-      <TMPL_LOOP SESSIONS><tr><td><code><TMPL_VAR client ESCAPE=HTML></code></td><td><code><TMPL_VAR identity ESCAPE=HTML></code></td><td><code><TMPL_VAR scopes ESCAPE=HTML></code></td><td><TMPL_VAR expires_at ESCAPE=HTML></td><td><form method="post" action="index.cgi" data-ajax="revoke_session"><input type="hidden" name="action" value="revoke_session"><input type="hidden" name="id" value="<TMPL_VAR id ESCAPE=HTML>"><button class="lb-button" type="submit"><TMPL_VAR ACTION.REVOKE></button></form></td></tr></TMPL_LOOP>
+      <TMPL_LOOP SESSIONS><tr data-session-id="<TMPL_VAR id ESCAPE=HTML>"><td><code><TMPL_VAR client ESCAPE=HTML></code></td><td><code><TMPL_VAR identity ESCAPE=HTML></code></td><td><code><TMPL_VAR scopes ESCAPE=HTML></code></td><td><TMPL_VAR expires_at ESCAPE=HTML></td><td><form method="post" action="index.cgi" data-ajax="revoke_session"><input type="hidden" name="action" value="revoke_session"><input type="hidden" name="id" value="<TMPL_VAR id ESCAPE=HTML>"><button class="lb-button" type="submit"><TMPL_VAR ACTION.REVOKE></button></form></td></tr></TMPL_LOOP>
       </tbody></table></div>
       <form method="post" action="index.cgi" data-ajax="revoke_all"><input type="hidden" name="action" value="revoke_all"><button class="lb-button" type="submit"><TMPL_VAR ACTION.REVOKE_ALL></button></form>
     <TMPL_ELSE><p><TMPL_VAR SESSIONS.EMPTY></p></TMPL_IF>
+    </div>
   </section>
 
   <section id="diagnostics" class="mcp-card" aria-labelledby="diagnostics-title">
@@ -97,12 +99,38 @@
 <script>
 (() => {
   const status = document.getElementById('ajax-status');
-  for (const form of document.querySelectorAll('form[data-ajax]')) {
-    form.addEventListener('submit', async (event) => {
+  const hideStatusTimers = new WeakMap();
+  const hideSuccess = (element) => {
+    window.clearTimeout(hideStatusTimers.get(element));
+    hideStatusTimers.set(element, window.setTimeout(() => { element.hidden = true; }, 4000));
+  };
+  const pageNotice = document.getElementById('page-notice');
+  if (pageNotice) {
+    const url = new URL(window.location.href);
+    url.searchParams.delete('notice');
+    window.history.replaceState(null, '', url);
+    if (pageNotice.dataset.kind === 'success') hideSuccess(pageNotice);
+  }
+  const updateSessions = (sessions) => {
+    const activeIds = new Set(sessions.map((session) => session.id));
+    const list = document.getElementById('session-list');
+    for (const row of list.querySelectorAll('tr[data-session-id]')) {
+      if (!activeIds.has(row.dataset.sessionId)) row.remove();
+    }
+    if (!list.querySelector('tr[data-session-id]')) {
+      const empty = document.createElement('p');
+      empty.textContent = document.getElementById('sessions').dataset.emptyLabel;
+      list.replaceChildren(empty);
+    }
+  };
+  document.addEventListener('submit', async (event) => {
+    const form = event.target.closest('form[data-ajax]');
+    if (!form) return;
       event.preventDefault();
       const button = form.querySelector('button[type="submit"]');
       button.disabled = true;
       button.setAttribute('aria-busy', 'true');
+      window.clearTimeout(hideStatusTimers.get(status));
       status.hidden = false;
       status.dataset.kind = '';
       status.textContent = '<TMPL_VAR AJAX.WORKING ESCAPE=JS>';
@@ -116,8 +144,10 @@
         if (!response.ok || !result.ok) throw new Error(result.error?.message || '<TMPL_VAR AJAX.ERROR ESCAPE=JS>');
         status.dataset.kind = 'success';
         status.textContent = '<TMPL_VAR AJAX.SUCCESS ESCAPE=JS>';
-        if (form.dataset.ajax === 'status') document.getElementById('service-state').textContent = result.data.service_active ? '<TMPL_VAR STATUS.RUNNING ESCAPE=JS>' : '<TMPL_VAR STATUS.STOPPED ESCAPE=JS>';
-        if (form.dataset.ajax.startsWith('revoke')) window.location.reload();
+        hideSuccess(status);
+        if ('service_active' in result.data) document.getElementById('service-state').textContent = result.data.service_active ? '<TMPL_VAR STATUS.RUNNING ESCAPE=JS>' : '<TMPL_VAR STATUS.STOPPED ESCAPE=JS>';
+        if (Array.isArray(result.data.sessions)) updateSessions(result.data.sessions);
+        if (form.dataset.ajax === 'save_config') document.querySelector('form[data-ajax="test_connection"] input[name="endpoint"]').value = result.data.configuration.loxone.endpoint;
       } catch (error) {
         status.dataset.kind = 'error';
         if (error instanceof DOMException && error.name === 'AbortError') status.textContent = '<TMPL_VAR AJAX.TIMEOUT ESCAPE=JS>';
@@ -128,7 +158,6 @@
         button.disabled = false;
         button.removeAttribute('aria-busy');
       }
-    });
-  }
+  });
 })();
 </script>

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -49,6 +49,27 @@ def test_admin_rejects_unknown_actions() -> None:
         dispatch({"action": "delete_everything"})
 
 
+def test_page_state_aggregates_initial_admin_ui_data(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = PluginConfig.defaults()
+
+    class ConfigStore:
+        def load(self) -> PluginConfig:
+            return config
+
+    monkeypatch.setattr("mcpserver.admin._config_store", lambda: ConfigStore())
+    monkeypatch.setattr("mcpserver.admin._service_active", lambda: True)
+    monkeypatch.setattr("mcpserver.admin._sessions", lambda: [{"id": "family"}])
+
+    result = dispatch({"action": "page_state"})
+
+    assert result == {
+        "configuration": config.to_document(),
+        "version": result["version"],
+        "service_active": True,
+        "sessions": [{"id": "family"}],
+    }
+
+
 def test_failed_config_apply_restores_previous_configuration(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -153,6 +174,15 @@ def test_session_list_excludes_revoked_families(
     result = dispatch({"action": "list_sessions"})
 
     assert [session["id"] for session in result["sessions"]] == ["active-family"]
+
+
+def test_revoke_response_contains_updated_sessions(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("mcpserver.admin._revoke", lambda family_id: 1)
+    monkeypatch.setattr("mcpserver.admin._sessions", lambda: [])
+
+    result = dispatch({"action": "revoke_session", "payload": {"id": "family"}})
+
+    assert result == {"revoked": 1, "sessions": []}
 
 
 def test_revoke_survives_unreadable_encrypted_token(
@@ -274,7 +304,7 @@ def test_revoke_deletes_local_token_after_remote_protocol_error(
 
     monkeypatch.setenv("MCPSERVER_AUTH_STORE", str(auth_path))
     monkeypatch.setattr("mcpserver.admin._token_store", lambda: TrackingTokenStore())
-    monkeypatch.setattr("mcpserver.admin.LoxoneClient", ProtocolFailingClient)
+    monkeypatch.setattr("mcpserver.admin._loxone_client", ProtocolFailingClient)
     monkeypatch.setattr(
         "mcpserver.admin._config_store",
         lambda: type(

--- a/tests/test_admin_ui.py
+++ b/tests/test_admin_ui.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_initial_page_uses_one_aggregated_admin_call() -> None:
+    cgi = (ROOT / "webfrontend/htmlauth/index.cgi").read_text(encoding="utf-8")
+
+    assert "admin_call('page_state', {})" in cgi
+    assert "my $config_result =" not in cgi
+    assert "my $status_result =" not in cgi
+    assert "my $sessions_result =" not in cgi
+
+
+def test_common_actions_update_the_page_without_a_reload() -> None:
+    template = (ROOT / "templates/index.html").read_text(encoding="utf-8")
+
+    assert 'data-ajax="save_config"' in template
+    assert "Array.isArray(result.data.sessions)" in template
+    assert "updateSessions(result.data.sessions)" in template
+    assert "window.location.reload" not in template
+    assert "window.setTimeout(() => { element.hidden = true; }, 4000)" in template
+    assert "window.clearTimeout(hideStatusTimers.get(status))" in template
+    assert "url.searchParams.delete('notice')" in template

--- a/webfrontend/htmlauth/index.cgi
+++ b/webfrontend/htmlauth/index.cgi
@@ -137,11 +137,10 @@ my $template = HTML::Template->new_scalar_ref(
 );
 my %L = LoxBerry::System::readlanguage($template, 'language.ini');
 
-my $config_result = admin_call('get_config', {});
-my $status_result = admin_call('status', {});
-my $sessions_result = admin_call('list_sessions', {});
-my $config = $config_result->{ok} ? $config_result->{data}{configuration} : {};
-my $sessions = $sessions_result->{ok} ? $sessions_result->{data}{sessions} : [];
+my $page_result = admin_call('page_state', {});
+my $page_state = $page_result->{ok} ? $page_result->{data} : {};
+my $config = $page_state->{configuration} // {};
+my $sessions = $page_state->{sessions} // [];
 $config->{server} = {} if ref($config->{server}) ne 'HASH';
 $config->{loxone} = {} if ref($config->{loxone}) ne 'HASH';
 $config->{tools} = {} if ref($config->{tools}) ne 'HASH';
@@ -157,10 +156,12 @@ $template->param(
     REQUESTS_PER_MINUTE => $config->{limits}{requests_per_minute} // 60,
     CONTROL_REQUESTS_PER_MINUTE => $config->{limits}{control_requests_per_minute} // 10,
     MAX_PARALLEL_CALLS => $config->{limits}{max_parallel_calls} // 4,
-    SERVICE_ACTIVE => ($status_result->{ok} && $status_result->{data}{service_active}) ? 1 : 0,
+    SERVICE_ACTIVE => $page_state->{service_active} ? 1 : 0,
     SESSIONS => $sessions,
     HAS_SESSIONS => scalar(@$sessions) ? 1 : 0,
-    NOTICE => $q->{notice} // '',
+    NOTICE => ($q->{notice} // '') eq 'success' ? $L{'AJAX.SUCCESS'} :
+        (($q->{notice} // '') ne '' ? $L{'AJAX.ERROR'} : ''),
+    NOTICE_KIND => ($q->{notice} // '') eq 'success' ? 'success' : 'error',
     LOGLIST => LoxBerry::Web::loglist_html(),
 );
 


### PR DESCRIPTION
## What changed

- aggregate initial configuration, service, and session state into one admin-helper call
- submit save, status, and revoke actions through AJAX without full-page reloads
- update service and session state directly from action responses
- hide successful notifications after four seconds while keeping errors visible
- lazily load heavy Loxone and cryptography dependencies for fast status actions
- add regression coverage for the aggregated page state and reload-free UI contract

## Why

The admin page and common actions were slow because the initial render launched the Python helper three times and each helper eagerly imported heavy runtime dependencies. Revoking a token also forced a complete page reload, while success notices remained visible indefinitely.

## Validation

- `PYTHONPATH=src .venv/Scripts/python.exe tools/test.py` — 200 passed; Ruff and mypy clean
- reproducible release-candidate build and archive verification completed before the final lazy-import optimization
- targeted file hot-swap on the authorized Loxberry-Test system with backups and atomic replacement
- service restart and loopback health check passed
- target timings: admin status about 1.0 s; aggregated page state about 1.6 s
- authenticated browser checks at desktop and mobile sizes; no page overflow
- English and German AJAX status flows confirmed; success notification hides after four seconds

A native Plugin Manager install was intentionally not performed for this diagnostic UI hot-swap.