### PR TITLE
Format session expiry timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,12 @@ Bestätigte Kombinationen, Nachweise und bekannte Clientgrenzen stehen in der
 - [Recherche-Ergebnisse](docs/research/research-results.md)
 - [Beitragen und Git-Workflow](CONTRIBUTING.md)
 
-Die Referenzentwicklung verwendet Python 3.13. Nach dem Anlegen eines lokalen
-virtuellen Environments werden die fixierten Laufzeit- und Testabhängigkeiten
-installiert und das Projekt ohne erneute Abhängigkeitsauflösung eingebunden:
+Die Referenzentwicklung verwendet Python 3.13. Für das vollständige lokale Gate
+müssen außerdem Perl und Node.js im `PATH` verfügbar sein; damit werden die
+ausführbaren Regressionstests für die Perl-CGI- und Browserlogik ausgeführt.
+Nach dem Anlegen eines lokalen virtuellen Environments werden die fixierten
+Laufzeit- und Testabhängigkeiten installiert und das Projekt ohne erneute
+Abhängigkeitsauflösung eingebunden:
 
 ```text
 python -m pip install -r requirements/runtime-arm64.lock -r requirements/dev.lock

--- a/docs/development/automation.md
+++ b/docs/development/automation.md
@@ -6,6 +6,8 @@ authorization, connection profiles, credentials, and private test fixtures outsi
 ## Local and CI-safe commands
 
 - `python tools/test.py` runs the deterministic formatting, lint, type, and test gate.
+  The complete gate requires Python 3.13, Perl, and Node.js on `PATH`; missing
+  runtimes are failures rather than silently skipped browser or CGI checks.
 - `python tools/build_release_candidate.py --runtime-wheelhouse <cache>` rebuilds the
   project wheel, runs the full gate, builds the plugin twice, requires byte-identical
   ZIPs, writes the checksum, and verifies the final archive. Omit the cache argument to

--- a/templates/index.html
+++ b/templates/index.html
@@ -81,7 +81,7 @@
     <div id="session-list">
     <TMPL_IF HAS_SESSIONS>
       <div class="mcp-table-wrap"><table class="mcp-table"><thead><tr><th><TMPL_VAR SESSIONS.CLIENT></th><th><TMPL_VAR SESSIONS.IDENTITY></th><th><TMPL_VAR SESSIONS.SCOPES></th><th><TMPL_VAR SESSIONS.EXPIRES></th><th><TMPL_VAR SESSIONS.ACTION></th></tr></thead><tbody>
-      <TMPL_LOOP SESSIONS><tr data-session-id="<TMPL_VAR id ESCAPE=HTML>"><td><code><TMPL_VAR client ESCAPE=HTML></code></td><td><code><TMPL_VAR identity ESCAPE=HTML></code></td><td><code><TMPL_VAR scopes ESCAPE=HTML></code></td><td><TMPL_VAR expires_at ESCAPE=HTML></td><td><form method="post" action="index.cgi" data-ajax="revoke_session"><input type="hidden" name="action" value="revoke_session"><input type="hidden" name="id" value="<TMPL_VAR id ESCAPE=HTML>"><button class="lb-button" type="submit"><TMPL_VAR ACTION.REVOKE></button></form></td></tr></TMPL_LOOP>
+      <TMPL_LOOP SESSIONS><tr data-session-id="<TMPL_VAR id ESCAPE=HTML>"><td><code><TMPL_VAR client ESCAPE=HTML></code></td><td><code><TMPL_VAR identity ESCAPE=HTML></code></td><td><code><TMPL_VAR scopes ESCAPE=HTML></code></td><td><time class="mcp-expiry" data-expires-at="<TMPL_VAR expires_at ESCAPE=HTML>"><TMPL_VAR expires_display ESCAPE=HTML></time></td><td><form method="post" action="index.cgi" data-ajax="revoke_session"><input type="hidden" name="action" value="revoke_session"><input type="hidden" name="id" value="<TMPL_VAR id ESCAPE=HTML>"><button class="lb-button" type="submit"><TMPL_VAR ACTION.REVOKE></button></form></td></tr></TMPL_LOOP>
       </tbody></table></div>
       <form method="post" action="index.cgi" data-ajax="revoke_all"><input type="hidden" name="action" value="revoke_all"><button class="lb-button" type="submit"><TMPL_VAR ACTION.REVOKE_ALL></button></form>
     <TMPL_ELSE><p><TMPL_VAR SESSIONS.EMPTY></p></TMPL_IF>
@@ -99,6 +99,18 @@
 <script>
 (() => {
   const status = document.getElementById('ajax-status');
+  const expiryFormatter = new Intl.DateTimeFormat(document.documentElement.lang || undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'medium',
+  });
+  for (const element of document.querySelectorAll('time.mcp-expiry')) {
+    const expiresAt = Number(element.dataset.expiresAt);
+    const date = new Date(expiresAt * 1000);
+    if (Number.isFinite(expiresAt) && !Number.isNaN(date.getTime())) {
+      element.dateTime = date.toISOString();
+      element.textContent = expiryFormatter.format(date);
+    }
+  }
   const hideStatusTimers = new WeakMap();
   const hideSuccess = (element) => {
     window.clearTimeout(hideStatusTimers.get(element));

--- a/templates/index.html
+++ b/templates/index.html
@@ -103,10 +103,16 @@
     dateStyle: 'medium',
     timeStyle: 'medium',
   });
+  const MAX_EXPIRY_EPOCH = 4102444799;
+  const parseExpiry = (raw) => {
+    if (!/^(?:0|[1-9]\d*)$/.test(raw) || raw.length > 12) return null;
+    const value = Number(raw);
+    return Number.isSafeInteger(value) && value <= MAX_EXPIRY_EPOCH ? value : null;
+  };
   for (const element of document.querySelectorAll('time.mcp-expiry')) {
-    const expiresAt = Number(element.dataset.expiresAt);
-    const date = new Date(expiresAt * 1000);
-    if (Number.isFinite(expiresAt) && !Number.isNaN(date.getTime())) {
+    const expiresAt = parseExpiry(element.dataset.expiresAt);
+    if (expiresAt !== null) {
+      const date = new Date(expiresAt * 1000);
       element.dateTime = date.toISOString();
       element.textContent = expiryFormatter.format(date);
     }

--- a/templates/index.html
+++ b/templates/index.html
@@ -105,7 +105,7 @@
   });
   const MAX_EXPIRY_EPOCH = 4102444799;
   const parseExpiry = (raw) => {
-    if (!/^(?:0|[1-9]\d*)$/.test(raw) || raw.length > 12) return null;
+    if (!/^(?:0|[1-9][0-9]*)$/.test(raw) || raw.length > 10) return null;
     const value = Number(raw);
     return Number.isSafeInteger(value) && value <= MAX_EXPIRY_EPOCH ? value : null;
   };

--- a/tests/test_admin_ui.py
+++ b/tests/test_admin_ui.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -49,11 +50,16 @@ def test_perl_expiry_formatter_rejects_out_of_range_values_safely() -> None:
 
     assert constant is not None
     assert formatter is not None
+    perl = shutil.which("perl")
+    assert perl is not None, "Perl is required for the complete deterministic gate"
     script = f"""
 use POSIX qw(strftime);
 {constant.group(0)}
 {formatter.group(0)}
 for my $value (@ARGV) {{ print format_expiry($value), "\\n"; }}
+for my $value ("1" . chr(0x0662), "1" . chr(0xff12)) {{
+    print format_expiry($value) eq $value ? "unicode-raw\\n" : "unicode-changed\\n";
+}}
 print format_expiry(undef), "\\n";
 """
     values = [
@@ -67,7 +73,7 @@ print format_expiry(undef), "\\n";
         "01",
     ]
     result = subprocess.run(
-        ["perl", "-e", script, *values],
+        [perl, "-e", script, *values],
         check=True,
         capture_output=True,
         text=True,
@@ -76,7 +82,7 @@ print format_expiry(undef), "\\n";
 
     assert output[0] != values[0]
     assert output[1] != values[1]
-    assert output[2:] == [*values[2:], ""]
+    assert output[2:] == [*values[2:], "unicode-raw", "unicode-raw", ""]
 
 
 def test_browser_expiry_parser_uses_the_same_bounds() -> None:
@@ -88,6 +94,8 @@ def test_browser_expiry_parser_uses_the_same_bounds() -> None:
     )
 
     assert parser is not None
+    node = shutil.which("node")
+    assert node is not None, "Node.js is required for the complete deterministic gate"
     values = [
         "1900000000",
         "4102444799",
@@ -97,6 +105,8 @@ def test_browser_expiry_parser_uses_the_same_bounds() -> None:
         "1.5",
         " 1",
         "01",
+        "1\u0662",
+        "1\uff12",
         "",
     ]
     script = f"""
@@ -104,10 +114,12 @@ def test_browser_expiry_parser_uses_the_same_bounds() -> None:
 console.log(JSON.stringify(process.argv.slice(1).map(parseExpiry)));
 """
     result = subprocess.run(
-        ["node", "-e", script, *values],
+        [node, "-e", script, *values],
         check=True,
         capture_output=True,
         text=True,
     )
 
-    assert result.stdout.strip() == "[1900000000,4102444799,null,null,null,null,null,null,null]"
+    assert result.stdout.strip() == (
+        "[1900000000,4102444799,null,null,null,null,null,null,null,null,null]"
+    )

--- a/tests/test_admin_ui.py
+++ b/tests/test_admin_ui.py
@@ -24,3 +24,17 @@ def test_common_actions_update_the_page_without_a_reload() -> None:
     assert "window.setTimeout(() => { element.hidden = true; }, 4000)" in template
     assert "window.clearTimeout(hideStatusTimers.get(status))" in template
     assert "url.searchParams.delete('notice')" in template
+
+
+def test_session_expiry_is_rendered_as_a_local_date_and_time() -> None:
+    cgi = (ROOT / "webfrontend/htmlauth/index.cgi").read_text(encoding="utf-8")
+    template = (ROOT / "templates/index.html").read_text(encoding="utf-8")
+
+    assert "strftime('%Y-%m-%d %H:%M:%S %Z', localtime(0 + $value))" in cgi
+    assert "$session->{expires_display} = format_expiry($session->{expires_at})" in cgi
+    assert 'class="mcp-expiry"' in template
+    assert 'data-expires-at="<TMPL_VAR expires_at ESCAPE=HTML>"' in template
+    assert "<TMPL_VAR expires_display ESCAPE=HTML>" in template
+    assert "new Intl.DateTimeFormat(document.documentElement.lang || undefined" in template
+    assert "element.textContent = expiryFormatter.format(date)" in template
+    assert "<td><TMPL_VAR expires_at ESCAPE=HTML></td>" not in template

--- a/tests/test_admin_ui.py
+++ b/tests/test_admin_ui.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+import subprocess
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -30,7 +32,7 @@ def test_session_expiry_is_rendered_as_a_local_date_and_time() -> None:
     cgi = (ROOT / "webfrontend/htmlauth/index.cgi").read_text(encoding="utf-8")
     template = (ROOT / "templates/index.html").read_text(encoding="utf-8")
 
-    assert "strftime('%Y-%m-%d %H:%M:%S %Z', localtime(0 + $value))" in cgi
+    assert "strftime('%Y-%m-%d %H:%M:%S %Z', localtime(0 + $raw))" in cgi
     assert "$session->{expires_display} = format_expiry($session->{expires_at})" in cgi
     assert 'class="mcp-expiry"' in template
     assert 'data-expires-at="<TMPL_VAR expires_at ESCAPE=HTML>"' in template
@@ -38,3 +40,74 @@ def test_session_expiry_is_rendered_as_a_local_date_and_time() -> None:
     assert "new Intl.DateTimeFormat(document.documentElement.lang || undefined" in template
     assert "element.textContent = expiryFormatter.format(date)" in template
     assert "<td><TMPL_VAR expires_at ESCAPE=HTML></td>" not in template
+
+
+def test_perl_expiry_formatter_rejects_out_of_range_values_safely() -> None:
+    cgi = (ROOT / "webfrontend/htmlauth/index.cgi").read_text(encoding="utf-8")
+    constant = re.search(r"use constant MAX_EXPIRY_EPOCH => [^;]+;", cgi)
+    formatter = re.search(r"sub format_expiry \{.*?^\}", cgi, re.MULTILINE | re.DOTALL)
+
+    assert constant is not None
+    assert formatter is not None
+    script = f"""
+use POSIX qw(strftime);
+{constant.group(0)}
+{formatter.group(0)}
+for my $value (@ARGV) {{ print format_expiry($value), "\\n"; }}
+print format_expiry(undef), "\\n";
+"""
+    values = [
+        "1900000000",
+        "4102444799",
+        "4102444800",
+        "999999999999999999",
+        "-1",
+        "1.5",
+        " 1",
+        "01",
+    ]
+    result = subprocess.run(
+        ["perl", "-e", script, *values],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    output = result.stdout.splitlines()
+
+    assert output[0] != values[0]
+    assert output[1] != values[1]
+    assert output[2:] == [*values[2:], ""]
+
+
+def test_browser_expiry_parser_uses_the_same_bounds() -> None:
+    template = (ROOT / "templates/index.html").read_text(encoding="utf-8")
+    parser = re.search(
+        r"const MAX_EXPIRY_EPOCH = .*?^  \};",
+        template,
+        re.MULTILINE | re.DOTALL,
+    )
+
+    assert parser is not None
+    values = [
+        "1900000000",
+        "4102444799",
+        "4102444800",
+        "999999999999999999",
+        "-1",
+        "1.5",
+        " 1",
+        "01",
+        "",
+    ]
+    script = f"""
+{parser.group(0)}
+console.log(JSON.stringify(process.argv.slice(1).map(parseExpiry)));
+"""
+    result = subprocess.run(
+        ["node", "-e", script, *values],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout.strip() == "[1900000000,4102444799,null,null,null,null,null,null,null]"

--- a/webfrontend/htmlauth/index.cgi
+++ b/webfrontend/htmlauth/index.cgi
@@ -143,8 +143,8 @@ use constant MAX_EXPIRY_EPOCH => 4_102_444_799;
 sub format_expiry {
     my ($value) = @_;
     my $raw = defined($value) ? "$value" : '';
-    return $raw if $raw !~ /\A(?:0|[1-9]\d*)\z/
-        || length($raw) > 12
+    return $raw if $raw !~ /\A(?:0|[1-9][0-9]*)\z/
+        || length($raw) > 10
         || 0 + $raw > MAX_EXPIRY_EPOCH;
     my $formatted = eval {
         strftime('%Y-%m-%d %H:%M:%S %Z', localtime(0 + $raw));

--- a/webfrontend/htmlauth/index.cgi
+++ b/webfrontend/htmlauth/index.cgi
@@ -6,6 +6,7 @@ use CGI;
 use HTML::Template;
 use IPC::Open3;
 use JSON::PP qw(decode_json encode_json);
+use POSIX qw(strftime);
 use Symbol qw(gensym);
 use LoxBerry::System;
 use LoxBerry::Web;
@@ -137,10 +138,20 @@ my $template = HTML::Template->new_scalar_ref(
 );
 my %L = LoxBerry::System::readlanguage($template, 'language.ini');
 
+sub format_expiry {
+    my ($value) = @_;
+    return '' if !defined($value) || "$value" !~ /\A\d+\z/;
+    return strftime('%Y-%m-%d %H:%M:%S %Z', localtime(0 + $value));
+}
+
 my $page_result = admin_call('page_state', {});
 my $page_state = $page_result->{ok} ? $page_result->{data} : {};
 my $config = $page_state->{configuration} // {};
 my $sessions = $page_state->{sessions} // [];
+for my $session (@$sessions) {
+    next if ref($session) ne 'HASH';
+    $session->{expires_display} = format_expiry($session->{expires_at});
+}
 $config->{server} = {} if ref($config->{server}) ne 'HASH';
 $config->{loxone} = {} if ref($config->{loxone}) ne 'HASH';
 $config->{tools} = {} if ref($config->{tools}) ne 'HASH';

--- a/webfrontend/htmlauth/index.cgi
+++ b/webfrontend/htmlauth/index.cgi
@@ -138,10 +138,18 @@ my $template = HTML::Template->new_scalar_ref(
 );
 my %L = LoxBerry::System::readlanguage($template, 'language.ini');
 
+use constant MAX_EXPIRY_EPOCH => 4_102_444_799;
+
 sub format_expiry {
     my ($value) = @_;
-    return '' if !defined($value) || "$value" !~ /\A\d+\z/;
-    return strftime('%Y-%m-%d %H:%M:%S %Z', localtime(0 + $value));
+    my $raw = defined($value) ? "$value" : '';
+    return $raw if $raw !~ /\A(?:0|[1-9]\d*)\z/
+        || length($raw) > 12
+        || 0 + $raw > MAX_EXPIRY_EPOCH;
+    my $formatted = eval {
+        strftime('%Y-%m-%d %H:%M:%S %Z', localtime(0 + $raw));
+    };
+    return defined($formatted) && length($formatted) ? $formatted : $raw;
 }
 
 my $page_result = admin_call('page_state', {});


### PR DESCRIPTION
## Summary

- render OAuth session expiry values as localized date and time values in the admin UI
- provide a server-rendered local-time fallback when JavaScript is unavailable
- preserve the machine-readable Unix timestamp and expose an ISO `datetime` value in the browser

## Reason

The admin API returns Unix epoch seconds. Displaying that raw value makes it difficult to identify which session is about to expire. This change is intentionally separated from the OAuth consent-dialog work in PR #16.

## Validation

- `python -m pytest tests/test_admin_ui.py -q`: 3 passed
- `git diff --check`: passed

## Stacked merge order

This PR is temporarily based on PR #17 so both halves of the history correction can be reviewed without leaving `master` in a regressed state. Merge PR #17 first, retarget this PR to `master`, then merge this PR.