### PR TITLE
Separate session expiry formatting from OAuth change

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -81,7 +81,7 @@
     <div id="session-list">
     <TMPL_IF HAS_SESSIONS>
       <div class="mcp-table-wrap"><table class="mcp-table"><thead><tr><th><TMPL_VAR SESSIONS.CLIENT></th><th><TMPL_VAR SESSIONS.IDENTITY></th><th><TMPL_VAR SESSIONS.SCOPES></th><th><TMPL_VAR SESSIONS.EXPIRES></th><th><TMPL_VAR SESSIONS.ACTION></th></tr></thead><tbody>
-      <TMPL_LOOP SESSIONS><tr data-session-id="<TMPL_VAR id ESCAPE=HTML>"><td><code><TMPL_VAR client ESCAPE=HTML></code></td><td><code><TMPL_VAR identity ESCAPE=HTML></code></td><td><code><TMPL_VAR scopes ESCAPE=HTML></code></td><td><time class="mcp-expiry" data-expires-at="<TMPL_VAR expires_at ESCAPE=HTML>"><TMPL_VAR expires_display ESCAPE=HTML></time></td><td><form method="post" action="index.cgi" data-ajax="revoke_session"><input type="hidden" name="action" value="revoke_session"><input type="hidden" name="id" value="<TMPL_VAR id ESCAPE=HTML>"><button class="lb-button" type="submit"><TMPL_VAR ACTION.REVOKE></button></form></td></tr></TMPL_LOOP>
+      <TMPL_LOOP SESSIONS><tr data-session-id="<TMPL_VAR id ESCAPE=HTML>"><td><code><TMPL_VAR client ESCAPE=HTML></code></td><td><code><TMPL_VAR identity ESCAPE=HTML></code></td><td><code><TMPL_VAR scopes ESCAPE=HTML></code></td><td><TMPL_VAR expires_at ESCAPE=HTML></td><td><form method="post" action="index.cgi" data-ajax="revoke_session"><input type="hidden" name="action" value="revoke_session"><input type="hidden" name="id" value="<TMPL_VAR id ESCAPE=HTML>"><button class="lb-button" type="submit"><TMPL_VAR ACTION.REVOKE></button></form></td></tr></TMPL_LOOP>
       </tbody></table></div>
       <form method="post" action="index.cgi" data-ajax="revoke_all"><input type="hidden" name="action" value="revoke_all"><button class="lb-button" type="submit"><TMPL_VAR ACTION.REVOKE_ALL></button></form>
     <TMPL_ELSE><p><TMPL_VAR SESSIONS.EMPTY></p></TMPL_IF>
@@ -99,18 +99,6 @@
 <script>
 (() => {
   const status = document.getElementById('ajax-status');
-  const expiryFormatter = new Intl.DateTimeFormat(document.documentElement.lang || undefined, {
-    dateStyle: 'medium',
-    timeStyle: 'medium',
-  });
-  for (const element of document.querySelectorAll('time.mcp-expiry')) {
-    const expiresAt = Number(element.dataset.expiresAt);
-    const date = new Date(expiresAt * 1000);
-    if (Number.isFinite(expiresAt) && !Number.isNaN(date.getTime())) {
-      element.dateTime = date.toISOString();
-      element.textContent = expiryFormatter.format(date);
-    }
-  }
   const hideStatusTimers = new WeakMap();
   const hideSuccess = (element) => {
     window.clearTimeout(hideStatusTimers.get(element));

--- a/tests/test_admin_ui.py
+++ b/tests/test_admin_ui.py
@@ -24,17 +24,3 @@ def test_common_actions_update_the_page_without_a_reload() -> None:
     assert "window.setTimeout(() => { element.hidden = true; }, 4000)" in template
     assert "window.clearTimeout(hideStatusTimers.get(status))" in template
     assert "url.searchParams.delete('notice')" in template
-
-
-def test_session_expiry_is_rendered_as_a_local_date_and_time() -> None:
-    cgi = (ROOT / "webfrontend/htmlauth/index.cgi").read_text(encoding="utf-8")
-    template = (ROOT / "templates/index.html").read_text(encoding="utf-8")
-
-    assert "strftime('%Y-%m-%d %H:%M:%S %Z', localtime(0 + $value))" in cgi
-    assert "$session->{expires_display} = format_expiry($session->{expires_at})" in cgi
-    assert 'class="mcp-expiry"' in template
-    assert 'data-expires-at="<TMPL_VAR expires_at ESCAPE=HTML>"' in template
-    assert "<TMPL_VAR expires_display ESCAPE=HTML>" in template
-    assert "new Intl.DateTimeFormat(document.documentElement.lang || undefined" in template
-    assert "element.textContent = expiryFormatter.format(date)" in template
-    assert "<td><TMPL_VAR expires_at ESCAPE=HTML></td>" not in template

--- a/webfrontend/htmlauth/index.cgi
+++ b/webfrontend/htmlauth/index.cgi
@@ -6,7 +6,6 @@ use CGI;
 use HTML::Template;
 use IPC::Open3;
 use JSON::PP qw(decode_json encode_json);
-use POSIX qw(strftime);
 use Symbol qw(gensym);
 use LoxBerry::System;
 use LoxBerry::Web;
@@ -138,20 +137,10 @@ my $template = HTML::Template->new_scalar_ref(
 );
 my %L = LoxBerry::System::readlanguage($template, 'language.ini');
 
-sub format_expiry {
-    my ($value) = @_;
-    return '' if !defined($value) || "$value" !~ /\A\d+\z/;
-    return strftime('%Y-%m-%d %H:%M:%S %Z', localtime(0 + $value));
-}
-
 my $page_result = admin_call('page_state', {});
 my $page_state = $page_result->{ok} ? $page_result->{data} : {};
 my $config = $page_state->{configuration} // {};
 my $sessions = $page_state->{sessions} // [];
-for my $session (@$sessions) {
-    next if ref($session) ne 'HASH';
-    $session->{expires_display} = format_expiry($session->{expires_at});
-}
 $config->{server} = {} if ref($config->{server}) ne 'HASH';
 $config->{loxone} = {} if ref($config->{loxone}) ne 'HASH';
 $config->{tools} = {} if ref($config->{tools}) ne 'HASH';


### PR DESCRIPTION
## Summary

- remove the unrelated session-expiry formatting that was accidentally included in PR #16
- restore the three admin UI files to their pre-PR #16 behavior
- keep the OAuth consent dialog change from PR #16 unchanged

## Reason

The session-expiry formatting is a separate UI change and must be reviewed in its own pull request.

## Validation

- exact file comparison against the pre-PR #16 base for the three affected files
- `python -m pytest tests/test_admin_ui.py -q`: 2 passed
- `git diff --check`: passed