### PR TITLE
Add selectable OAuth consent scopes

### DIFF
--- a/docs/clients/chatgpt-codex-desktop.de.md
+++ b/docs/clients/chatgpt-codex-desktop.de.md
@@ -56,22 +56,24 @@ Desktop-App die verbundenen MCP-Server kontrollieren.
 
 ## Lese- und Schreibrechte verstehen
 
-Wenn die Loxone-Steuerung im Plugin aktiviert ist, erscheinen bei der
-Authentifizierung sofort beide Scopes:
+Wenn die Loxone-Steuerung im Plugin aktiviert ist, fordert die Desktop-App bei
+der Authentifizierung beide Scopes an:
 
 ```text
 loxone:read loxone:control
 ```
 
-Nach der Bestätigung stehen damit die sechs Lesewerkzeuge und das begrenzte
+Der Freigabedialog zeigt **Lesezugriff** verpflichtend und
+**Loxone-Steuerung** als optionale Checkbox. Nur wenn die Steuerung ausgewählt
+und bestätigt wird, stehen die sechs Lesewerkzeuge und das begrenzte
 Switch-Schreibwerkzeug zur Verfügung. Das Schreibwerkzeug kann ausschließlich
 freigegebene, sichtbare Gen.-1-Switches ein- oder ausschalten. Die tatsächlichen
 Möglichkeiten bleiben zusätzlich durch die Rechte des angemeldeten
 Loxone-Benutzers begrenzt.
 
 Die Schreibrechte werden nicht nachträglich still hinzugefügt: Sie müssen auf
-der Browser-Freigabeseite angezeigt und dort bestätigt werden. Möchtest du nur
-lesen, deaktiviere **Loxone-Steuerung** im Plugin vor der Anmeldung.
+der Browser-Freigabeseite ausgewählt und dort bestätigt werden. Für reinen
+Lesezugriff lässt du die optionale Checkbox deaktiviert.
 
 Beim späteren Deaktivieren der Loxone-Steuerung widerruft das Plugin bestehende
 Control-Sitzungen. Authentifiziere die Desktop-App danach erneut, um eine reine
@@ -85,8 +87,8 @@ Read-only-Sitzung zu erhalten.
   die Zertifikatswarnung. Deaktiviere die Zertifikatsprüfung nicht.
 - **Authentifizieren fehlt:** Prüfe, ob der Server gespeichert und erreichbar
   ist. Öffne den Eintrag anschließend erneut.
-- **Unerwartete Schreibrechte:** Brich die Browser-Freigabe ab, deaktiviere
-  **Loxone-Steuerung** im Plugin und starte die Authentifizierung erneut.
+- **Unerwartete Schreibrechte:** Widerrufe die Sitzung und authentifiziere dich
+  erneut, ohne die optionale Steuerungsberechtigung auszuwählen.
 - **Verbindung bleibt ausstehend:** Starte die Desktop-App neu und kontrolliere
   den Server anschließend über `/mcp`.
 

--- a/docs/clients/chatgpt-codex-desktop.en.md
+++ b/docs/clients/chatgpt-codex-desktop.en.md
@@ -55,21 +55,22 @@ inspect connected MCP servers.
 
 ## Understand read and write access
 
-When Loxone control is enabled in the plugin, authentication immediately shows
-both scopes:
+When Loxone control is enabled in the plugin, the desktop app requests both
+scopes during authentication:
 
 ```text
 loxone:read loxone:control
 ```
 
-After approval, the six read tools and the narrowly limited Switch write tool
-are available. The write tool can only turn permitted, visible Gen. 1 Switches
-on or off. The authenticated Loxone user's permissions further restrict what is
-actually possible.
+The consent dialog shows required **Read access** and optional **Loxone
+control** as a checkbox. Only when control is selected and confirmed are the six
+read tools and the narrowly limited Switch write tool available. The write tool
+can only turn permitted, visible Gen. 1 Switches on or off. The authenticated
+Loxone user's permissions further restrict what is actually possible.
 
-Write access is not silently added later: it must appear on the browser consent
-page and be approved there. For read-only access, disable **Loxone control** in
-the plugin before authentication.
+Write access is not silently added later: it must be selected and approved on
+the browser consent page. For read-only access, leave the optional checkbox
+clear.
 
 If Loxone control is disabled later, the plugin revokes existing control
 sessions. Authenticate the desktop app again to obtain a read-only session.
@@ -82,8 +83,8 @@ sessions. Authenticate the desktop app again to obtain a read-only session.
   certificate warning first. Never disable certificate validation.
 - **Authenticate is missing:** Check that the server is saved and reachable,
   then open its entry again.
-- **Unexpected write access:** Cancel browser consent, disable **Loxone control**
-  in the plugin, and start authentication again.
+- **Unexpected write access:** Revoke the session and authenticate again without
+  selecting the optional control permission.
 - **Connection remains pending:** Restart the desktop app and then inspect the
   server through `/mcp`.
 

--- a/docs/clients/claude-desktop.de.md
+++ b/docs/clients/claude-desktop.de.md
@@ -174,10 +174,11 @@ den zusätzlichen Scope nicht automatisch.
 
 4. Widerrufe die bisherige Claude-Sitzung in der Plugin-Oberfläche. Beende
    Claude vollständig und starte es neu.
