### PR TITLE
Clarify Miniserver access selection

### DIFF
--- a/docs/clients/chatgpt-codex-desktop.de.md
+++ b/docs/clients/chatgpt-codex-desktop.de.md
@@ -23,9 +23,9 @@ Miniservers. Trage keine Zugangsdaten in die URL ein.
 
 Entscheide außerdem vor der Anmeldung, welche Rechte benötigt werden:
 
-- Ist **Loxone-Steuerung** im Plugin deaktiviert, wird nur der Lesezugriff
+- Ist im Plugin **Nur lesen** ausgewählt, wird nur der Lesezugriff
   `loxone:read` angeboten.
-- Ist **Loxone-Steuerung** aktiviert, bietet der Server zusätzlich
+- Ist **Lesen und schalten** ausgewählt, bietet der Server zusätzlich
   `loxone:control` an. Die Desktop-App bevorzugt die vom Server angebotenen
   Scopes und fordert deshalb bei einer neuen Anmeldung beide Rechte an.
 
@@ -56,8 +56,8 @@ Desktop-App die verbundenen MCP-Server kontrollieren.
 
 ## Lese- und Schreibrechte verstehen
 
-Wenn die Loxone-Steuerung im Plugin aktiviert ist, fordert die Desktop-App bei
-der Authentifizierung beide Scopes an:
+Wenn im Plugin **Lesen und schalten** ausgewählt ist, fordert die Desktop-App
+bei der Authentifizierung beide Scopes an:
 
 ```text
 loxone:read loxone:control
@@ -75,7 +75,7 @@ Die Schreibrechte werden nicht nachträglich still hinzugefügt: Sie müssen auf
 der Browser-Freigabeseite ausgewählt und dort bestätigt werden. Für reinen
 Lesezugriff lässt du die optionale Checkbox deaktiviert.
 
-Beim späteren Deaktivieren der Loxone-Steuerung widerruft das Plugin bestehende
+Beim späteren Wechsel auf **Nur lesen** widerruft das Plugin bestehende
 Control-Sitzungen. Authentifiziere die Desktop-App danach erneut, um eine reine
 Read-only-Sitzung zu erhalten.
 

--- a/docs/clients/chatgpt-codex-desktop.en.md
+++ b/docs/clients/chatgpt-codex-desktop.en.md
@@ -23,9 +23,9 @@ credentials in the URL.
 
 Also decide which permissions are needed before authentication:
 
-- When **Loxone control** is disabled in the plugin, the server offers only
+- When **Read only** is selected in the plugin, the server offers only
   `loxone:read`.
-- When **Loxone control** is enabled, the server also advertises
+- When **Read and switch** is selected, the server also advertises
   `loxone:control`. The desktop app prefers the server-advertised scopes and
   therefore requests both permissions during a new login.
 
@@ -55,8 +55,8 @@ inspect connected MCP servers.
 
 ## Understand read and write access
 
-When Loxone control is enabled in the plugin, the desktop app requests both
-scopes during authentication:
+When **Read and switch** is selected in the plugin, the desktop app requests
+both scopes during authentication:
 
 ```text
 loxone:read loxone:control
@@ -72,8 +72,9 @@ Write access is not silently added later: it must be selected and approved on
 the browser consent page. For read-only access, leave the optional checkbox
 clear.
 
-If Loxone control is disabled later, the plugin revokes existing control
-sessions. Authenticate the desktop app again to obtain a read-only session.
+If the setting is later changed to **Read only**, the plugin revokes existing
+control sessions. Authenticate the desktop app again to obtain a read-only
+session.
 
 ## Troubleshooting
 

--- a/docs/clients/claude-desktop.de.md
+++ b/docs/clients/claude-desktop.de.md
@@ -127,9 +127,9 @@ Freigabeseite im Browser.
 > vollständigen Claude-Test von Registrierung, Freigabe und Werkzeugaufruf
 > bestätigt. Der dokumentierte und geprüfte Standard bleibt Read-only.
 
-Dieser Abschnitt gilt nur, wenn die kontrollierte Gen.-1-Switch-Steuerung in der
-Plugin-Oberfläche bewusst aktiviert wurde. Für normalen Lesezugriff ist er nicht
-erforderlich.
+Dieser Abschnitt gilt nur, wenn in der Plugin-Oberfläche unter **Zugriff auf den
+Miniserver über den MCP Server** bewusst **Lesen und schalten** gewählt wurde.
+Für normalen Lesezugriff ist er nicht erforderlich.
 
 Die Steuerung benötigt immer beide Scopes:
 
