### PR TITLE
Expand Claude Desktop setup guide

### DIFF
--- a/docs/clients/claude-desktop.de.md
+++ b/docs/clients/claude-desktop.de.md
@@ -37,11 +37,13 @@ solches Programm, ohne dass du dessen Installationsordner selbst suchen musst.
 
    ```powershell
    node --version
-   npm --version
-   npx --version
+   npm.cmd --version
+   npx.cmd --version
    ```
 
-Alle drei Befehle müssen eine Versionsnummer ausgeben. Beim ersten Start durch
+Die `.cmd`-Form vermeidet dabei mögliche PowerShell-Execution-Policy-Fehler mit
+den ebenfalls installierten `.ps1`-Startdateien. Alle drei Befehle müssen eine
+Versionsnummer ausgeben. Beim ersten Start durch
 Claude lädt `npx` die festgelegte Version `mcp-remote@0.1.38` einmalig aus dem
 npm-Register in den lokalen npm-Cache. Danach kann diese Version aus dem Cache
 erneut verwendet werden. Für eine bewusst dauerhaft offline gehaltene

--- a/docs/clients/claude-desktop.de.md
+++ b/docs/clients/claude-desktop.de.md
@@ -122,6 +122,11 @@ Freigabeseite im Browser.
 
 ## Optionale Loxone-Steuerung
 
+> **Experimentell und noch nicht mit Claude abgenommen:** Der folgende Ablauf
+> beschreibt die erwartete Einrichtung, wurde aber noch nicht durch einen
+> vollständigen Claude-Test von Registrierung, Freigabe und Werkzeugaufruf
+> bestätigt. Der dokumentierte und geprüfte Standard bleibt Read-only.
+
 Dieser Abschnitt gilt nur, wenn die kontrollierte Gen.-1-Switch-Steuerung in der
 Plugin-Oberfläche bewusst aktiviert wurde. Für normalen Lesezugriff ist er nicht
 erforderlich.
@@ -169,9 +174,10 @@ den zusätzlichen Scope nicht automatisch.
 
 4. Widerrufe die bisherige Claude-Sitzung in der Plugin-Oberfläche. Beende
    Claude vollständig und starte es neu.
-5. Melde dich erneut an. Auf der Freigabeseite müssen jetzt
+5. Melde dich erneut an. Prüfe, ob auf der Freigabeseite
    `loxone:read loxone:control` erscheinen. Bestätige nur, wenn diese Erweiterung
-   beabsichtigt ist.
+   beabsichtigt ist. Fehlt einer der Scopes, verwende die Steuerung nicht und
+   bleibe bei der geprüften Read-only-Einrichtung.
 
 Wird die Steuerung später im Plugin deaktiviert, werden Sitzungen mit
 `loxone:control` widerrufen. Für erneuten reinen Lesezugriff entfernst du die

--- a/docs/clients/claude-desktop.de.md
+++ b/docs/clients/claude-desktop.de.md
@@ -1,32 +1,80 @@
 # Claude Desktop verbinden
 
 Diese Anleitung richtet Claude Desktop unter Windows für den LoxBerry MCP
-Server ein. Claude verwendet dabei eine kleine lokale Bridge. Die Verbindung
-zum LoxBerry bleibt im lokalen Netzwerk und wird nicht über einen
-Claude-Cloud-Connector hergestellt.
+Server ein. Claude startet dafür auf dem Computer eine kleine lokale Bridge
+namens `mcp-remote`. Die Verbindung zum LoxBerry bleibt im lokalen Netzwerk und
+wird nicht über einen Claude-Cloud-Connector hergestellt.
 
-## Vorher prüfen
+## Vorbereitung
 