-5. Melde dich erneut an. Prüfe, ob auf der Freigabeseite
-   `loxone:read loxone:control` erscheinen. Bestätige nur, wenn diese Erweiterung
-   beabsichtigt ist. Fehlt einer der Scopes, verwende die Steuerung nicht und
-   bleibe bei der geprüften Read-only-Einrichtung.
+5. Melde dich erneut an. Die Freigabeseite zeigt den verpflichtenden
+   **Lesezugriff** und zusätzlich die optionale **Loxone-Steuerung**. Aktiviere
+   die Steuerungs-Checkbox nur, wenn diese Erweiterung beabsichtigt ist. Fehlt
+   die Auswahlmöglichkeit, verwende die Steuerung nicht und bleibe bei der
+   geprüften Read-only-Einrichtung.
 
 Wird die Steuerung später im Plugin deaktiviert, werden Sitzungen mit
 `loxone:control` widerrufen. Für erneuten reinen Lesezugriff entfernst du die
@@ -213,8 +214,9 @@ von einem anderen Computer.
 - **Keine Anmeldung oder Verbindung:** Prüfe die MCP-Adresse und den
   Dienststatus in der Plugin-Oberfläche. Veröffentliche Adresse und Logs nur
   maskiert.
-- **Steuerungswerkzeug fehlt:** Prüfe Aktivierung, Metadatendatei, beide Scopes
-  und den Widerruf der alten Read-only-Sitzung.
+- **Steuerungswerkzeug fehlt:** Prüfe Aktivierung, Metadatendatei, die beim
+  OAuth-Dialog ausgewählte Steuerungsberechtigung und den Widerruf der alten
+  Read-only-Sitzung.
 
 Getestete Versionen und bekannte Einschränkungen stehen in der
 [Support-Matrix](../development/support-matrix.md).

--- a/docs/clients/claude-desktop.en.md
+++ b/docs/clients/claude-desktop.en.md
@@ -167,10 +167,10 @@ additional scope automatically.
 
 4. Revoke the existing Claude session in the plugin UI. Quit Claude completely
    and start it again.
-5. Sign in again. Check whether the consent page shows
-   `loxone:read loxone:control`. Approve only when this extension is intended. If
-   either scope is missing, do not use control and stay with the tested read-only
-   setup.
+5. Sign in again. The consent page shows required **Read access** and optional
+   **Loxone control**. Select the control checkbox only when this extension is
+   intended. If the option is missing, do not use control and stay with the
+   tested read-only setup.
 
 If control is later disabled in the plugin, sessions with `loxone:control` are
 revoked. To return to read-only access, remove the two metadata arguments and
@@ -204,8 +204,9 @@ Never copy user-specific Node, Codex, or project paths from another computer.
   hostname mismatch.
 - **No login or connection:** Check the MCP address and service status in the
   plugin UI. Publish addresses and logs only after masking them.
-- **Control tool is missing:** Check plugin activation, metadata file, both
-  scopes, and revocation of the previous read-only session.
+- **Control tool is missing:** Check plugin activation, the metadata file, the
+  control permission selected in the OAuth dialog, and revocation of the
+  previous read-only session.
 
 Tested versions and known limitations are listed in the
 [support matrix](../development/support-matrix.md).

--- a/docs/development/adr/0003-phase-2-controlled-switch.md
+++ b/docs/development/adr/0003-phase-2-controlled-switch.md
@@ -34,7 +34,12 @@ The tool annotations are `readOnlyHint=false`, `destructiveHint=true`,
 
 The supported scope sets are `loxone:read` and `loxone:read loxone:control`.
 Control alone is invalid. Existing sessions remain read-only and refresh never
-adds a scope. The consent page calls out control access explicitly.
+adds a scope. Protected resource metadata advertises control only while it is
+enabled, without making it mandatory for the MCP endpoint. The consent page
+shows required read access and lets the user explicitly add or omit requested
+control access. All server-owned login, consent and error messages use the same
+responsive dialog presentation; the registered client's callback page remains
+client-owned.
 
 Configuration adds `tools.loxone_control_enabled`, default `false`, and
 `limits.control_requests_per_minute`, default `10` with range `1` to `60`,

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -36,6 +36,14 @@ von Gen.-1-Switches aktiviere zusätzlich **Loxone-Steuerung**. Danach ist eine
 neue OAuth-Freigabe mit `loxone:control` erforderlich. Deaktivieren widerruft
 bestehende Control-Sitzungen; reine Lesesitzungen bleiben gültig. Bei einem
 Gen.-2-/HTTPS-Ziel kann die Steuerung nicht aktiviert werden.