@@ -140,7 +140,7 @@ loxone:read loxone:control
 `loxone:control` allein ist ungültig. Bestehende Read-only-Sitzungen erhalten
 den zusätzlichen Scope nicht automatisch.
 
-1. Aktiviere **Loxone-Steuerung** im Plugin und speichere die Konfiguration.
+1. Wähle im Plugin **Lesen und schalten** und speichere die Konfiguration.
 2. Erstelle den lokalen Ordner `C:\Users\Public\LoxBerryMCP` und darin die Datei
    `loxberry-oauth-client.json` mit diesem Inhalt:
 

--- a/docs/clients/claude-desktop.de.md
+++ b/docs/clients/claude-desktop.de.md
@@ -180,7 +180,7 @@ den zusätzlichen Scope nicht automatisch.
    die Auswahlmöglichkeit, verwende die Steuerung nicht und bleibe bei der
    geprüften Read-only-Einrichtung.
 
-Wird die Steuerung später im Plugin deaktiviert, werden Sitzungen mit
+Wird im Plugin später **Nur lesen** ausgewählt, werden Sitzungen mit
 `loxone:control` widerrufen. Für erneuten reinen Lesezugriff entfernst du die
 beiden Metadatenargumente wieder und verbindest Claude neu.
 

--- a/docs/clients/claude-desktop.en.md
+++ b/docs/clients/claude-desktop.en.md
@@ -173,9 +173,9 @@ additional scope automatically.
    intended. If the option is missing, do not use control and stay with the
    tested read-only setup.
 
-If control is later disabled in the plugin, sessions with `loxone:control` are
-revoked. To return to read-only access, remove the two metadata arguments and
-reconnect Claude.
+If **Read only** is later selected in the plugin, sessions with
+`loxone:control` are revoked. To return to read-only access, remove the two
+metadata arguments and reconnect Claude.
 
 ## Why a prepared configuration may look different
 

--- a/docs/clients/claude-desktop.en.md
+++ b/docs/clients/claude-desktop.en.md
@@ -121,8 +121,9 @@ the browser consent page before approving access.
 > consent, and tool availability has not yet confirmed it. Read-only remains the
 > documented and tested default.
 
-This section applies only when controlled Gen. 1 Switch operation was
-deliberately enabled in the plugin UI. It is unnecessary for normal read access.
+This section applies only when **Read and switch** was deliberately selected
+under **Miniserver access through the MCP server** in the plugin UI. It is
+unnecessary for normal read access.
 
 Control always requires both scopes:
 
@@ -133,7 +134,7 @@ loxone:read loxone:control
 `loxone:control` alone is invalid. Existing read-only sessions never receive the
 additional scope automatically.
 
-1. Enable **Loxone control** in the plugin and save the configuration.
+1. Select **Read and switch** in the plugin and save the configuration.
 2. Create the local folder `C:\Users\Public\LoxBerryMCP` and add
    `loxberry-oauth-client.json` with this content:
 

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -31,11 +31,12 @@ Für die ChatGPT-/Codex-Desktop-App beschreibt die
 Hinzufügen per URL, die Browser-Authentifizierung und die angeforderten Lese-
 beziehungsweise Schreibrechte. Dafür wird keine lokale Node.js-Bridge benötigt.
 
-Die sechs Lesetools bleiben standardmäßig aktiv. Für die optionale Bedienung
-von Gen.-1-Switches aktiviere zusätzlich **Loxone-Steuerung**. Danach ist eine
-neue OAuth-Freigabe mit `loxone:control` erforderlich. Deaktivieren widerruft
-bestehende Control-Sitzungen; reine Lesesitzungen bleiben gültig. Bei einem
-Gen.-2-/HTTPS-Ziel kann die Steuerung nicht aktiviert werden.
+Die sechs Lesetools bleiben standardmäßig aktiv. Wähle unter **Zugriff auf den
+Miniserver über den MCP Server** die Option **Lesen und schalten**, um zusätzlich
+Gen.-1-Switches bedienen zu können. Danach ist eine neue OAuth-Freigabe mit
+`loxone:control` erforderlich. Beim Zurückwechseln auf **Nur lesen** werden
+bestehende Control-Sitzungen widerrufen; reine Lesesitzungen bleiben gültig.
+Bei einem Gen.-2-/HTTPS-Ziel kann **Lesen und schalten** nicht aktiviert werden.
 
 Der einheitliche OAuth-Dialog zeigt den erforderlichen Lesezugriff und, falls
 vom Client angefordert und im Plugin aktiviert, die optionale

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -31,11 +31,11 @@ For the ChatGPT/Codex desktop app, the
 setup, browser authentication, and the requested read or write permissions. It
 does not require a local Node.js bridge.
 