-- Das Plugin ist eingerichtet, aktiviert und der Verbindungstest ist
-  erfolgreich.
-- Claude Desktop ist installiert.
-- Node.js mit `npx` ist installiert. Öffne bei Bedarf PowerShell und prüfe dies
-  mit `npx --version`. Wird der Befehl nicht gefunden, installiere zuerst eine
-  aktuelle LTS-Version von [Node.js](https://nodejs.org/). Beim ersten Start
-  lädt `npx` die festgelegte Bridge-Version einmalig aus dem npm-Register.
-- Halte die im Plugin eingetragene HTTPS-Adresse des LoxBerry bereit. Ergänzt
-  um `/plugins/mcpserver/mcp` ergibt sie die MCP-Adresse. Dafür ist keine
-  Veröffentlichung des LoxBerry im Internet erforderlich.
+### 1. Plugin und MCP-Adresse vorbereiten
 
-Benutzernamen, Passwörter und Tokens gehören **nicht** in die Konfigurationsdatei.
-Die Anmeldung erfolgt später geschützt im Browser.
+- Das Plugin ist eingerichtet und aktiviert. Der Verbindungstest in der
+  Plugin-Oberfläche ist erfolgreich.
+- Verwende die dort eingetragene HTTPS-Adresse des **LoxBerry**, nicht die
+  Adresse des Miniservers. Ergänze `/plugins/mcpserver/mcp`, zum Beispiel:
 
-## MCP-Server hinzufügen
+  ```text
+  https://loxberry.example/plugins/mcpserver/mcp
+  ```
+
+- Veröffentliche die Adresse nicht im Internet. Der Computer mit Claude muss den
+  LoxBerry lediglich im lokalen Netzwerk erreichen können.
+- Benutzernamen, Passwörter und Tokens gehören weder in die MCP-Adresse noch in
+  die Claude-Konfiguration. Die Anmeldung erfolgt später geschützt im Browser.
+
+### 2. Node.js und npx installieren
+
+`mcp-remote` ist ein Node.js-Programm. `npx` gehört zu npm und startet ein
+solches Programm, ohne dass du dessen Installationsordner selbst suchen musst.
+
+1. Lade die aktuelle **LTS-Version** von [Node.js](https://nodejs.org/) herunter.
+2. Führe den Windows-Installer mit den vorgeschlagenen Komponenten aus und
+   behalte die Aufnahme in `PATH` aktiviert. npm und `npx` werden dabei
+   mitinstalliert; `npx` wird nicht separat heruntergeladen.
+3. Schließe bereits geöffnete PowerShell-Fenster. Öffne PowerShell neu und
+   prüfe die Installation:
+
+   ```powershell
+   node --version
+   npm --version
+   npx --version
+   ```
+
+Alle drei Befehle müssen eine Versionsnummer ausgeben. Beim ersten Start durch
+Claude lädt `npx` die festgelegte Version `mcp-remote@0.1.38` einmalig aus dem
+npm-Register in den lokalen npm-Cache. Danach kann diese Version aus dem Cache
+erneut verwendet werden. Für eine bewusst dauerhaft offline gehaltene
+Installation ist dagegen der unten beschriebene direkte Node-Aufruf gedacht.
+
+### 3. Den richtigen npx-Pfad ermitteln
+
+Normalerweise reicht in Claude der kurze Befehl `npx`. Falls Claude später
+meldet, dass `npx` nicht gefunden wurde, ermittle den vollständigen Pfad in
+PowerShell:
+
+```powershell
+where.exe npx
+```
+
+Verwende die ausgegebene Zeile, die auf `npx.cmd` endet. Ein typisches Ergebnis
+ist `C:\Program Files\nodejs\npx.cmd`. Wird ein vollständiger Windows-Pfad in
+JSON eingetragen, muss jeder umgekehrte Schrägstrich doppelt geschrieben werden:
+
+```json
+"command": "C:\\Program Files\\nodejs\\npx.cmd"
+```
+
+Der bei einer vorbereiteten Testinstallation sichtbare Pfad zu einer Codex-
+Laufzeit ist **kein** allgemeiner Node.js-Pfad und darf nicht kopiert werden.
+
+## Read-only-Verbindung einrichten
 
 1. Öffne in Claude Desktop **Einstellungen → Entwickler** und wähle
-   **Konfiguration bearbeiten**.
-2. Ergänze den Eintrag `loxberry-mcp` in der geöffneten Datei. Ersetze nur die
-   Beispieladresse durch deine vollständige MCP-Adresse:
+   **Konfiguration bearbeiten**. Verwende immer diesen Menüpunkt, damit auch die
+   Microsoft-Store-Version ihre tatsächlich aktive Datei öffnet.
+2. Ergänze den Eintrag `loxberry-mcp`. Ersetze nur die Beispieladresse durch
+   deine vollständige MCP-Adresse:
 
    ```json
    {
@@ -39,41 +87,130 @@ Die Anmeldung erfolgt später geschützt im Browser.
            "https://loxberry.example/plugins/mcpserver/mcp",
            "--transport",
            "http-only"
-         ]
+         ],
+         "env": {
+           "NODE_USE_SYSTEM_CA": "1"
+         }
        }
      }
    }
    ```
 
+   `-y` beantwortet die einmalige npm-Rückfrage automatisch. Die Einstellung
+   `NODE_USE_SYSTEM_CA` erlaubt einer aktuellen Node.js-Version zusätzlich die
+   unter Windows als vertrauenswürdig hinterlegten Zertifikate zu verwenden.
+   Sie schaltet die Zertifikatsprüfung nicht aus.
+
    Sind bereits andere MCP-Server eingetragen, behalte diese und füge nur den
-   neuen Block hinzu. Achte auf gültiges JSON und die notwendigen Kommas.
+   neuen Block sowie das notwendige Komma hinzu.
 3. Speichere die Datei und beende Claude Desktop vollständig. Öffne Claude
    danach erneut.
 4. Beim ersten Verbindungsaufbau öffnet sich die Anmeldung im Browser. Melde
    dich mit dem dafür vorgesehenen Loxone-Benutzer an und bestätige den Zugriff.
-5. Öffne in einem Claude-Chat über **+ → Connectors** die Liste der Verbindungen.
-   `loxberry-mcp` und seine Werkzeuge müssen dort verfügbar sein. Den Status und
-   die MCP-Logs findest du zusätzlich unter **Einstellungen → Entwickler**.
+5. Öffne in einem Claude-Chat **+ → Connectors**. `loxberry-mcp` und seine
+   Werkzeuge müssen dort verfügbar sein. Status und MCP-Logs findest du
+   zusätzlich unter **Einstellungen → Entwickler**.
+
+### Scope für Read-only
+
+Für die sechs Lesewerkzeuge muss kein Scope in die Claude-Konfiguration
+geschrieben werden. Ohne ausdrückliche Angabe fordert die Bridge ausschließlich
+`loxone:read` an. Kontrolliere diesen Scope vor der Bestätigung auf der
+Freigabeseite im Browser.
+
+## Optionale Loxone-Steuerung
+
+Dieser Abschnitt gilt nur, wenn die kontrollierte Gen.-1-Switch-Steuerung in der
+Plugin-Oberfläche bewusst aktiviert wurde. Für normalen Lesezugriff ist er nicht
+erforderlich.
+
+Die Steuerung benötigt immer beide Scopes:
+
+```text
+loxone:read loxone:control
+```
+
+`loxone:control` allein ist ungültig. Bestehende Read-only-Sitzungen erhalten
+den zusätzlichen Scope nicht automatisch.
+
+1. Aktiviere **Loxone-Steuerung** im Plugin und speichere die Konfiguration.
+2. Erstelle den lokalen Ordner `C:\Users\Public\LoxBerryMCP` und darin die Datei
+   `loxberry-oauth-client.json` mit diesem Inhalt:
+
+   ```json
+   {
+     "scope": "loxone:read loxone:control"
+   }
+   ```
+
+   Die Datei enthält keine Zugangsdaten und darf trotzdem nur lokal bleiben.
+3. Ergänze am Ende der bestehenden `args`-Liste nach `"http-only"`:
+
+   ```json
+   "--static-oauth-client-metadata",
+   "@C:\\Users\\Public\\LoxBerryMCP\\loxberry-oauth-client.json"
+   ```
+
+   Der vollständige Ausschnitt lautet dann:
+
+   ```json
+   "args": [
+     "-y",
+     "mcp-remote@0.1.38",
+     "https://loxberry.example/plugins/mcpserver/mcp",
+     "--transport",
+     "http-only",
+     "--static-oauth-client-metadata",
+     "@C:\\Users\\Public\\LoxBerryMCP\\loxberry-oauth-client.json"
+   ]
+   ```
+
+4. Widerrufe die bisherige Claude-Sitzung in der Plugin-Oberfläche. Beende
+   Claude vollständig und starte es neu.
+5. Melde dich erneut an. Auf der Freigabeseite müssen jetzt
+   `loxone:read loxone:control` erscheinen. Bestätige nur, wenn diese Erweiterung
+   beabsichtigt ist.
+
+Wird die Steuerung später im Plugin deaktiviert, werden Sitzungen mit
+`loxone:control` widerrufen. Für erneuten reinen Lesezugriff entfernst du die
+beiden Metadatenargumente wieder und verbindest Claude neu.
+
+## Warum eine vorbereitete Konfiguration anders aussehen kann
+
+Eine vorbereitete oder offline gehaltene Testinstallation kann direkt eine
+bestimmte `node.exe` und eine bereits lokal installierte `proxy.js` starten. Das
+ist dieselbe Bridge, nur ohne die Paketauflösung durch `npx`:
+
+```text
+npx mcp-remote@0.1.38 ...
+        oder
+node.exe <lokaler Pfad zu proxy.js> ...
+```
+
+Der direkte Weg startet die Bridge nach der Vorbereitung vollständig aus lokalen
+Dateien, benötigt aber einen eigens installierten Paketordner und dauerhaft
+gültige absolute Pfade. Für normale Benutzer ist deshalb `npx` der einfachere
+Standard. Kopiere niemals benutzerspezifische Node-, Codex- oder Projektpfade
+von einem anderen Computer.
 
 ## Wenn es nicht funktioniert
 
-- **`npx` wurde nicht gefunden:** Installiere Node.js und starte Claude danach
-  neu.
+- **`npx` wurde nicht gefunden:** Prüfe die drei Versionsbefehle und verwende
+  danach den mit `where.exe npx` ermittelten vollständigen `npx.cmd`-Pfad.
 - **Der Server erscheint nicht:** Öffne die Konfiguration erneut über Claude.
-  Prüfe Schreibweise, Kommas und Klammern. Beende anschließend wirklich alle
-  Claude-Fenster und starte die App neu.
-- **Microsoft-Store-Version:** Verwende immer **Konfiguration bearbeiten** in
-  Claude. Diese Version kann ihre aktive Datei in einem Store-Profil statt im
-  klassischen `%APPDATA%`-Ordner ablegen.
-- **Keine Anmeldung oder keine Verbindung:** Prüfe, ob die MCP-Adresse im
-  Browser grundsätzlich zum LoxBerry führt und ob der Dienst in der
-  Plugin-Oberfläche aktiv ist. Veröffentliche die Adresse oder Fehlermeldungen
-  nicht unmaskiert.
-- **Zugriff neu erteilen:** Widerrufe die betroffene Sitzung in der
-  Plugin-Oberfläche und verbinde Claude erneut.
+  Prüfe Schreibweise, Kommas und Klammern und starte alle Claude-Prozesse neu.
+- **Zertifikatsfehler:** Das LoxBerry-Zertifikat muss für die verwendete Adresse
+  gültig und unter Windows vertrauenswürdig sein. `NODE_USE_SYSTEM_CA` umgeht
+  weder eine abgelaufene Bescheinigung noch einen falschen Hostnamen.
+- **Keine Anmeldung oder Verbindung:** Prüfe die MCP-Adresse und den
+  Dienststatus in der Plugin-Oberfläche. Veröffentliche Adresse und Logs nur
+  maskiert.
+- **Steuerungswerkzeug fehlt:** Prüfe Aktivierung, Metadatendatei, beide Scopes
+  und den Widerruf der alten Read-only-Sitzung.
 
 Getestete Versionen und bekannte Einschränkungen stehen in der
 [Support-Matrix](../development/support-matrix.md).
 
-Weiterführend: [Claude-Dokumentation zu lokalen MCP-Servern](https://support.claude.com/en/articles/10949351-getting-started-with-local-mcp-servers-on-claude-desktop)
-und [`mcp-remote`](https://github.com/geelen/mcp-remote).
+Weiterführend: [Claude-Dokumentation zu lokalen MCP-Servern](https://support.claude.com/en/articles/10949351-getting-started-with-local-mcp-servers-on-claude-desktop),
+[npm-Dokumentation zu `npx`](https://docs.npmjs.com/cli/commands/npx/) und
+[`mcp-remote`](https://github.com/geelen/mcp-remote).

--- a/docs/clients/claude-desktop.en.md
+++ b/docs/clients/claude-desktop.en.md
@@ -36,11 +36,13 @@ program without requiring you to locate its installation directory yourself.
 
    ```powershell
    node --version
-   npm --version
-   npx --version
+   npm.cmd --version
+   npx.cmd --version
    ```
 
-All three commands must print a version. On first use by Claude, `npx` downloads
+The `.cmd` form avoids possible PowerShell execution-policy errors involving the
+also installed `.ps1` launchers. All three commands must print a version. On
+first use by Claude, `npx` downloads
 the pinned `mcp-remote@0.1.38` release once from the npm registry into the local
 npm cache, which is normally reused for later starts.
 The direct Node method described below is intended for deliberately permanent

--- a/docs/clients/claude-desktop.en.md
+++ b/docs/clients/claude-desktop.en.md
@@ -116,6 +116,11 @@ the browser consent page before approving access.
 
 ## Optional Loxone control
 
+> **Experimental and not yet accepted with Claude:** The following workflow
+> describes the expected setup, but a complete Claude test of registration,
+> consent, and tool availability has not yet confirmed it. Read-only remains the
+> documented and tested default.
+
 This section applies only when controlled Gen. 1 Switch operation was
 deliberately enabled in the plugin UI. It is unnecessary for normal read access.
 
@@ -162,8 +167,10 @@ additional scope automatically.
 
 4. Revoke the existing Claude session in the plugin UI. Quit Claude completely
    and start it again.
-5. Sign in again. The consent page must now show
-   `loxone:read loxone:control`. Approve only when this extension is intended.
+5. Sign in again. Check whether the consent page shows
+   `loxone:read loxone:control`. Approve only when this extension is intended. If
+   either scope is missing, do not use control and stay with the tested read-only
+   setup.
 
 If control is later disabled in the plugin, sessions with `loxone:control` are
 revoked. To return to read-only access, remove the two metadata arguments and

--- a/docs/clients/claude-desktop.en.md
+++ b/docs/clients/claude-desktop.en.md
@@ -1,29 +1,78 @@
 # Connect Claude Desktop
 
 This guide connects Claude Desktop on Windows to the LoxBerry MCP Server. Claude
-uses a small local bridge, so the connection to the LoxBerry stays on the local
-network instead of using a Claude cloud connector.
+starts a small local bridge named `mcp-remote` on the computer. The connection
+to the LoxBerry stays on the local network instead of using a Claude cloud
+connector.
 
-## Before you start
+## Preparation
+
+### 1. Prepare the plugin and MCP address
 
 - The plugin is configured and enabled, and its connection test succeeds.
-- Claude Desktop is installed.
-- Node.js with `npx` is installed. If needed, open PowerShell and run
-  `npx --version`. If the command is unavailable, install a current LTS release
-  of [Node.js](https://nodejs.org/) first. On first use, `npx` downloads the
-  pinned bridge version once from the npm registry.
-- Have the LoxBerry HTTPS address entered in the plugin ready. Append
-  `/plugins/mcpserver/mcp` to obtain the MCP address. The LoxBerry does not need
-  to be published on the Internet for this setup.
+- Use the **LoxBerry** HTTPS address entered in the plugin, not the Miniserver
+  address. Append `/plugins/mcpserver/mcp`, for example:
 
-User names, passwords, and tokens do **not** belong in the configuration file.
-Authentication takes place securely in the browser later.
+  ```text
+  https://loxberry.example/plugins/mcpserver/mcp
+  ```
 
-## Add the MCP server
+- Do not publish this address on the Internet. The computer running Claude only
+  needs to reach the LoxBerry on the local network.
+- User names, passwords, and tokens do not belong in the MCP address or Claude
+  configuration. Authentication takes place securely in the browser later.
+
+### 2. Install Node.js and npx
+
+`mcp-remote` is a Node.js program. `npx` is included with npm and starts such a
+program without requiring you to locate its installation directory yourself.
+
+1. Download the current **LTS release** from [Node.js](https://nodejs.org/).
+2. Run the Windows installer with the suggested components and keep the option
+   to add Node.js to `PATH` enabled. npm and `npx` are installed with Node.js;
+   `npx` is not a separate download.
+3. Close any open PowerShell windows. Open PowerShell again and verify the
+   installation:
+
+   ```powershell
+   node --version
+   npm --version
+   npx --version
+   ```
+
+All three commands must print a version. On first use by Claude, `npx` downloads
+the pinned `mcp-remote@0.1.38` release once from the npm registry into the local
+npm cache, which is normally reused for later starts.
+The direct Node method described below is intended for deliberately permanent
+offline preparation instead.
+
+### 3. Find the correct npx path
+
+The short `npx` command normally works in Claude. If Claude later reports that
+`npx` was not found, obtain the complete path in PowerShell:
+
+```powershell
+where.exe npx
+```
+
+Use the returned line ending in `npx.cmd`. A typical result is
+`C:\Program Files\nodejs\npx.cmd`. In JSON, each backslash in a complete Windows
+path must be written twice:
+
+```json
+"command": "C:\\Program Files\\nodejs\\npx.cmd"
+```
+
+A Codex runtime path visible in a prepared test installation is **not** a
+general Node.js path and must not be copied.
+
+## Set up the read-only connection
 
 1. In Claude Desktop, open **Settings → Developer** and select **Edit Config**.
-2. Add the `loxberry-mcp` entry to the file that Claude opens. Replace only the
-   example address with your complete MCP address:
+   Always use this menu item so the Microsoft Store edition also opens its
+   active file.
+2. Add the `loxberry-mcp` entry. Replace only the example address with your
+   complete MCP address:
 
    ```json
    {
@@ -36,38 +85,122 @@ Authentication takes place securely in the browser later.
            "https://loxberry.example/plugins/mcpserver/mcp",
            "--transport",
            "http-only"
-         ]
+         ],
+         "env": {
+           "NODE_USE_SYSTEM_CA": "1"
+         }
        }
      }
    }
    ```
 
-   Keep any existing MCP server entries and add only the new block. Make sure
-   the result is valid JSON with the required commas.
+   `-y` answers the one-time npm prompt automatically. `NODE_USE_SYSTEM_CA`
+   allows a current Node.js release to additionally use certificates trusted by
+   Windows. It does not disable certificate validation.
+
+   Keep any existing MCP server entries and add only the new block and required
+   comma.
 3. Save the file and quit Claude Desktop completely. Then open Claude again.
 4. On the first connection, authentication opens in your browser. Sign in with
    the dedicated Loxone user and approve access.
 5. In a Claude chat, open **+ → Connectors**. `loxberry-mcp` and its tools must
-   be available there. Connection status and MCP logs are also available under
-   **Settings → Developer**.
+   be available. Status and MCP logs are also under **Settings → Developer**.
+
+### Scope for read-only access
+
+The six read tools do not require a scope in the Claude configuration. Without
+an explicit value, the bridge requests only `loxone:read`. Verify this scope on
+the browser consent page before approving access.
+
+## Optional Loxone control
+
+This section applies only when controlled Gen. 1 Switch operation was
+deliberately enabled in the plugin UI. It is unnecessary for normal read access.
+
+Control always requires both scopes:
+
+```text
+loxone:read loxone:control
+```
+
+`loxone:control` alone is invalid. Existing read-only sessions never receive the
+additional scope automatically.
+
+1. Enable **Loxone control** in the plugin and save the configuration.
+2. Create the local folder `C:\Users\Public\LoxBerryMCP` and add
+   `loxberry-oauth-client.json` with this content:
+
+   ```json
+   {
+     "scope": "loxone:read loxone:control"
+   }
+   ```
+
+   The file contains no credentials but must still remain local.
+3. At the end of the existing `args` list, after `"http-only"`, add:
+
+   ```json
+   "--static-oauth-client-metadata",
+   "@C:\\Users\\Public\\LoxBerryMCP\\loxberry-oauth-client.json"
+   ```
+
+   The complete section then reads:
+
+   ```json
+   "args": [
+     "-y",
+     "mcp-remote@0.1.38",
+     "https://loxberry.example/plugins/mcpserver/mcp",
+     "--transport",
+     "http-only",
+     "--static-oauth-client-metadata",
+     "@C:\\Users\\Public\\LoxBerryMCP\\loxberry-oauth-client.json"
+   ]
+   ```
+
+4. Revoke the existing Claude session in the plugin UI. Quit Claude completely
+   and start it again.
+5. Sign in again. The consent page must now show
+   `loxone:read loxone:control`. Approve only when this extension is intended.
+
+If control is later disabled in the plugin, sessions with `loxone:control` are
+revoked. To return to read-only access, remove the two metadata arguments and
+reconnect Claude.
+
+## Why a prepared configuration may look different
+
+A prepared or offline test installation may directly start a particular
+`node.exe` and an already installed `proxy.js`. This is the same bridge without
+package resolution through `npx`:
+
+```text
+npx mcp-remote@0.1.38 ...
+        or
+node.exe <local path to proxy.js> ...
+```
+
+After preparation, the direct method starts the bridge entirely from local
+files, but it needs a separately installed package directory and permanently
+valid absolute paths. For normal users, `npx` is therefore the simpler default.
+Never copy user-specific Node, Codex, or project paths from another computer.
 
 ## Troubleshooting
 
-- **`npx` was not found:** Install Node.js and restart Claude afterwards.
+- **`npx` was not found:** Check the three version commands and then use the
+  complete `npx.cmd` path reported by `where.exe npx`.
 - **The server is missing:** Open the configuration through Claude again. Check
-  spelling, commas, and brackets. Then quit every Claude window before
-  restarting the app.
-- **Microsoft Store version:** Always use **Edit Config** in Claude. This version
-  may store its active file in a Store profile instead of the classic
-  `%APPDATA%` directory.
-- **No login or connection:** Check that the MCP address reaches the LoxBerry in
-  a browser and that the service is enabled in the plugin UI. Do not publish the
-  address or error details without masking them.
-- **Grant access again:** Revoke the affected session in the plugin UI and
-  reconnect Claude.
+  spelling, commas, and brackets, then restart every Claude process.
+- **Certificate error:** The LoxBerry certificate must be valid for the address
+  and trusted by Windows. `NODE_USE_SYSTEM_CA` bypasses neither expiry nor a
+  hostname mismatch.
+- **No login or connection:** Check the MCP address and service status in the
+  plugin UI. Publish addresses and logs only after masking them.
+- **Control tool is missing:** Check plugin activation, metadata file, both
+  scopes, and revocation of the previous read-only session.
 
 Tested versions and known limitations are listed in the
 [support matrix](../development/support-matrix.md).
 
-Further reading: [Claude documentation for local MCP servers](https://support.claude.com/en/articles/10949351-getting-started-with-local-mcp-servers-on-claude-desktop)
-and [`mcp-remote`](https://github.com/geelen/mcp-remote).
+Further reading: [Claude documentation for local MCP servers](https://support.claude.com/en/articles/10949351-getting-started-with-local-mcp-servers-on-claude-desktop),
+[npm documentation for `npx`](https://docs.npmjs.com/cli/commands/npx/), and
+[`mcp-remote`](https://github.com/geelen/mcp-remote).

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -31,6 +31,8 @@ von Gen.-1-Switches aktiviere zusätzlich **Loxone-Steuerung**. Danach ist eine
 neue OAuth-Freigabe mit `loxone:control` erforderlich. Deaktivieren widerruft
 bestehende Control-Sitzungen; reine Lesesitzungen bleiben gültig. Bei einem
 Gen.-2-/HTTPS-Ziel kann die Steuerung nicht aktiviert werden.
+Claude-Benutzer finden die dafür notwendige Scope-Konfiguration im Abschnitt
+[Optionale Loxone-Steuerung](clients/claude-desktop.de.md#optionale-loxone-steuerung).
 
 Speichern, Verbindungstest und Sitzungswiderruf funktionieren auch ohne
 JavaScript. Mit JavaScript werden Status, Test und Widerruf ohne Seitenwechsel

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -31,6 +31,8 @@ additionally enable **Loxone control**. A new OAuth grant with `loxone:control`
 is then required. Disabling control revokes existing control sessions while
 read-only sessions remain valid. Control cannot be enabled for a Gen. 2/HTTPS
 target.
+Claude users can find the required scope configuration under
+[Optional Loxone control](clients/claude-desktop.en.md#optional-loxone-control).
 
 Save, connection test and session revocation remain usable without JavaScript.
 With JavaScript, status, test and revocation update without a page navigation.


### PR DESCRIPTION
## Summary
- expand the German and English Claude Desktop setup guides with a preparation chapter
- explain where Node.js, npm, and npx come from and how to verify the installation
- show how to find and use the correct Windows `npx.cmd` path
- document the read-only scope default and optional control-scope metadata
- explain the difference between the portable npx setup and a prepared direct-node setup

## Verification
- documentation example and link validation passed
- `git diff --check` passed
- full local gate passed: Ruff, mypy, and 204 pytest tests
- documentation-only change; no target system, plugin, or Miniserver modification required