+
+Der einheitliche OAuth-Dialog zeigt den erforderlichen Lesezugriff und, falls
+vom Client angefordert und im Plugin aktiviert, die optionale
+Loxone-Steuerung als separate Auswahl. Ohne ausgewählte Steuerung wird nur
+`loxone:read` freigegeben. Nach der Bestätigung übergibt der LoxBerry an den
+registrierten Callback des MCP-Clients. Die dort angezeigte Abschlussmeldung
+stammt vom Client, beispielsweise von Claude Code, und nicht vom Plugin.
+
 Claude-Benutzer finden die dafür notwendige Scope-Konfiguration im Abschnitt
 [Optionale Loxone-Steuerung](clients/claude-desktop.de.md#optionale-loxone-steuerung).
 

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -36,6 +36,14 @@ additionally enable **Loxone control**. A new OAuth grant with `loxone:control`
 is then required. Disabling control revokes existing control sessions while
 read-only sessions remain valid. Control cannot be enabled for a Gen. 2/HTTPS
 target.
+
+The consistent OAuth dialog shows required read access and, when requested by
+the client and enabled in the plugin, optional Loxone control as a separate
+choice. If control is not selected, only `loxone:read` is granted. After
+confirmation, the LoxBerry hands off to the MCP client's registered callback.
+The final message shown there belongs to the client, such as Claude Code, not
+to the plugin.
+
 Claude users can find the required scope configuration under
 [Optional Loxone control](clients/claude-desktop.en.md#optional-loxone-control).
 

--- a/src/mcpserver/auth/web.py
+++ b/src/mcpserver/auth/web.py
@@ -135,12 +135,28 @@ def _html_page(
 main{{box-sizing:border-box;max-width:34rem;margin:4vh auto;padding:1.4rem;border-radius:.8rem;background:#fff;color:#17202a}}
 label{{display:block;margin:.9rem 0 .25rem}}input{{box-sizing:border-box;width:100%;padding:.75rem;font:inherit}}
 .actions{{display:flex;gap:.7rem;flex-wrap:wrap;margin-top:1.2rem}}button{{padding:.7rem 1rem;font:inherit}}
-.error{{color:#a00000}}dl{{display:grid;grid-template-columns:max-content 1fr;gap:.4rem .8rem}}dt{{font-weight:700}}
+.error{{color:#a00000}}.notice{{padding:.8rem;border-left:.3rem solid #476d91;background:#edf4fa}}
+.scope-list{{margin:1rem 0;padding:0;border:0}}.scope-list legend{{font-weight:700;margin-bottom:.35rem}}
+.scope-option{{display:flex;align-items:flex-start;gap:.7rem;margin:.65rem 0;padding:.8rem;border:1px solid #b6c2cc;border-radius:.5rem}}
+.scope-option input{{width:auto;margin:.2rem 0 0;padding:0;flex:none}}.scope-option span{{display:block}}.scope-option small{{display:block;margin-top:.2rem}}
+dl{{display:grid;grid-template-columns:max-content 1fr;gap:.4rem .8rem}}dt{{font-weight:700}}
 @media(max-width:430px){{main{{margin:0 auto;padding:1rem}}dl{{display:block}}dd{{margin:0 0 .7rem}}button{{flex:1}}}}
 </style></head><body><main>{body}</main></body></html>"""
     return HTMLResponse(
         document, status_code=status, headers=_security_headers(callback_uri=callback_uri)
     )
+
+
+def _message_page(
+    title: str,
+    heading: str,
+    message: str,
+    *,
+    status: int,
+    callback_uri: str | None = None,
+) -> HTMLResponse:
+    body = f'<h1>{html.escape(heading)}</h1><p class="notice">{html.escape(message)}</p>'
+    return _html_page(title, body, status=status, callback_uri=callback_uri)
 
 
 async def _limited_body(request: Request, limit: int) -> bytes | None:
@@ -322,9 +338,10 @@ class Phase0OAuthWeb:
     async def _authorize_start(self, request: Request) -> Response:
         query = self._single_query(request)
         if query is None:
-            return _html_page(
+            return _message_page(
                 "Invalid authorization request",
-                "<h1>Invalid authorization request</h1>",
+                "Invalid authorization request / Ungültige Autorisierungsanfrage",
+                "Restart the connection from your MCP client. / Starten Sie die Verbindung in Ihrem MCP-Client neu.",
                 status=400,
             )
         client_id = query.get("client_id", "")
@@ -335,9 +352,10 @@ class Phase0OAuthWeb:
             or client.redirect_uris is None
             or redirect_uri not in {str(value) for value in client.redirect_uris}
         ):
-            return _html_page(
+            return _message_page(
                 "Invalid authorization request",
-                "<h1>Invalid authorization request</h1>",
+                "Invalid authorization request / Ungültige Autorisierungsanfrage",
+                "Restart the connection from your MCP client. / Starten Sie die Verbindung in Ihrem MCP-Client neu.",
                 status=400,
             )
         try:
@@ -361,9 +379,10 @@ class Phase0OAuthWeb:
                 {"error": "invalid_request", "state": query.get("state", ""), "iss": self.issuer},
             )
         if len(self.transactions) >= _MAX_LOGIN_TRANSACTIONS:
-            return _html_page(
+            return _message_page(
                 "Authorization unavailable",
-                "<h1>Authorization unavailable / Autorisierung nicht verfügbar</h1>",
+                "Authorization unavailable / Autorisierung nicht verfügbar",
+                "Try again later. / Versuchen Sie es später erneut.",
                 status=503,
             )
         transaction = LoginTransaction(
@@ -407,30 +426,32 @@ class Phase0OAuthWeb:
         return _html_page("Connect Loxone", body, callback_uri=transaction.redirect_uri)
 
     def _consent_page(self, transaction: LoginTransaction) -> HTMLResponse:
-        control = CONTROL_SCOPE in transaction.scopes
-        heading = (
-            "Allow Loxone control? / Loxone-Steuerung erlauben?"
-            if control
-            else "Allow read-only access? / Lesezugriff erlauben?"
-        )
-        warning = (
-            '<p class="error"><strong>This client can switch permitted Loxone controls on and off. / Dieser Client darf freigegebene Loxone-Steuerungen ein- und ausschalten.</strong></p>'
-            if control
+        control_requested = CONTROL_SCOPE in transaction.scopes
+        control_option = (
+            """<label class="scope-option" for="grant_control"><input id="grant_control" type="checkbox" name="grant_control" value="true">
+<span><strong>Loxone control / Loxone-Steuerung</strong><small>Optional: switch permitted Loxone controls on and off. / Optional: Freigegebene Loxone-Steuerungen ein- und ausschalten.</small></span></label>"""
+            if control_requested
             else ""
         )
-        body = f"""<h1>{heading}</h1>{warning}<dl>
+        body = f"""<h1>Choose permissions / Berechtigungen auswählen</h1><dl>
 <dt>Client</dt><dd>{html.escape(transaction.client_name)}</dd>
 <dt>Miniserver</dt><dd>{html.escape(transaction.miniserver_name or "")}</dd>
-<dt>Loxone identity / Loxone-Identität</dt><dd>{html.escape(transaction.identity_name or "")}</dd>
-<dt>Scope / Berechtigung</dt><dd>{html.escape(scope_text(list(transaction.scopes)))}</dd></dl>
+<dt>Loxone identity / Loxone-Identität</dt><dd>{html.escape(transaction.identity_name or "")}</dd></dl>
 <form method="post" action="{html.escape(self.issuer)}/authorize">{self._hidden(transaction, "approve")}
-<div class="actions"><button type="submit">Allow / Erlauben</button></div></form>
+<fieldset class="scope-list"><legend>Permissions / Berechtigungen</legend>
+<label class="scope-option"><input type="checkbox" checked disabled><span><strong>Read access / Lesezugriff</strong><small>Required: read permitted Loxone structure and states. / Erforderlich: Freigegebene Loxone-Struktur und Zustände lesen.</small></span></label>
+{control_option}</fieldset>
+<p class="notice">After confirmation, you will be redirected to your MCP client. / Nach der Bestätigung werden Sie zu Ihrem MCP-Client weitergeleitet.</p>
+<div class="actions"><button type="submit">Confirm permissions / Berechtigungen bestätigen</button></div></form>
 <form method="post" action="{html.escape(self.issuer)}/authorize">{self._hidden(transaction, "deny")}
 <div class="actions"><button type="submit">Deny / Ablehnen</button></div></form>"""
         return _html_page("Authorize client", body, callback_uri=transaction.redirect_uri)
 
     async def _authorize_post(self, request: Request) -> Response:
-        form = await _form(request, allowed={"csrf", "action", "username", "password"})
+        form = await _form(
+            request,
+            allowed={"csrf", "action", "username", "password", "grant_control"},
+        )
         transaction_id = request.cookies.get(_COOKIE_NAME, "")
         transaction = self.transactions.get(transaction_id)
         if (
@@ -439,12 +460,20 @@ class Phase0OAuthWeb:
             or not hmac.compare_digest(form.get("csrf", ""), transaction.csrf_token)
             or transaction.created_at + _TRANSACTION_TTL <= int(time.time())
         ):
-            return _html_page("Authorization expired", "<h1>Authorization expired</h1>", status=400)
+            return _message_page(
+                "Authorization expired",
+                "Authorization expired / Autorisierung abgelaufen",
+                "Restart the connection from your MCP client. / Starten Sie die Verbindung in Ihrem MCP-Client neu.",
+                status=400,
+            )
         action = form.get("action")
         async with transaction.lock:
             if self.transactions.get(transaction_id) is not transaction:
-                return _html_page(
-                    "Authorization expired", "<h1>Authorization expired</h1>", status=400
+                return _message_page(
+                    "Authorization expired",
+                    "Authorization expired / Autorisierung abgelaufen",
+                    "Restart the connection from your MCP client. / Starten Sie die Verbindung in Ihrem MCP-Client neu.",
+                    status=400,
                 )
             if action == "login" and transaction.phase == "login":
                 transaction.phase = "login_pending"
@@ -455,25 +484,42 @@ class Phase0OAuthWeb:
                 and transaction.identity_id
                 and transaction.miniserver_id
             ):
+                grant_control = form.get("grant_control")
+                if grant_control not in {None, "true"} or (
+                    grant_control is not None and CONTROL_SCOPE not in transaction.scopes
+                ):
+                    return _message_page(
+                        "Invalid authorization request",
+                        "Invalid authorization request / Ungültige Autorisierungsanfrage",
+                        "Review the requested permissions and try again. / Prüfen Sie die angeforderten Berechtigungen und versuchen Sie es erneut.",
+                        status=400,
+                    )
+                approved_scopes: tuple[str, ...] = (READ_SCOPE,)
+                if grant_control == "true":
+                    approved_scopes = (READ_SCOPE, CONTROL_SCOPE)
                 transaction.phase = "approving"
                 family_id: str | None = None
                 if self.loxone_store is None:
                     if not await self._kill(transaction):
                         transaction.phase = "consent"
-                        return _html_page(
+                        return _message_page(
                             "Authorization unavailable",
-                            "<h1>Authorization unavailable</h1>",
+                            "Authorization unavailable / Autorisierung nicht verfügbar",
+                            "The authorization could not be completed. Try again. / Die Autorisierung konnte nicht abgeschlossen werden. Versuchen Sie es erneut.",
                             status=503,
+                            callback_uri=transaction.redirect_uri,
                         )
                 else:
                     family_id = secrets.token_hex(16)
                     token = transaction.loxone_token
                     if token is None:
                         transaction.phase = "consent"
-                        return _html_page(
+                        return _message_page(
                             "Authorization unavailable",
-                            "<h1>Authorization unavailable</h1>",
+                            "Authorization unavailable / Autorisierung nicht verfügbar",
+                            "The authorization could not be completed. Try again. / Die Autorisierung konnte nicht abgeschlossen werden. Versuchen Sie es erneut.",
                             status=503,
+                            callback_uri=transaction.redirect_uri,
                         )
                     try:
                         self.loxone_store.put(
@@ -484,10 +530,12 @@ class Phase0OAuthWeb:
                         )
                     except Exception:
                         transaction.phase = "consent"
-                        return _html_page(
+                        return _message_page(
                             "Authorization unavailable",
-                            "<h1>Authorization unavailable</h1>",
+                            "Authorization unavailable / Autorisierung nicht verfügbar",
+                            "The authorization could not be completed. Try again. / Die Autorisierung konnte nicht abgeschlossen werden. Versuchen Sie es erneut.",
                             status=503,
+                            callback_uri=transaction.redirect_uri,
                         )
                 try:
                     code = self.provider.issue_authorization_code(
@@ -497,17 +545,19 @@ class Phase0OAuthWeb:
                         resource=transaction.resource,
                         identity_id=transaction.identity_id,
                         miniserver_id=transaction.miniserver_id,
-                        scopes=transaction.scopes,
+                        scopes=approved_scopes,
                         family_id=family_id,
                     )
                 except TokenError:
                     if family_id is not None and self.loxone_store is not None:
                         self.loxone_store.delete(family_id)
                     transaction.phase = "consent"
-                    return _html_page(
+                    return _message_page(
                         "Authorization unavailable",
-                        "<h1>Authorization unavailable</h1>",
+                        "Authorization unavailable / Autorisierung nicht verfügbar",
+                        "The authorization could not be completed. Try again. / Die Autorisierung konnte nicht abgeschlossen werden. Versuchen Sie es erneut.",
                         status=503,
+                        callback_uri=transaction.redirect_uri,
                     )
                 transaction.loxone_token = None
                 transaction.phase = "finished"
@@ -522,10 +572,12 @@ class Phase0OAuthWeb:
                 transaction.phase = "denying"
                 if not await self._kill(transaction):
                     transaction.phase = "consent" if transaction.identity_id else "login"
-                    return _html_page(
+                    return _message_page(
                         "Authorization unavailable",
-                        "<h1>Authorization unavailable</h1>",
+                        "Authorization unavailable / Autorisierung nicht verfügbar",
+                        "The authorization could not be completed. Try again. / Die Autorisierung konnte nicht abgeschlossen werden. Versuchen Sie es erneut.",
                         status=503,
+                        callback_uri=transaction.redirect_uri,
                     )
                 transaction.phase = "finished"
                 self.transactions.pop(transaction_id, None)
@@ -535,8 +587,11 @@ class Phase0OAuthWeb:
                 )
                 response.delete_cookie(_COOKIE_NAME, path="/plugins/mcpserver/oauth/authorize")
                 return response
-        return _html_page(
-            "Invalid authorization request", "<h1>Invalid authorization request</h1>", status=400
+        return _message_page(
+            "Invalid authorization request",
+            "Invalid authorization request / Ungültige Autorisierungsanfrage",
+            "Restart the connection from your MCP client. / Starten Sie die Verbindung in Ihrem MCP-Client neu.",
+            status=400,
         )
 
     async def _login(self, transaction: LoginTransaction, form: Mapping[str, str]) -> Response:
@@ -544,16 +599,22 @@ class Phase0OAuthWeb:
         if transaction.attempts > _MAX_LOGIN_ATTEMPTS:
             self.transactions.pop(transaction.transaction_id, None)
             transaction.phase = "finished"
-            return _html_page("Authorization expired", "<h1>Authorization expired</h1>", status=429)
+            return _message_page(
+                "Authorization expired",
+                "Authorization expired / Autorisierung abgelaufen",
+                "Restart the connection from your MCP client. / Starten Sie die Verbindung in Ihrem MCP-Client neu.",
+                status=429,
+            )
         username = form.get("username", "")
         password = form.get("password", "")
         now = int(time.time())
         rate_keys = self._login_rate_keys(transaction, username)
         if self._login_is_limited(rate_keys, now):
             transaction.phase = "login"
-            return _html_page(
+            return _message_page(
                 "Sign-in temporarily unavailable",
-                "<h1>Sign-in temporarily unavailable / Anmeldung vorübergehend nicht verfügbar</h1>",
+                "Sign-in temporarily unavailable / Anmeldung vorübergehend nicht verfügbar",
+                "Try again later. / Versuchen Sie es später erneut.",
                 status=429,
             )
         if not username or len(username) > 128 or not password or len(password) > 1024:

--- a/src/mcpserver/server.py
+++ b/src/mcpserver/server.py
@@ -6,6 +6,7 @@ import logging
 from typing import Final
 
 from mcp.server.auth.provider import AccessToken, TokenVerifier
+from mcp.server.auth.routes import create_protected_resource_routes
 from mcp.server.auth.settings import AuthSettings
 from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecurityMiddleware, TransportSecuritySettings
@@ -111,9 +112,23 @@ class _ForwardedHostFastMCP(FastMCP):
     forwarded_allowed_hosts: tuple[str, ...] = ()
     transport_guard: TransportSecurityMiddleware | None = None
     service_enabled: bool = True
+    advertised_scopes: tuple[str, ...] = ()
 
     def streamable_http_app(self) -> Starlette:
         app = super().streamable_http_app()
+        auth = self.settings.auth
+        if self.advertised_scopes and auth and auth.resource_server_url:
+            metadata_route = create_protected_resource_routes(
+                resource_url=auth.resource_server_url,
+                authorization_servers=[auth.issuer_url],
+                scopes_supported=list(self.advertised_scopes),
+            )[0]
+            for index, route in enumerate(app.routes):
+                if getattr(route, "path", None) == metadata_route.path:
+                    app.routes[index] = metadata_route
+                    break
+            else:  # pragma: no cover - pinned SDK always creates this route
+                raise RuntimeError("OAuth protected resource metadata route is missing")
         app.router.redirect_slashes = False
         if not self.service_enabled:
             app.add_middleware(_DisabledServiceMiddleware)
@@ -216,6 +231,7 @@ def create_server(settings: ServerSettings) -> FastMCP:
         and settings.phase0_auth.plugin_config
         and settings.phase0_auth.plugin_config.loxone_control_enabled
     )
+    server.advertised_scopes = (READ_SCOPE,) + ((CONTROL_SCOPE,) if control_enabled else ())
     register_read_tools(server, runtime, control_enabled=control_enabled)
     if control_enabled:
         register_control_tool(server, runtime)

--- a/templates/index.html
+++ b/templates/index.html
@@ -81,7 +81,7 @@
     <div id="session-list">
     <TMPL_IF HAS_SESSIONS>
       <div class="mcp-table-wrap"><table class="mcp-table"><thead><tr><th><TMPL_VAR SESSIONS.CLIENT></th><th><TMPL_VAR SESSIONS.IDENTITY></th><th><TMPL_VAR SESSIONS.SCOPES></th><th><TMPL_VAR SESSIONS.EXPIRES></th><th><TMPL_VAR SESSIONS.ACTION></th></tr></thead><tbody>
-      <TMPL_LOOP SESSIONS><tr data-session-id="<TMPL_VAR id ESCAPE=HTML>"><td><code><TMPL_VAR client ESCAPE=HTML></code></td><td><code><TMPL_VAR identity ESCAPE=HTML></code></td><td><code><TMPL_VAR scopes ESCAPE=HTML></code></td><td><TMPL_VAR expires_at ESCAPE=HTML></td><td><form method="post" action="index.cgi" data-ajax="revoke_session"><input type="hidden" name="action" value="revoke_session"><input type="hidden" name="id" value="<TMPL_VAR id ESCAPE=HTML>"><button class="lb-button" type="submit"><TMPL_VAR ACTION.REVOKE></button></form></td></tr></TMPL_LOOP>
+      <TMPL_LOOP SESSIONS><tr data-session-id="<TMPL_VAR id ESCAPE=HTML>"><td><code><TMPL_VAR client ESCAPE=HTML></code></td><td><code><TMPL_VAR identity ESCAPE=HTML></code></td><td><code><TMPL_VAR scopes ESCAPE=HTML></code></td><td><time class="mcp-expiry" data-expires-at="<TMPL_VAR expires_at ESCAPE=HTML>"><TMPL_VAR expires_display ESCAPE=HTML></time></td><td><form method="post" action="index.cgi" data-ajax="revoke_session"><input type="hidden" name="action" value="revoke_session"><input type="hidden" name="id" value="<TMPL_VAR id ESCAPE=HTML>"><button class="lb-button" type="submit"><TMPL_VAR ACTION.REVOKE></button></form></td></tr></TMPL_LOOP>
       </tbody></table></div>
       <form method="post" action="index.cgi" data-ajax="revoke_all"><input type="hidden" name="action" value="revoke_all"><button class="lb-button" type="submit"><TMPL_VAR ACTION.REVOKE_ALL></button></form>
     <TMPL_ELSE><p><TMPL_VAR SESSIONS.EMPTY></p></TMPL_IF>
@@ -99,6 +99,18 @@
 <script>
 (() => {
   const status = document.getElementById('ajax-status');
+  const expiryFormatter = new Intl.DateTimeFormat(document.documentElement.lang || undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'medium',
+  });
+  for (const element of document.querySelectorAll('time.mcp-expiry')) {
+    const expiresAt = Number(element.dataset.expiresAt);
+    const date = new Date(expiresAt * 1000);
+    if (Number.isFinite(expiresAt) && !Number.isNaN(date.getTime())) {
+      element.dateTime = date.toISOString();
+      element.textContent = expiryFormatter.format(date);
+    }
+  }
   const hideStatusTimers = new WeakMap();
   const hideSuccess = (element) => {
     window.clearTimeout(hideStatusTimers.get(element));

--- a/tests/test_admin_ui.py
+++ b/tests/test_admin_ui.py
@@ -24,3 +24,17 @@ def test_common_actions_update_the_page_without_a_reload() -> None:
     assert "window.setTimeout(() => { element.hidden = true; }, 4000)" in template
     assert "window.clearTimeout(hideStatusTimers.get(status))" in template
     assert "url.searchParams.delete('notice')" in template
+
+
+def test_session_expiry_is_rendered_as_a_local_date_and_time() -> None:
+    cgi = (ROOT / "webfrontend/htmlauth/index.cgi").read_text(encoding="utf-8")
+    template = (ROOT / "templates/index.html").read_text(encoding="utf-8")
+
+    assert "strftime('%Y-%m-%d %H:%M:%S %Z', localtime(0 + $value))" in cgi
+    assert "$session->{expires_display} = format_expiry($session->{expires_at})" in cgi
+    assert 'class="mcp-expiry"' in template
+    assert 'data-expires-at="<TMPL_VAR expires_at ESCAPE=HTML>"' in template
+    assert "<TMPL_VAR expires_display ESCAPE=HTML>" in template
+    assert "new Intl.DateTimeFormat(document.documentElement.lang || undefined" in template
+    assert "element.textContent = expiryFormatter.format(date)" in template
+    assert "<td><TMPL_VAR expires_at ESCAPE=HTML></td>" not in template

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -5,6 +5,7 @@ import base64
 import hashlib
 from pathlib import Path
 from types import SimpleNamespace
+from urllib.parse import parse_qs, urlsplit
 
 import httpx
 import pytest
@@ -373,6 +374,117 @@ def test_metadata_advertises_only_the_public_contract(tmp_path: Path) -> None:
     assert response.json()["code_challenge_methods_supported"] == ["S256"]
     assert response.headers["cache-control"] == "no-store"
     assert response.headers["referrer-policy"] == "strict-origin"
+
+
+def test_consent_page_uses_one_permission_dialog_for_read_and_control(tmp_path: Path) -> None:
+    web = Phase0OAuthWeb(
+        _provider(tmp_path),
+        endpoint=MiniserverEndpoint.parse_gen1("http://192.168.255.254"),
+        issuer=ISSUER,
+        resource=RESOURCE,
+    )
+    transaction = LoginTransaction(
+        transaction_id="transaction",
+        csrf_token="csrf",
+        client_id="client",
+        client_name="Claude Code",
+        redirect_uri=REDIRECT,
+        state="state",
+        code_challenge=CHALLENGE,
+        resource=RESOURCE,
+        created_at=1_800_000_000,
+        scopes=(READ_SCOPE, CONTROL_SCOPE),
+        identity_name="user",
+        miniserver_name="miniserver",
+    )
+
+    response = web._consent_page(transaction)
+
+    assert response.status_code == 200
+    assert "Choose permissions / Berechtigungen auswählen" in response.body.decode()
+    assert 'type="checkbox" checked disabled' in response.body.decode()
+    assert 'name="grant_control" value="true"' in response.body.decode()
+    assert "Confirm permissions / Berechtigungen bestätigen" in response.body.decode()
+    assert "redirected to your MCP client" in response.body.decode()
+
+
+@pytest.mark.parametrize(
+    ("grant_control", "expected_scopes"),
+    [
+        (False, [READ_SCOPE]),
+        (True, [READ_SCOPE, CONTROL_SCOPE]),
+    ],
+)
+@pytest.mark.asyncio
+async def test_consent_issues_only_the_scopes_selected_by_the_user(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    grant_control: bool,
+    expected_scopes: list[str],
+) -> None:
+    provider = Phase0OAuthProvider(
+        AtomicJsonAuthStore(tmp_path / "auth" / "sessions.json"),
+        issuer=ISSUER,
+        resource=RESOURCE,
+        clock=Clock(),
+        control_enabled=True,
+    )
+    client_info = OAuthClientInformationFull(
+        client_id="control-client",
+        client_name="Claude Code",
+        redirect_uris=[AnyUrl(REDIRECT)],
+        token_endpoint_auth_method="none",
+        grant_types=["authorization_code", "refresh_token"],
+        response_types=["code"],
+        scope=f"{READ_SCOPE} {CONTROL_SCOPE}",
+    )
+    await provider.register_client(client_info)
+    web = Phase0OAuthWeb(
+        provider,
+        endpoint=MiniserverEndpoint.parse_gen1("http://192.168.255.254"),
+        issuer=ISSUER,
+        resource=RESOURCE,
+    )
+    transaction = LoginTransaction(
+        transaction_id="transaction",
+        csrf_token="csrf",
+        client_id="control-client",
+        client_name="Claude Code",
+        redirect_uri=REDIRECT,
+        state="client-state",
+        code_challenge=CHALLENGE,
+        resource=RESOURCE,
+        created_at=provider.now(),
+        scopes=(READ_SCOPE, CONTROL_SCOPE),
+        identity_id="identity",
+        miniserver_id="miniserver",
+        phase="consent",
+    )
+    web.transactions[transaction.transaction_id] = transaction
+
+    async def kill_token(selected: LoginTransaction) -> bool:
+        selected.loxone_token = None
+        return True
+
+    monkeypatch.setattr(web, "_kill", kill_token)
+    app = Starlette(routes=[Route("/authorize", web.authorize, methods=["POST"])])
+    data = {"csrf": "csrf", "action": "approve"}
+    if grant_control:
+        data["grant_control"] = "true"
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="https://public.example",
+        follow_redirects=False,
+        headers={"Cookie": "phase0_oauth_tx=transaction"},
+    ) as client:
+        approved = await client.post("/authorize", data=data)
+
+    code_value = parse_qs(urlsplit(approved.headers["location"]).query)["code"][0]
+    code = await provider.load_authorization_code(client_info, code_value)
+    assert approved.status_code == 302
+    assert code is not None
+    assert code.scopes == expected_scopes
 
 
 @pytest.mark.parametrize(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import pytest
 from starlette.testclient import TestClient
 
+from mcpserver.auth.provider import CONTROL_SCOPE, READ_SCOPE
+from mcpserver.config import PluginConfig
 from mcpserver.loxone.client import MiniserverEndpoint
 from mcpserver.server import create_server
 from mcpserver.settings import Phase0AuthSettings, ServerSettings
@@ -231,5 +233,34 @@ def test_oauth_routes_and_protected_resource_metadata_are_exact(tmp_path: Path) 
     assert resource.json()["authorization_servers"] == [
         "https://public.example/plugins/mcpserver/oauth"
     ]
+    assert resource.json()["scopes_supported"] == [READ_SCOPE]
     assert unauthenticated.status_code == 401
     assert all(response.status_code == 404 for response in aliases)
+
+
+def test_protected_resource_metadata_advertises_optional_control_scope(tmp_path: Path) -> None:
+    settings = ServerSettings(
+        host="127.0.0.1",
+        port=8765,
+        allowed_hosts=("testserver",),
+        allowed_origins=(),
+        phase0_auth=Phase0AuthSettings(
+            public_origin="https://public.example",
+            store_path=tmp_path / "sessions.json",
+            loxone_endpoint=MiniserverEndpoint.parse_gen1("http://192.168.255.254"),
+            plugin_config=PluginConfig(loxone_control_enabled=True),
+        ),
+    )
+    app = create_server(settings).streamable_http_app()
+    with TestClient(app, base_url="http://testserver") as client:
+        resource = client.get("/.well-known/oauth-protected-resource/plugins/mcpserver/mcp")
+        unauthenticated = client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+            headers={"Accept": "application/json, text/event-stream"},
+        )
+
+    assert resource.status_code == 200
+    assert resource.json()["scopes_supported"] == [READ_SCOPE, CONTROL_SCOPE]
+    assert unauthenticated.status_code == 401
+    assert "scope=" not in unauthenticated.headers["www-authenticate"]

--- a/webfrontend/htmlauth/index.cgi
+++ b/webfrontend/htmlauth/index.cgi
@@ -6,6 +6,7 @@ use CGI;
 use HTML::Template;
 use IPC::Open3;
 use JSON::PP qw(decode_json encode_json);
+use POSIX qw(strftime);
 use Symbol qw(gensym);
 use LoxBerry::System;
 use LoxBerry::Web;
@@ -137,10 +138,20 @@ my $template = HTML::Template->new_scalar_ref(
 );
 my %L = LoxBerry::System::readlanguage($template, 'language.ini');
 
+sub format_expiry {
+    my ($value) = @_;
+    return '' if !defined($value) || "$value" !~ /\A\d+\z/;
+    return strftime('%Y-%m-%d %H:%M:%S %Z', localtime(0 + $value));
+}
+
 my $page_result = admin_call('page_state', {});
 my $page_state = $page_result->{ok} ? $page_result->{data} : {};
 my $config = $page_state->{configuration} // {};
 my $sessions = $page_state->{sessions} // [];
+for my $session (@$sessions) {
+    next if ref($session) ne 'HASH';
+    $session->{expires_display} = format_expiry($session->{expires_at});
+}
 $config->{server} = {} if ref($config->{server}) ne 'HASH';
 $config->{loxone} = {} if ref($config->{loxone}) ne 'HASH';
 $config->{tools} = {} if ref($config->{tools}) ne 'HASH';


### PR DESCRIPTION
## Summary

- advertise the optional `loxone:control` scope while control is enabled without making it mandatory for read-only MCP access
- replace the single-scope consent prompt with one bilingual permission dialog: required read access and optional Loxone control
- issue exactly the scopes selected by the user and keep all server-owned login, consent, and error messages in one responsive presentation
- synchronize the German and English user, Claude Desktop, ChatGPT Desktop, and architecture documentation
- document that the final loopback callback page is owned by the MCP client and cannot be styled by the plugin

## Root cause

The protected-resource metadata exposed only the endpoint's mandatory `loxone:read` scope. Current clients therefore did not request the optional control scope, and the existing consent page could only approve the complete requested scope set.

## Validation

- `PYTHONPATH=src .venv/Scripts/python.exe tools/test.py`: Ruff, mypy, and 208 tests passed
- targeted OAuth/server suite: 53 tests passed
- responsive browser acceptance at 1280x800, 900x768, 390x844, 360x800, and 320x568; no horizontal overflow and both permission controls/actions remained reachable
- diagnostic hot-swap of the two changed runtime files on the configured Loxberry-Test target: deployed hashes matched, service active, and loopback health check passed; configuration, sessions, and Miniserver state were unchanged

The hot-swap is runtime smoke evidence only. It is not a native Plugin Manager upgrade or lifecycle acceptance, and real Claude end-to-end acceptance remains open.