### PR TITLE
Document ChatGPT desktop MCP setup

### DIFF
--- a/docs/clients/chatgpt-codex-desktop.de.md
+++ b/docs/clients/chatgpt-codex-desktop.de.md
@@ -1,0 +1,93 @@
+# ChatGPT-/Codex-Desktop-App einrichten
+
+Die ChatGPT-Desktop-App kann den LoxBerry MCP Server direkt per Streamable HTTP
+und OAuth verwenden. Anders als bei Claude Desktop werden dafür weder Node.js
+noch `npx` noch eine lokale Bridge benötigt.
+
+## Vorbereitung
+
+Vor der Einrichtung benötigst du:
+
+- ein installiertes, eingerichtetes und aktiviertes LoxBerry-MCP-Server-Plugin;
+- die HTTPS-Adresse deines LoxBerry, die vom Computer aus erreichbar ist;
+- ein vom Computer als vertrauenswürdig erkanntes HTTPS-Zertifikat;
+- die vollständige MCP-Adresse. Sie besteht aus der LoxBerry-Adresse und dem
+  festen Pfad `/plugins/mcpserver/mcp`, zum Beispiel:
+
+  ```text
+  https://loxberry.local/plugins/mcpserver/mcp
+  ```
+
+Verwende hier die Adresse des **LoxBerry**, nicht die Adresse des Loxone
+Miniservers. Trage keine Zugangsdaten in die URL ein.
+
+Entscheide außerdem vor der Anmeldung, welche Rechte benötigt werden:
+
+- Ist **Loxone-Steuerung** im Plugin deaktiviert, wird nur der Lesezugriff
+  `loxone:read` angeboten.
+- Ist **Loxone-Steuerung** aktiviert, bietet der Server zusätzlich
+  `loxone:control` an. Die Desktop-App bevorzugt die vom Server angebotenen
+  Scopes und fordert deshalb bei einer neuen Anmeldung beide Rechte an.
+
+## MCP-Server hinzufügen
+
+1. Öffne in der ChatGPT-Desktop-App die **Einstellungen**.
+2. Öffne **Plugins > MCP**. Je nach App-Version heißt der Bereich direkt
+   **MCP-Server**.
+3. Wähle **MCP-Server hinzufügen**.
+4. Vergib einen verständlichen Namen, zum Beispiel `LoxBerry MCP Server`.
+5. Wähle als Typ ausdrücklich **Streamable HTTP**.
+6. Trage die vollständige MCP-Adresse ein, zum Beispiel:
+
+   ```text
+   https://loxberry.local/plugins/mcpserver/mcp
+   ```
+
+7. Bestätige mit **Speichern**.
+8. Sobald die App den Server gefunden hat, wähle **Authentifizieren**.
+9. Im Browser öffnet sich die Freigabeseite des LoxBerry MCP Servers. Prüfe die
+   angezeigten Rechte und bestätige die Anmeldung nur, wenn sie deiner Auswahl
+   entsprechen.
+10. Kehre anschließend zur Desktop-App zurück. Falls die App einen Neustart
+    anbietet oder verlangt, führe ihn aus.
+
+Der Server sollte danach als verbunden erscheinen. Über `/mcp` kannst du in der
+Desktop-App die verbundenen MCP-Server kontrollieren.
+
+## Lese- und Schreibrechte verstehen
+
+Wenn die Loxone-Steuerung im Plugin aktiviert ist, erscheinen bei der
+Authentifizierung sofort beide Scopes:
+
+```text
+loxone:read loxone:control
+```
+
+Nach der Bestätigung stehen damit die sechs Lesewerkzeuge und das begrenzte
+Switch-Schreibwerkzeug zur Verfügung. Das Schreibwerkzeug kann ausschließlich
+freigegebene, sichtbare Gen.-1-Switches ein- oder ausschalten. Die tatsächlichen
+Möglichkeiten bleiben zusätzlich durch die Rechte des angemeldeten
+Loxone-Benutzers begrenzt.
+
+Die Schreibrechte werden nicht nachträglich still hinzugefügt: Sie müssen auf
+der Browser-Freigabeseite angezeigt und dort bestätigt werden. Möchtest du nur
+lesen, deaktiviere **Loxone-Steuerung** im Plugin vor der Anmeldung.
+
+Beim späteren Deaktivieren der Loxone-Steuerung widerruft das Plugin bestehende
+Control-Sitzungen. Authentifiziere die Desktop-App danach erneut, um eine reine
+Read-only-Sitzung zu erhalten.
+
+## Fehlerbehebung
+
+- **Server wird nicht gefunden:** Prüfe, ob **Streamable HTTP** gewählt wurde
+  und die URL vollständig mit `/plugins/mcpserver/mcp` endet.
+- **Zertifikatsfehler:** Öffne die LoxBerry-Adresse im Browser und behebe zuerst
+  die Zertifikatswarnung. Deaktiviere die Zertifikatsprüfung nicht.
+- **Authentifizieren fehlt:** Prüfe, ob der Server gespeichert und erreichbar
+  ist. Öffne den Eintrag anschließend erneut.
+- **Unerwartete Schreibrechte:** Brich die Browser-Freigabe ab, deaktiviere
+  **Loxone-Steuerung** im Plugin und starte die Authentifizierung erneut.
+- **Verbindung bleibt ausstehend:** Starte die Desktop-App neu und kontrolliere
+  den Server anschließend über `/mcp`.
+
+Weiterführend: [Offizielle OpenAI-Dokumentation zu MCP](https://learn.chatgpt.com/docs/extend/mcp).

--- a/docs/clients/chatgpt-codex-desktop.en.md
+++ b/docs/clients/chatgpt-codex-desktop.en.md
@@ -1,0 +1,90 @@
+# Set up the ChatGPT/Codex desktop app
+
+The ChatGPT desktop app can use the LoxBerry MCP Server directly through
+Streamable HTTP and OAuth. Unlike Claude Desktop, this setup needs neither
+Node.js nor `npx` nor a local bridge.
+
+## Preparation
+
+Before setup, you need:
+
+- an installed, configured, and enabled LoxBerry MCP Server plugin;
+- the HTTPS address of your LoxBerry, reachable from the computer;
+- an HTTPS certificate that the computer trusts;
+- the complete MCP address. It combines the LoxBerry address and the fixed
+  `/plugins/mcpserver/mcp` path, for example:
+
+  ```text
+  https://loxberry.local/plugins/mcpserver/mcp
+  ```
+
+Use the address of the **LoxBerry**, not the Loxone Miniserver address. Never put
+credentials in the URL.
+
+Also decide which permissions are needed before authentication:
+
+- When **Loxone control** is disabled in the plugin, the server offers only
+  `loxone:read`.
+- When **Loxone control** is enabled, the server also advertises
+  `loxone:control`. The desktop app prefers the server-advertised scopes and
+  therefore requests both permissions during a new login.
+
+## Add the MCP server
+
+1. Open **Settings** in the ChatGPT desktop app.
+2. Open **Plugins > MCP**. Depending on the app version, this section may be
+   named **MCP servers** directly.
+3. Select **Add MCP server**.
+4. Enter a clear name, for example `LoxBerry MCP Server`.
+5. Explicitly select **Streamable HTTP** as the type.
+6. Enter the complete MCP address, for example:
+
+   ```text
+   https://loxberry.local/plugins/mcpserver/mcp
+   ```
+
+7. Select **Save**.
+8. When the app has found the server, select **Authenticate**.
+9. The LoxBerry MCP Server consent page opens in the browser. Check the displayed
+   permissions and approve the login only when they match your intended access.
+10. Return to the desktop app. If the app offers or requires a restart, perform
+    it.
+
+The server should then appear as connected. Use `/mcp` in the desktop app to
+inspect connected MCP servers.
+
+## Understand read and write access
+
+When Loxone control is enabled in the plugin, authentication immediately shows
+both scopes:
+
+```text
+loxone:read loxone:control
+```
+
+After approval, the six read tools and the narrowly limited Switch write tool
+are available. The write tool can only turn permitted, visible Gen. 1 Switches
+on or off. The authenticated Loxone user's permissions further restrict what is
+actually possible.
+
+Write access is not silently added later: it must appear on the browser consent
+page and be approved there. For read-only access, disable **Loxone control** in
+the plugin before authentication.
+
+If Loxone control is disabled later, the plugin revokes existing control
+sessions. Authenticate the desktop app again to obtain a read-only session.
+
+## Troubleshooting
+
+- **Server is not found:** Check that **Streamable HTTP** is selected and that
+  the complete URL ends with `/plugins/mcpserver/mcp`.
+- **Certificate error:** Open the LoxBerry address in a browser and resolve the
+  certificate warning first. Never disable certificate validation.
+- **Authenticate is missing:** Check that the server is saved and reachable,
+  then open its entry again.
+- **Unexpected write access:** Cancel browser consent, disable **Loxone control**
+  in the plugin, and start authentication again.
+- **Connection remains pending:** Restart the desktop app and then inspect the
+  server through `/mcp`.
+
+Further reading: [Official OpenAI MCP documentation](https://learn.chatgpt.com/docs/extend/mcp).

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -26,6 +26,11 @@ Für Claude Desktop steht eine kurze
 [Schritt-für-Schritt-Anleitung](clients/claude-desktop.de.md) mit fertigem
 Konfigurationsbeispiel und Fehlerhilfe bereit.
 
+Für die ChatGPT-/Codex-Desktop-App beschreibt die
+[direkte Streamable-HTTP-Einrichtung](clients/chatgpt-codex-desktop.de.md) das
+Hinzufügen per URL, die Browser-Authentifizierung und die angeforderten Lese-
+beziehungsweise Schreibrechte. Dafür wird keine lokale Node.js-Bridge benötigt.
+
 Die sechs Lesetools bleiben standardmäßig aktiv. Für die optionale Bedienung
 von Gen.-1-Switches aktiviere zusätzlich **Loxone-Steuerung**. Danach ist eine
 neue OAuth-Freigabe mit `loxone:control` erforderlich. Deaktivieren widerruft

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -26,6 +26,11 @@ For Claude Desktop, follow the short
 [step-by-step guide](clients/claude-desktop.en.md), which includes a ready-to-use
 configuration example and troubleshooting help.
 
+For the ChatGPT/Codex desktop app, the
+[direct Streamable HTTP guide](clients/chatgpt-codex-desktop.en.md) explains URL
+setup, browser authentication, and the requested read or write permissions. It
+does not require a local Node.js bridge.
+
 The six read tools remain enabled by default. To operate Gen. 1 switches,
 additionally enable **Loxone control**. A new OAuth grant with `loxone:control`
 is then required. Disabling control revokes existing control sessions while


### PR DESCRIPTION
## Summary
- add German and English setup guides for the ChatGPT/Codex desktop app
- document the direct Streamable HTTP URL setup and browser OAuth flow
- explain why Codex requests both read and control scopes when control is advertised
- show how to retain or restore read-only access
- link the new guide from both user guides

## Evidence and verification
- setup flow is based on a real desktop-app observation and aligned with the current official OpenAI MCP manual
- examples use nonprivate placeholder addresses
- full local gate passed: Ruff, mypy, and 204 pytest tests
- documentation-only change; no plugin, test-device, or Miniserver mutation