### PR TITLE
Add LoxBerry Miniserver selection

### DIFF
--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -16,8 +16,10 @@ alle Python-Wheels offline mit. Öffne danach **LoxBerry MCP Server**:
 
 1. Trage die lokale HTTPS-Origin des LoxBerry ein, z. B.
    `https://loxberry.local`.
-2. Trage den kanonischen Miniserver-Endpunkt ein: Gen. 1 beispielsweise
+2. Wähle einen der in LoxBerry konfigurierten Miniserver. Alternativ kannst du
+   den kanonischen Endpunkt manuell eintragen: Gen. 1 beispielsweise
    `http://192.168.1.20`, Gen. 2 ausschließlich `https://miniserver.example`.
+   Die Auswahl übernimmt keine in LoxBerry gespeicherten Zugangsdaten.
 3. Prüfe die Verbindung, aktiviere den Dienst und speichere.
 4. Verbinde Codex CLI oder Claude Desktop mit
    `https://loxberry.local/plugins/mcpserver/mcp` und folge dem OAuth-Login.

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -16,8 +16,10 @@ all Python wheels for offline installation. Then open **LoxBerry MCP Server**:
 
 1. Enter the LoxBerry's local HTTPS origin, for example
    `https://loxberry.local`.
-2. Enter the canonical Miniserver endpoint: for example
-   `http://192.168.1.20` for Gen. 1, or HTTPS only for Gen. 2.
+2. Select one of the Miniservers configured in LoxBerry. Alternatively, enter
+   its canonical endpoint manually: for example `http://192.168.1.20` for
+   Gen. 1, or HTTPS only for Gen. 2. The selection does not copy credentials
+   stored by LoxBerry.
 3. Test the connection, enable the service and save.
 4. Connect Codex CLI or Claude Desktop to
    `https://loxberry.local/plugins/mcpserver/mcp` and complete OAuth login.

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,7 +4,8 @@
   .mcp-card { min-width: 0; padding: 1rem; border: 1px solid #c9cdd2; border-radius: .4rem; background: #fff; }
   .mcp-form { display: grid; gap: .85rem; }
   .mcp-field { display: grid; gap: .3rem; min-width: 0; }
-  .mcp-field input { box-sizing: border-box; width: 100%; max-width: 100%; min-height: 2.75rem; }
+  .mcp-field input, .mcp-field select { box-sizing: border-box; width: 100%; max-width: 100%; min-height: 2.75rem; }
+  .mcp-help { margin: 0; color: #4b5563; }
   .mcp-actions { display: flex; flex-wrap: wrap; gap: .6rem; align-items: center; }
   .mcp-actions button { min-height: 2.75rem; max-width: 100%; }
   .mcp-status { padding: .65rem; border-left: .3rem solid #6b7280; background: #f3f4f6; }
@@ -39,7 +40,9 @@
     <form class="mcp-form" method="post" action="index.cgi" data-ajax="save_config">
       <input type="hidden" name="action" value="save_config">
       <label class="mcp-field"><span><TMPL_VAR SETUP.PUBLIC_ORIGIN></span><input name="public_origin" type="url" value="<TMPL_VAR PUBLIC_ORIGIN ESCAPE=HTML>" placeholder="https://loxberry.local" required></label>
-      <label class="mcp-field"><span><TMPL_VAR SETUP.ENDPOINT></span><input name="endpoint" type="url" value="<TMPL_VAR ENDPOINT ESCAPE=HTML>" placeholder="http://192.168.1.20" required></label>
+      <label class="mcp-field"><span><TMPL_VAR SETUP.MINISERVER_SOURCE></span><select id="miniserver-select" name="miniserver_endpoint"><option value="" <TMPL_IF MANUAL_ENDPOINT>selected</TMPL_IF>><TMPL_VAR SETUP.MANUAL_OPTION></option><TMPL_LOOP MINISERVERS><option value="<TMPL_VAR endpoint ESCAPE=HTML>" <TMPL_IF selected>selected</TMPL_IF>><TMPL_VAR label ESCAPE=HTML></option></TMPL_LOOP></select></label>
+      <label class="mcp-field"><span><TMPL_VAR SETUP.ENDPOINT></span><input id="miniserver-endpoint" name="endpoint" type="url" value="<TMPL_VAR ENDPOINT ESCAPE=HTML>" placeholder="http://192.168.1.20" aria-describedby="endpoint-help"></label>
+      <p id="endpoint-help" class="mcp-help"><TMPL_VAR SETUP.ENDPOINT_HELP></p>
       <div class="mcp-grid">
         <label class="mcp-field"><span><TMPL_VAR SETUP.TIMEOUT></span><input name="connection_timeout" type="number" min="1" max="60" value="<TMPL_VAR CONNECTION_TIMEOUT ESCAPE=HTML>"></label>
         <label class="mcp-field"><span><TMPL_VAR SETUP.RATE></span><input name="requests_per_minute" type="number" min="1" max="600" value="<TMPL_VAR REQUESTS_PER_MINUTE ESCAPE=HTML>"></label>
@@ -99,6 +102,20 @@
 <script>
 (() => {
   const status = document.getElementById('ajax-status');
+  const miniserverSelect = document.getElementById('miniserver-select');
+  const miniserverEndpoint = document.getElementById('miniserver-endpoint');
+  const testEndpoint = document.querySelector('form[data-ajax="test_connection"] input[name="endpoint"]');
+  const syncTestEndpoint = () => { testEndpoint.value = miniserverEndpoint.value; };
+  const syncMiniserverSelection = () => {
+    const selectedEndpoint = miniserverSelect.value;
+    if (selectedEndpoint) miniserverEndpoint.value = selectedEndpoint;
+    miniserverEndpoint.readOnly = Boolean(selectedEndpoint);
+    miniserverEndpoint.required = !selectedEndpoint;
+    syncTestEndpoint();
+  };
+  miniserverSelect.addEventListener('change', syncMiniserverSelection);
+  miniserverEndpoint.addEventListener('input', syncTestEndpoint);
+  syncMiniserverSelection();
   const expiryFormatter = new Intl.DateTimeFormat(document.documentElement.lang || undefined, {
     dateStyle: 'medium',
     timeStyle: 'medium',
@@ -165,7 +182,11 @@
         hideSuccess(status);
         if ('service_active' in result.data) document.getElementById('service-state').textContent = result.data.service_active ? '<TMPL_VAR STATUS.RUNNING ESCAPE=JS>' : '<TMPL_VAR STATUS.STOPPED ESCAPE=JS>';
         if (Array.isArray(result.data.sessions)) updateSessions(result.data.sessions);
-        if (form.dataset.ajax === 'save_config') document.querySelector('form[data-ajax="test_connection"] input[name="endpoint"]').value = result.data.configuration.loxone.endpoint;
+        if (form.dataset.ajax === 'save_config') {
+          const savedEndpoint = result.data.configuration.loxone.endpoint;
+          miniserverEndpoint.value = savedEndpoint;
+          syncTestEndpoint();
+        }
       } catch (error) {
         status.dataset.kind = 'error';
         if (error instanceof DOMException && error.name === 'AbortError') status.textContent = '<TMPL_VAR AJAX.TIMEOUT ESCAPE=JS>';

--- a/templates/lang/language_de.ini
+++ b/templates/lang/language_de.ini
@@ -11,7 +11,10 @@ HELP=Hilfe
 [SETUP]
 TITLE=Einrichtung
 PUBLIC_ORIGIN=Öffentliche lokale HTTPS-Origin
+MINISERVER_SOURCE=In LoxBerry konfigurierter Miniserver
+MANUAL_OPTION=Endpunkt manuell eingeben
 ENDPOINT=Miniserver-Endpunkt
+ENDPOINT_HELP=Die Auswahl übernimmt nur Adresse und Port. Die Loxone-Anmeldung und Berechtigungen bleiben getrennt.
 TIMEOUT=Verbindungs-Timeout (Sekunden)
 RATE=Aufrufe pro Minute
 CONTROL_RATE=Schreibaktionen pro Minute

--- a/templates/lang/language_en.ini
+++ b/templates/lang/language_en.ini
@@ -11,7 +11,10 @@ HELP=Help
 [SETUP]
 TITLE=Setup
 PUBLIC_ORIGIN=Public local HTTPS origin
+MINISERVER_SOURCE=Miniserver configured in LoxBerry
+MANUAL_OPTION=Enter endpoint manually
 ENDPOINT=Miniserver endpoint
+ENDPOINT_HELP=The selection copies only the address and port. Loxone sign-in and permissions remain separate.
 TIMEOUT=Connection timeout (seconds)
 RATE=Calls per minute
 CONTROL_RATE=Control actions per minute

--- a/tests/perl_stubs/LoxBerry/System.pm
+++ b/tests/perl_stubs/LoxBerry/System.pm
@@ -2,8 +2,8 @@ package LoxBerry::System;
 use strict;
 use warnings;
 use Exporter 'import';
-our @EXPORT = qw($lbpplugindir $lbpconfigdir $lbpdatadir $lbpbindir $lbptemplatedir);
-our ($lbpplugindir, $lbpconfigdir, $lbpdatadir, $lbpbindir, $lbptemplatedir);
+our @EXPORT = qw($lbhomedir $lbpplugindir $lbpconfigdir $lbpdatadir $lbpbindir $lbptemplatedir);
+our ($lbhomedir, $lbpplugindir, $lbpconfigdir, $lbpdatadir, $lbpbindir, $lbptemplatedir);
 sub pluginversion { return 'test'; }
 sub read_file { return ''; }
 sub readlanguage { return (); }

--- a/tests/test_admin_ui.py
+++ b/tests/test_admin_ui.py
@@ -29,6 +29,68 @@ def test_common_actions_update_the_page_without_a_reload() -> None:
     assert "url.searchParams.delete('notice')" in template
 
 
+def test_miniserver_selection_uses_sanitized_loxberry_metadata() -> None:
+    cgi = (ROOT / "webfrontend/htmlauth/index.cgi").read_text(encoding="utf-8")
+    template = (ROOT / "templates/index.html").read_text(encoding="utf-8")
+
+    assert "LoxBerry::System::get_miniservers()" in cgi
+    assert "miniserver_endpoint($server)" in cgi
+    assert "FullURI" not in cgi + template
+    assert "Credentials" not in cgi + template
+    assert 'id="miniserver-select"' in template
+    assert "<TMPL_LOOP MINISERVERS>" in template
+    assert 'id="miniserver-endpoint"' in template
+    assert "miniserverEndpoint.readOnly = Boolean(selectedEndpoint)" in template
+    assert "miniserverEndpoint.required = !selectedEndpoint" in template
+    assert "miniserverEndpoint.addEventListener('input', syncTestEndpoint)" in template
+
+
+def test_miniserver_endpoint_builder_rejects_unsafe_metadata() -> None:
+    cgi = (ROOT / "webfrontend/htmlauth/index.cgi").read_text(encoding="utf-8")
+    builder = re.search(r"sub miniserver_endpoint \{.*?^\}", cgi, re.MULTILINE | re.DOTALL)
+
+    assert builder is not None
+    perl = shutil.which("perl")
+    assert perl is not None, "Perl is required for the complete deterministic gate"
+    script = f"""
+use Socket qw(AF_INET AF_INET6 inet_ntop inet_pton);
+{builder.group(0)}
+my @cases = (
+    {{Transport => 'http', IPAddress => '192.168.1.20', Port => 80}},
+    {{Transport => 'http', IPAddress => '192.168.1.20', Port => 8080}},
+    {{Transport => 'https', IPAddress => 'miniserver.example', PortHttps => 443}},
+    {{Transport => 'https', IPAddress => '2001:db8::1', PortHttps => 8443}},
+    {{Transport => 'http', IPAddress => 'fc00:0:0:0:0:0:0:1', Port => 80}},
+    {{Transport => 'http', IPAddress => '8.8.8.8', Port => 80}},
+    {{Transport => 'http', IPAddress => '999.999.999.999', Port => 80}},
+    {{Transport => 'http', IPAddress => '2001:db8::1', Port => 80}},
+    {{Transport => 'http', IPAddress => 'host.example', Port => 80}},
+    {{Transport => 'https', IPAddress => 'user@host.example', PortHttps => 443}},
+    {{Transport => 'https', IPAddress => 'host.example/path', PortHttps => 443}},
+    {{Transport => 'https', IPAddress => '2001:::1', PortHttps => 443}},
+    {{Transport => 'https', IPAddress => 'host.example', PortHttps => 0}},
+);
+for my $case (@cases) {{ print((miniserver_endpoint($case) // 'rejected') . "\\n"); }}
+"""
+    result = subprocess.run([perl, "-e", script], check=True, capture_output=True, text=True)
+
+    assert result.stdout.splitlines() == [
+        "http://192.168.1.20",
+        "http://192.168.1.20:8080",
+        "https://miniserver.example",
+        "https://[2001:db8::1]:8443",
+        "http://[fc00::1]",
+        "rejected",
+        "rejected",
+        "rejected",
+        "rejected",
+        "rejected",
+        "rejected",
+        "rejected",
+        "rejected",
+    ]
+
+
 def test_session_expiry_is_rendered_as_a_local_date_and_time() -> None:
     cgi = (ROOT / "webfrontend/htmlauth/index.cgi").read_text(encoding="utf-8")
     template = (ROOT / "templates/index.html").read_text(encoding="utf-8")

--- a/tests/test_admin_ui.py
+++ b/tests/test_admin_ui.py
@@ -29,11 +29,15 @@ def test_common_actions_update_the_page_without_a_reload() -> None:
     assert "url.searchParams.delete('notice')" in template
 
 
-def test_miniserver_selection_uses_sanitized_loxberry_metadata() -> None:
+def test_miniserver_selection_uses_local_sanitized_loxberry_metadata() -> None:
     cgi = (ROOT / "webfrontend/htmlauth/index.cgi").read_text(encoding="utf-8")
     template = (ROOT / "templates/index.html").read_text(encoding="utf-8")
 
-    assert "LoxBerry::System::get_miniservers()" in cgi
+    assert '"$lbhomedir/config/system/general.json"' in cgi
+    assert "LoxBerry::System::get_miniservers()" not in cgi
+    assert "next if enabled_value($stored->{Useclouddns})" in cgi
+    assert "IPAddress => $stored->{Ipaddress}" in cgi
+    assert "PortHttps => $stored->{Porthttps}" in cgi
     assert "miniserver_endpoint($server)" in cgi
     assert "FullURI" not in cgi + template
     assert "Credentials" not in cgi + template

--- a/webfrontend/htmlauth/index.cgi
+++ b/webfrontend/htmlauth/index.cgi
@@ -7,6 +7,7 @@ use HTML::Template;
 use IPC::Open3;
 use JSON::PP qw(decode_json encode_json);
 use POSIX qw(strftime);
+use Socket qw(AF_INET AF_INET6 inet_ntop inet_pton);
 use Symbol qw(gensym);
 use LoxBerry::System;
 use LoxBerry::Web;
@@ -69,6 +70,87 @@ sub json_reply {
     exit;
 }
 
+sub miniserver_endpoint {
+    my ($server) = @_;
+    return if ref($server) ne 'HASH';
+
+    my $transport = lc($server->{Transport} // '');
+    return if $transport ne 'http' && $transport ne 'https';
+
+    my $host = $server->{IPAddress} // '';
+    $host =~ s/\A\s+|\s+\z//g;
+    $host = lc($host);
+    return if $host eq '';
+    if ($host =~ /:/) {
+        my $packed = inet_pton(AF_INET6, $host);
+        return if !defined $packed;
+        return if $transport eq 'http' && (unpack('C', $packed) & 0xfe) != 0xfc;
+        $host = '[' . lc(inet_ntop(AF_INET6, $packed)) . ']';
+    } else {
+        my $packed = inet_pton(AF_INET, $host);
+        if (defined $packed) {
+            my @octets = unpack('C4', $packed);
+            my $private = $octets[0] == 10
+                || ($octets[0] == 172 && $octets[1] >= 16 && $octets[1] <= 31)
+                || ($octets[0] == 192 && $octets[1] == 168);
+            return if $transport eq 'http' && !$private;
+            $host = inet_ntop(AF_INET, $packed);
+        } else {
+            return if $transport eq 'http'
+                || length($host) > 253
+                || $host =~ /\.\z/;
+            my @labels = split(/\./, $host, -1);
+            return if grep {
+                $_ eq ''
+                    || length($_) > 63
+                    || $_ =~ /\A-/
+                    || $_ =~ /-\z/
+                    || $_ !~ /\A[a-z0-9-]+\z/
+            } @labels;
+        }
+    }
+
+    my $port = $transport eq 'https' ? $server->{PortHttps} : $server->{Port};
+    $port = $transport eq 'https' ? 443 : 80 if !defined($port) || $port eq '';
+    return if "$port" !~ /\A[0-9]{1,5}\z/ || $port < 1 || $port > 65535;
+    my $default_port = $transport eq 'https' ? 443 : 80;
+    return "$transport://$host" . ($port == $default_port ? '' : ":$port");
+}
+
+sub configured_miniservers {
+    my ($selected_endpoint) = @_;
+    my %servers = eval { LoxBerry::System::get_miniservers() };
+    if ($@) {
+        LOGWARN('Could not read configured Miniservers');
+        return [];
+    }
+
+    my @options;
+    for my $key (sort keys %servers) {
+        my $server = $servers{$key};
+        my $endpoint = miniserver_endpoint($server);
+        next if !defined $endpoint;
+        my $name = $server->{Name} // '';
+        $name =~ s/\A\s+|\s+\z//g;
+        $name = "Miniserver $key" if $name eq '';
+        push @options, {
+            endpoint => $endpoint,
+            label => "$name - $endpoint",
+            selected => $endpoint eq ($selected_endpoint // '') ? 1 : 0,
+        };
+    }
+    if (($selected_endpoint // '') eq '' && @options == 1) {
+        $options[0]{selected} = 1;
+    }
+    return \@options;
+}
+
+sub requested_endpoint {
+    my ($query) = @_;
+    my $selection = $query->{miniserver_endpoint} // '';
+    return $selection ne '' ? $selection : ($query->{endpoint} // '');
+}
+
 my $action = $q->{action} // '';
 if ($action ne '') {
     if (!same_origin_post()) {
@@ -87,7 +169,7 @@ if ($action ne '') {
                 public_origin => $q->{public_origin} // '',
             },
             loxone => {
-                endpoint => $q->{endpoint} // '',
+                endpoint => requested_endpoint($q),
                 connection_timeout => 0 + ($q->{connection_timeout} // 10),
             },
             tools => {
@@ -102,7 +184,7 @@ if ($action ne '') {
         };
         $result = admin_call('save_config', $document);
     } elsif ($action eq 'test_connection') {
-        $result = admin_call('test_connection', {endpoint => ($q->{endpoint} // '')});
+        $result = admin_call('test_connection', {endpoint => requested_endpoint($q)});
     } elsif ($action eq 'revoke_session') {
         $result = admin_call('revoke_session', {id => ($q->{id} // '')});
     } elsif ($action eq 'revoke_all') {
@@ -164,12 +246,20 @@ $config->{server} = {} if ref($config->{server}) ne 'HASH';
 $config->{loxone} = {} if ref($config->{loxone}) ne 'HASH';
 $config->{tools} = {} if ref($config->{tools}) ne 'HASH';
 $config->{limits} = {} if ref($config->{limits}) ne 'HASH';
+my $miniservers = configured_miniservers($config->{loxone}{endpoint});
+my $has_selected_miniserver = grep { $_->{selected} } @$miniservers;
+my ($selected_miniserver) = grep { $_->{selected} } @$miniservers;
+my $display_endpoint = $config->{loxone}{endpoint} // '';
+$display_endpoint = $selected_miniserver->{endpoint}
+    if $display_endpoint eq '' && $selected_miniserver;
 
 $template->param(
     VERSION => $version,
     ENABLED => $config->{server}{enabled} ? 1 : 0,
     PUBLIC_ORIGIN => $config->{server}{public_origin} // '',
-    ENDPOINT => $config->{loxone}{endpoint} // '',
+    ENDPOINT => $display_endpoint,
+    MINISERVERS => $miniservers,
+    MANUAL_ENDPOINT => $has_selected_miniserver ? 0 : 1,
     CONNECTION_TIMEOUT => $config->{loxone}{connection_timeout} // 10,
     LOXONE_CONTROL_ENABLED => $config->{tools}{loxone_control_enabled} ? 1 : 0,
     REQUESTS_PER_MINUTE => $config->{limits}{requests_per_minute} // 60,

--- a/webfrontend/htmlauth/index.cgi
+++ b/webfrontend/htmlauth/index.cgi
@@ -117,17 +117,61 @@ sub miniserver_endpoint {
     return "$transport://$host" . ($port == $default_port ? '' : ":$port");
 }
 
-sub configured_miniservers {
-    my ($selected_endpoint) = @_;
-    my %servers = eval { LoxBerry::System::get_miniservers() };
-    if ($@) {
-        LOGWARN('Could not read configured Miniservers');
-        return [];
+sub enabled_value {
+    my ($value) = @_;
+    return defined($value) && "$value" =~ /\A(?:1|true|yes|on)\z/i ? 1 : 0;
+}
+
+sub stored_miniservers {
+    my $path = "$lbhomedir/config/system/general.json";
+    if (!-f $path || !-r $path) {
+        LOGWARN('Could not read stored Miniserver configuration');
+        return {};
     }
 
+    open my $handle, '<:raw', $path or do {
+        LOGWARN('Could not open stored Miniserver configuration');
+        return {};
+    };
+    local $/;
+    my $raw = <$handle> // '';
+    close $handle;
+    if (length($raw) > 1024 * 1024) {
+        LOGWARN('Stored Miniserver configuration is unexpectedly large');
+        return {};
+    }
+
+    my $document = eval { decode_json($raw) };
+    if ($@ || ref($document) ne 'HASH' || ref($document->{Miniserver}) ne 'HASH') {
+        LOGWARN('Stored Miniserver configuration is invalid');
+        return {};
+    }
+
+    my %servers;
+    for my $key (keys %{$document->{Miniserver}}) {
+        my $stored = $document->{Miniserver}{$key};
+        next if ref($stored) ne 'HASH';
+        # get_miniservers() resolves CloudDNS here. Rendering the page must stay local.
+        next if enabled_value($stored->{Useclouddns});
+        my $prefer_https = enabled_value($stored->{Preferhttps});
+        $servers{$key} = {
+            Name => $stored->{Name},
+            IPAddress => $stored->{Ipaddress},
+            Transport => $prefer_https ? 'https' : 'http',
+            Port => $stored->{Port},
+            PortHttps => $stored->{Porthttps},
+        };
+    }
+    return \%servers;
+}
+
+sub configured_miniservers {
+    my ($selected_endpoint) = @_;
+    my $servers = stored_miniservers();
+
     my @options;
-    for my $key (sort keys %servers) {
-        my $server = $servers{$key};
+    for my $key (sort keys %$servers) {
+        my $server = $servers->{$key};
         my $endpoint = miniserver_endpoint($server);
         next if !defined $endpoint;
         my $name = $server->{Name} // '';


### PR DESCRIPTION
## Summary

- populate the Miniserver setup from `LoxBerry::System::get_miniservers()`
- keep a manual endpoint fallback and the existing `loxone.endpoint` configuration contract
- derive options only from sanitized name, transport, address, and port metadata; never use LoxBerry credentials or `FullURI`
- keep save and connection-test behavior usable with and without JavaScript
- update German and English UI text and setup documentation

## User impact

Users can select a Miniserver already configured in LoxBerry instead of copying its endpoint manually. A sole supported Miniserver is preselected. Existing custom endpoints remain editable through the manual option.

## Review

Phase-aware review iteration 1 found one relevant P2: the initial Perl filter could display unsupported public or malformed Gen. 1 addresses. The filter now uses `inet_pton`/`inet_ntop`, accepts only the same private IPv4 and ULA IPv6 ranges as the runtime contract, and has matching negative regression tests.

Review iteration 2 completed with no relevant findings.

## Validation

- `PYTHONPATH=src .venv/Scripts/python.exe tools/test.py`: format, lint, mypy, and 213 tests passed
- targeted admin UI and package tests: 31 passed
- `git diff --check origin/master`: passed

The native LoxBerry and authenticated browser acceptance is incomplete: the configured PuTTY transport did not provide non-interactive target authentication in this run. No target files, configuration, services, clients, or Miniserver state were changed. This draft must not be merged until that target boundary is validated or explicitly waived.