-The six read tools remain enabled by default. To operate Gen. 1 switches,
-additionally enable **Loxone control**. A new OAuth grant with `loxone:control`
-is then required. Disabling control revokes existing control sessions while
-read-only sessions remain valid. Control cannot be enabled for a Gen. 2/HTTPS
-target.
+The six read tools remain enabled by default. Under **Miniserver access through
+the MCP server**, select **Read and switch** to additionally operate Gen. 1
+Switches. A new OAuth grant with `loxone:control` is then required. Switching
+back to **Read only** revokes existing control sessions while read-only sessions
+remain valid. **Read and switch** cannot be selected for a Gen. 2/HTTPS target.
 
 The consistent OAuth dialog shows required read access and, when requested by
 the client and enabled in the plugin, optional Loxone control as a separate

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -35,7 +35,7 @@ The six read tools remain enabled by default. Under **Miniserver access through
 the MCP server**, select **Read and switch** to additionally operate Gen. 1
 Switches. A new OAuth grant with `loxone:control` is then required. Switching
 back to **Read only** revokes existing control sessions while read-only sessions
-remain valid. **Read and switch** cannot be selected for a Gen. 2/HTTPS target.
+remain valid. **Read and switch** cannot be enabled for a Gen. 2/HTTPS target.
 
 The consistent OAuth dialog shows required read access and, when requested by
 the client and enabled in the plugin, optional Loxone control as a separate

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,7 +4,8 @@
   .mcp-card { min-width: 0; padding: 1rem; border: 1px solid #c9cdd2; border-radius: .4rem; background: #fff; }
   .mcp-form { display: grid; gap: .85rem; }
   .mcp-field { display: grid; gap: .3rem; min-width: 0; }
-  .mcp-field input { box-sizing: border-box; width: 100%; max-width: 100%; min-height: 2.75rem; }
+  .mcp-field input,
+  .mcp-field select { box-sizing: border-box; width: 100%; max-width: 100%; min-height: 2.75rem; }
   .mcp-actions { display: flex; flex-wrap: wrap; gap: .6rem; align-items: center; }
   .mcp-actions button { min-height: 2.75rem; max-width: 100%; }
   .mcp-status { padding: .65rem; border-left: .3rem solid #6b7280; background: #f3f4f6; }
@@ -47,7 +48,13 @@
         <label class="mcp-field"><span><TMPL_VAR SETUP.PARALLEL></span><input name="max_parallel_calls" type="number" min="1" max="32" value="<TMPL_VAR MAX_PARALLEL_CALLS ESCAPE=HTML>"></label>
       </div>
       <label><input name="enabled" type="checkbox" value="1" <TMPL_IF ENABLED>checked</TMPL_IF>> <TMPL_VAR SETUP.ENABLED></label>
-      <label><input name="loxone_control_enabled" type="checkbox" value="1" <TMPL_IF LOXONE_CONTROL_ENABLED>checked</TMPL_IF>> <TMPL_VAR SETUP.CONTROL_ENABLED></label>
+      <label class="mcp-field">
+        <span><TMPL_VAR SETUP.CONTROL_MODE></span>
+        <select name="loxone_control_enabled">
+          <option value="0" <TMPL_UNLESS LOXONE_CONTROL_ENABLED>selected</TMPL_UNLESS>><TMPL_VAR SETUP.CONTROL_READ_ONLY></option>
+          <option value="1" <TMPL_IF LOXONE_CONTROL_ENABLED>selected</TMPL_IF>><TMPL_VAR SETUP.CONTROL_READ_SWITCH></option>
+        </select>
+      </label>
       <p class="mcp-warning"><TMPL_VAR SETUP.CONTROL_WARNING></p>
       <div class="mcp-actions">
         <button class="lb-button" type="submit"><TMPL_VAR ACTION.SAVE></button>

--- a/templates/lang/language_de.ini
+++ b/templates/lang/language_de.ini
@@ -17,8 +17,10 @@ RATE=Aufrufe pro Minute
 CONTROL_RATE=Schreibaktionen pro Minute
 PARALLEL=Parallele Aufrufe
 ENABLED=Dienst aktivieren
-CONTROL_ENABLED=Loxone-Steuerung mit separater Berechtigung aktivieren
-CONTROL_WARNING=Schreibzugriff ist standardmäßig aus. Aktivierte Clients dürfen sichtbare Switch-Steuerungen mit ihren Loxone-Benutzerrechten ein- und ausschalten.
+CONTROL_MODE=Zugriff auf den Miniserver über den MCP Server
+CONTROL_READ_ONLY=Nur lesen
+CONTROL_READ_SWITCH=Lesen und schalten
+CONTROL_WARNING=„Lesen und schalten“ erlaubt autorisierten Clients zusätzlich, sichtbare Switch-Steuerungen auf dem Miniserver ein- und auszuschalten. Die Freigabe erfolgt separat je Client und gilt nur im Rahmen der Rechte des verwendeten Loxone-Benutzers.
 
 [STATUS]
 TITLE=Status

--- a/templates/lang/language_en.ini
+++ b/templates/lang/language_en.ini
@@ -17,8 +17,10 @@ RATE=Calls per minute
 CONTROL_RATE=Control actions per minute
 PARALLEL=Parallel calls
 ENABLED=Enable service
-CONTROL_ENABLED=Enable Loxone control with separate authorization
-CONTROL_WARNING=Write access is disabled by default. Authorized clients may switch visible Switch controls on and off with their Loxone user permissions.
+CONTROL_MODE=Miniserver access through the MCP server
+CONTROL_READ_ONLY=Read only
+CONTROL_READ_SWITCH=Read and switch
+CONTROL_WARNING=“Read and switch” additionally allows authorized clients to switch visible Switch controls on the Miniserver on and off. Access is granted separately for each client and remains limited by the permissions of the Loxone user in use.
 
 [STATUS]
 TITLE=Status

--- a/tests/test_admin_ui.py
+++ b/tests/test_admin_ui.py
@@ -29,6 +29,17 @@ def test_common_actions_update_the_page_without_a_reload() -> None:
     assert "url.searchParams.delete('notice')" in template
 
 
+def test_miniserver_access_mode_is_an_explicit_read_or_switch_selection() -> None:
+    cgi = (ROOT / "webfrontend/htmlauth/index.cgi").read_text(encoding="utf-8")
+    template = (ROOT / "templates/index.html").read_text(encoding="utf-8")
+
+    assert '<select name="loxone_control_enabled">' in template
+    assert '<option value="0" <TMPL_UNLESS LOXONE_CONTROL_ENABLED>selected' in template
+    assert '<option value="1" <TMPL_IF LOXONE_CONTROL_ENABLED>selected' in template
+    assert 'name="loxone_control_enabled" type="checkbox"' not in template
+    assert "($q->{loxone_control_enabled} // '') eq '1'" in cgi
+
+
 def test_session_expiry_is_rendered_as_a_local_date_and_time() -> None:
     cgi = (ROOT / "webfrontend/htmlauth/index.cgi").read_text(encoding="utf-8")
     template = (ROOT / "templates/index.html").read_text(encoding="utf-8")

--- a/webfrontend/htmlauth/index.cgi
+++ b/webfrontend/htmlauth/index.cgi
@@ -92,7 +92,8 @@ if ($action ne '') {
             },
             tools => {
                 loxone_read_enabled => JSON::PP::true,
-                loxone_control_enabled => $q->{loxone_control_enabled} ? JSON::PP::true : JSON::PP::false,
+                loxone_control_enabled => ($q->{loxone_control_enabled} // '') eq '1'
+                    ? JSON::PP::true : JSON::PP::false,
             },
             limits => {
                 requests_per_minute => 0 + ($q->{requests_per_minute} // 60),


### PR DESCRIPTION
## Summary

- replace the ambiguous Loxone-control checkbox with a Miniserver access dropdown
- offer explicit `Read only` and `Read and switch` modes in German and English
- preserve the existing `loxone_control_enabled` configuration contract
- synchronize the affected client and user documentation
- add a regression test for the rendered selection and strict form mapping

## Why

The former label could be read as enabling the Miniserver itself rather than granting MCP clients narrowly scoped write access. The new wording makes the affected system, access path, and current Switch-only capability explicit.

## Validation

- `tools/test.py`: 212 passed; Ruff format/lint and Mypy green
- targeted admin UI and package tests: 30 passed
- `git diff --check`

## Not tested

- browser viewport acceptance was not executed because the browser security policy blocked the local preview URL; no device behavior or runtime configuration contract changed.