### PR TITLE
Deliver bundled agent skill over MCP

### DIFF
--- a/docs/development/automation.md
+++ b/docs/development/automation.md
@@ -17,9 +17,12 @@ authorization, connection profiles, credentials, and private test fixtures outsi
   extracting or installing the archive.
 - `pwsh -File tools/test_mcp_client.ps1` detects the active Microsoft Store or
   classic Claude profile, starts its configured MCP proxy, and
-  exercises all six read-only tools. Use `-VisibilityFixturePath <private-json>` to add
-  a real visible/hidden-control boundary test. The private JSON contains only
+  exercises the six read-only Loxone data tools plus both skill-delivery surfaces
+  (MCP resource and fallback tool). Use `-VisibilityFixturePath <private-json>` to
+  add a real visible/hidden-control boundary test. The private JSON contains only
   `visible_control_uuid` and `hidden_control_uuid` and remains outside Git.
+- Use `-CallbackPort <unused-port>` when another running MCP proxy already owns
+  the callback port stored in the local OAuth client registration.
 - `-ControlFixturePath <private-json>` is a separate explicit opt-in for the Phase 2
   target smoke. It expects only `control_uuid` and `initial_state` (`on` or `off`),
   switches once to the opposite state and restores the recorded initial state. Use it
@@ -39,6 +42,9 @@ boundaries around state-changing operations:
 2. Compare local and remote SHA-256 before installation.
 3. Prefer the native LoxBerry Plugin Manager or its exact installer command for install,
    upgrade, and uninstall.
+   For an upgrade, verify that the bundled virtual environment was rebuilt through the
+   atomic installation path; an updated wheelhouse alone does not prove that changed
+   server code is active.
 4. Read the SecurePIN only from an approved external file or interactive input. Never
    place it in arguments, logs, repository files, or generated evidence.
 5. Run health, service, Apache, ownership, configuration-schema, and MCP read-only

--- a/docs/development/automation.md
+++ b/docs/development/automation.md
@@ -42,9 +42,6 @@ boundaries around state-changing operations:
 2. Compare local and remote SHA-256 before installation.
 3. Prefer the native LoxBerry Plugin Manager or its exact installer command for install,
    upgrade, and uninstall.
-   For an upgrade, verify that the bundled virtual environment was rebuilt through the
-   atomic installation path; an updated wheelhouse alone does not prove that changed
-   server code is active.
 4. Read the SecurePIN only from an approved external file or interactive input. Never
    place it in arguments, logs, repository files, or generated evidence.
 5. Run health, service, Apache, ownership, configuration-schema, and MCP read-only

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -31,11 +31,45 @@ Für die ChatGPT-/Codex-Desktop-App beschreibt die
 Hinzufügen per URL, die Browser-Authentifizierung und die angeforderten Lese-
 beziehungsweise Schreibrechte. Dafür wird keine lokale Node.js-Bridge benötigt.
 
-Die sechs Lesetools bleiben standardmäßig aktiv. Für die optionale Bedienung
-von Gen.-1-Switches aktiviere zusätzlich **Loxone-Steuerung**. Danach ist eine
+Die sechs lesenden Loxone-Datentools und das lesende Skill-Guide-Tool bleiben
+standardmäßig aktiv. Für die optionale Bedienung von Gen.-1-Switches aktiviere
+zusätzlich **Loxone-Steuerung**. Danach ist eine
 neue OAuth-Freigabe mit `loxone:control` erforderlich. Deaktivieren widerruft
 bestehende Control-Sitzungen; reine Lesesitzungen bleiben gültig. Bei einem
 Gen.-2-/HTTPS-Ziel kann die Steuerung nicht aktiviert werden.
+
+## Agent Skill
+
+Der Server liefert den Agent Skill
+[`using-loxberry-mcp`](../src/mcpserver/skills/using-loxberry-mcp/SKILL.md)
+direkt über MCP aus. Er beschreibt den sicheren Ablauf für Suche, Pagination,
+Zustandsabfragen, mehrdeutige Namen und ausdrücklich angeforderte
+Switch-Aktionen. Die maschinenlesbaren JSON-Schemas bleiben Bestandteil der
+MCP-Tools und werden im Skill nicht dupliziert.
+
+Beim Verbindungsaufbau weist der Server den Client in seinen MCP-Instructions
+auf `skill://using-loxberry-mcp/SKILL.md` hin. Ressourcenfähige Clients können
+die Anleitung dann bei Bedarf laden. Für Clients, die MCP-Ressourcen nicht
+verwenden, steht dasselbe Dokument über das immer lesende Tool
+`loxone_get_skill_guide` bereit. Das ist automatische Bereitstellung und
+Erkennung, aber keine stille Installation oder dauerhafte Prompt-Injektion auf
+dem Client.
+
+Eine lokale Installation ist optional. Sie ermöglicht Codex, Claude Code und
+anderen Agent-Skills-kompatiblen Clients die native, implizite Aktivierung anhand
+der Skill-Beschreibung, auch bevor eine MCP-Verbindung besteht:
+
+```bash
+npx skills add Miraculix2050/LoxBerry-Plugin-MCP-Server --skill using-loxberry-mcp
+```
+
+Alternativ kopiere den Ordner `using-loxberry-mcp` nach
+`~/.agents/skills/using-loxberry-mcp` für Codex oder nach
+`~/.claude/skills/using-loxberry-mcp` für Claude Code. In Claude Desktop und
+Claude.ai kann derselbe Skill-Ordner als ZIP unter **Customize > Skills**
+hochgeladen werden. Nach lokaler Installation wählt der Client den Skill bei
+passenden LoxBerry-/Loxone-Anfragen automatisch aus; mit `$using-loxberry-mcp`
+kann er ausdrücklich aktiviert werden.
 
 Der einheitliche OAuth-Dialog zeigt den erforderlichen Lesezugriff und, falls
 vom Client angefordert und im Plugin aktiviert, die optionale
@@ -53,8 +87,9 @@ aktualisiert.
 
 ## Umfang und Betrieb
 
-Die Alpha veröffentlicht sechs dokumentierte `loxone_*`-Lesetools und optional
-`loxone_operate_control`. Das Schreibtool akzeptiert ausschließlich eine
+Die Alpha veröffentlicht sechs dokumentierte Loxone-Datentools, das lesende
+`loxone_get_skill_guide` und optional `loxone_operate_control`. Das Schreibtool
+akzeptiert ausschließlich eine
 sichtbare Control-UUID vom Typ `Switch` und die Aktion `on` oder `off`. Es bietet
 keine Namens-, Raum-, Bulk- oder freien Kommandos. Historie, LoxBerry-Tools und
 Basic Auth bleiben ausgeschlossen. Ergebnisse und Aktionen entsprechen den

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -31,11 +31,44 @@ For the ChatGPT/Codex desktop app, the
 setup, browser authentication, and the requested read or write permissions. It
 does not require a local Node.js bridge.
 
-The six read tools remain enabled by default. To operate Gen. 1 switches,
-additionally enable **Loxone control**. A new OAuth grant with `loxone:control`
+The six read-only Loxone data tools and the read-only skill-guide tool remain
+enabled by default. To operate Gen. 1 switches, additionally enable
+**Loxone control**. A new OAuth grant with `loxone:control`
 is then required. Disabling control revokes existing control sessions while
 read-only sessions remain valid. Control cannot be enabled for a Gen. 2/HTTPS
 target.
+
+## Agent Skill
+
+The server delivers the
+[`using-loxberry-mcp`](../src/mcpserver/skills/using-loxberry-mcp/SKILL.md)
+Agent Skill directly through MCP. It describes the safe workflow for discovery,
+pagination, state reads, ambiguous names and explicitly requested Switch
+operations. Machine-readable JSON schemas remain part of the MCP tools and are
+not duplicated in the skill.
+
+During connection setup, the server's MCP instructions point the client to
+`skill://using-loxberry-mcp/SKILL.md`. Resource-capable clients can retrieve the
+guide on demand. Clients that do not consume MCP resources can retrieve the same
+document through the always-read-only `loxone_get_skill_guide` tool. This is
+automatic delivery and discovery, not a silent client-side installation or
+permanent prompt injection.
+
+Local installation is optional. It lets Codex, Claude Code and other
+Agent-Skills-compatible clients activate the skill natively from its
+description, even before an MCP connection exists:
+
+```bash
+npx skills add Miraculix2050/LoxBerry-Plugin-MCP-Server --skill using-loxberry-mcp
+```
+
+Alternatively, copy the `using-loxberry-mcp` folder to
+`~/.agents/skills/using-loxberry-mcp` for Codex or
+`~/.claude/skills/using-loxberry-mcp` for Claude Code. In Claude Desktop and
+Claude.ai, upload the same skill folder as a ZIP under **Customize > Skills**.
+After local installation, the client automatically selects the skill for
+matching LoxBerry or Loxone requests; `$using-loxberry-mcp` activates it
+explicitly.
 
 The consistent OAuth dialog shows required read access and, when requested by
 the client and enabled in the plugin, optional Loxone control as a separate
@@ -52,8 +85,9 @@ With JavaScript, status, test and revocation update without a page navigation.
 
 ## Scope and operation
 
-The alpha publishes six documented `loxone_*` read tools and optionally
-`loxone_operate_control`. The control tool accepts only a visible `Switch`
+The alpha publishes six documented Loxone data tools, the read-only
+`loxone_get_skill_guide`, and optionally `loxone_operate_control`. The control
+tool accepts only a visible `Switch`
 control UUID and the action `on` or `off`. It provides no name-, room-, bulk- or
 free-form commands. History, LoxBerry tools and Basic Auth remain excluded.
 Results and actions are limited to the authenticated Loxone user's permissions.

--- a/postupgrade.sh
+++ b/postupgrade.sh
@@ -1,21 +1,14 @@
 #!/bin/bash
 set -u
 
-actual_folder=$3
-if [ -z "$actual_folder" ] || [ -z "${LBPCONFIG:-}" ] || [ -z "${LBPDATA:-}" ]; then
-    echo "<ERROR> LoxBerry plugin paths are unavailable."
+hook_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd) || exit 2
+postinstall_hook="$hook_dir/postinstall.sh"
+if [ ! -f "$postinstall_hook" ] || [ -L "$postinstall_hook" ]; then
+    echo "<ERROR> The trusted postinstall hook is unavailable during upgrade."
     exit 2
 fi
 
-# Schema 1 is the first released configuration. The migration is intentionally
-# idempotent and never replaces an existing configuration or session store.
-plugin_config="$LBPCONFIG/$actual_folder"
-plugin_data="$LBPDATA/$actual_folder"
-if [ ! -f "$plugin_config/mcpserver.json" ]; then
-    cp "$plugin_config/default-config.json" "$plugin_config/mcpserver.json" || exit 2
-fi
-chmod 600 "$plugin_config/mcpserver.json"
-mkdir -p "$plugin_data/auth"
-chmod 700 "$plugin_data/auth"
-echo "<OK> Configuration and sessions retained."
-exit 0
+# LoxBerry invokes postupgrade instead of postinstall for an upgrade. Reuse the
+# complete atomic runtime rebuild and backup restoration so changed project code
+# and package data cannot remain hidden behind the previous virtual environment.
+exec /bin/bash "$postinstall_hook" "$@"

--- a/postupgrade.sh
+++ b/postupgrade.sh
@@ -1,14 +1,21 @@
 #!/bin/bash
 set -u
 
-hook_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd) || exit 2
-postinstall_hook="$hook_dir/postinstall.sh"
-if [ ! -f "$postinstall_hook" ] || [ -L "$postinstall_hook" ]; then
-    echo "<ERROR> The trusted postinstall hook is unavailable during upgrade."
+actual_folder=$3
+if [ -z "$actual_folder" ] || [ -z "${LBPCONFIG:-}" ] || [ -z "${LBPDATA:-}" ]; then
+    echo "<ERROR> LoxBerry plugin paths are unavailable."
     exit 2
 fi
 
-# LoxBerry invokes postupgrade instead of postinstall for an upgrade. Reuse the
-# complete atomic runtime rebuild and backup restoration so changed project code
-# and package data cannot remain hidden behind the previous virtual environment.
-exec /bin/bash "$postinstall_hook" "$@"
+# Schema 1 is the first released configuration. The migration is intentionally
+# idempotent and never replaces an existing configuration or session store.
+plugin_config="$LBPCONFIG/$actual_folder"
+plugin_data="$LBPDATA/$actual_folder"
+if [ ! -f "$plugin_config/mcpserver.json" ]; then
+    cp "$plugin_config/default-config.json" "$plugin_config/mcpserver.json" || exit 2
+fi
+chmod 600 "$plugin_config/mcpserver.json"
+mkdir -p "$plugin_data/auth"
+chmod 700 "$plugin_data/auth"
+echo "<OK> Configuration and sessions retained."
+exit 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,12 @@ package-dir = {"" = "src"}
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.setuptools.package-data]
+mcpserver = [
+    "skills/using-loxberry-mcp/SKILL.md",
+    "skills/using-loxberry-mcp/agents/openai.yaml",
+]
+
 [tool.pytest.ini_options]
 addopts = "-ra"
 testpaths = ["tests"]

--- a/src/mcpserver/server.py
+++ b/src/mcpserver/server.py
@@ -24,7 +24,8 @@ from mcpserver.auth.store import AtomicJsonAuthStore
 from mcpserver.auth.web import Phase0OAuthWeb
 from mcpserver.loxone.runtime import LoxoneRuntime
 from mcpserver.settings import ServerSettings
-from mcpserver.tools import register_control_tool, register_read_tools
+from mcpserver.skill_delivery import SERVER_INSTRUCTIONS, register_skill_resource
+from mcpserver.tools import register_control_tool, register_read_tools, register_skill_tool
 
 SERVER_NAME: Final = "LoxBerry MCP Server"
 _TRANSPORT_LOGGER_NAME: Final = "mcp.server.transport_security"
@@ -214,6 +215,7 @@ def create_server(settings: ServerSettings) -> FastMCP:
 
     server = _ForwardedHostFastMCP(
         SERVER_NAME,
+        instructions=SERVER_INSTRUCTIONS,
         token_verifier=token_verifier,
         host=settings.host,
         port=settings.port,
@@ -232,6 +234,8 @@ def create_server(settings: ServerSettings) -> FastMCP:
         and settings.phase0_auth.plugin_config.loxone_control_enabled
     )
     server.advertised_scopes = (READ_SCOPE,) + ((CONTROL_SCOPE,) if control_enabled else ())
+    register_skill_resource(server)
+    register_skill_tool(server)
     register_read_tools(server, runtime, control_enabled=control_enabled)
     if control_enabled:
         register_control_tool(server, runtime)

--- a/src/mcpserver/skill_delivery.py
+++ b/src/mcpserver/skill_delivery.py
@@ -1,0 +1,38 @@
+"""MCP delivery surfaces for the bundled agent skill."""
+
+from __future__ import annotations
+
+from importlib.resources import files
+from typing import Final
+
+from mcp.server.fastmcp import FastMCP
+
+SKILL_NAME: Final = "using-loxberry-mcp"
+SKILL_REVISION: Final = 1
+SKILL_MIME_TYPE: Final = "text/markdown"
+SKILL_RESOURCE_URI: Final = f"skill://{SKILL_NAME}/SKILL.md"
+SERVER_INSTRUCTIONS: Final = (
+    "For multi-step Loxone queries, ambiguous control names, stale or unconfirmed states, "
+    "and before any control operation, retrieve the using-loxberry-mcp guide from "
+    f"{SKILL_RESOURCE_URI} or call loxone_get_skill_guide. Never retry uncertain writes."
+)
+
+
+def read_skill_markdown() -> str:
+    """Read the canonical skill bundled in the installed Python package."""
+    resource = files("mcpserver").joinpath("skills", SKILL_NAME, "SKILL.md")
+    return resource.read_text(encoding="utf-8")
+
+
+def register_skill_resource(server: FastMCP) -> None:
+    """Publish the bundled skill as a static MCP resource."""
+
+    @server.resource(
+        SKILL_RESOURCE_URI,
+        name=SKILL_NAME,
+        title="Using LoxBerry MCP",
+        description="Agent workflow for safe Loxone discovery, state reads, and operations.",
+        mime_type=SKILL_MIME_TYPE,
+    )
+    def skill_resource() -> str:
+        return read_skill_markdown()

--- a/src/mcpserver/skills/using-loxberry-mcp/SKILL.md
+++ b/src/mcpserver/skills/using-loxberry-mcp/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: using-loxberry-mcp
+description: Guides safe use of the LoxBerry MCP Server to find Loxone rooms, categories, controls, read current states, diagnose connectivity, and explicitly operate supported switches. Use when a user asks about or requests control of a Loxone installation through the LoxBerry MCP Server, including ambiguous control names, stale state, pagination, or unconfirmed operations.
+---
+
+# Using LoxBerry MCP
+
+Use the connected LoxBerry MCP Server's canonical `loxone_*` tools. Treat their
+input and output schemas as authoritative; do not invent fields or UUIDs.
+
+## Read information
+
+1. Call `loxone_get_system_status` when connectivity or data freshness matters.
+2. Resolve human names with `loxone_find_controls`. Use
+   `loxone_list_rooms` or `loxone_list_categories` first when a room or category
+   filter would remove ambiguity.
+3. Follow every non-null `next_cursor` until the relevant result is found or all
+   pages have been checked.
+4. If more than one control remains plausible, present the candidates and ask
+   the user to choose. Never guess a UUID.
+5. Call `loxone_describe_control` to obtain the control's state UUIDs and
+   capabilities, then pass the required state UUIDs to `loxone_get_states`.
+
+Check the complete result envelope. Do not treat a response as successful when
+`ok` is false. Surface relevant `warnings`, and qualify answers when `stale` is
+true or a state has an old or missing `observed_at` value.
+
+## Operate a switch
+
+Only operate a control when the user has explicitly requested one unambiguous
+action on one identified target.
+
+1. Resolve the target with the read workflow; never accept or construct an
+   unverified UUID from conversation text.
+2. Call `loxone_describe_control` immediately before the operation.
+3. Continue only when `capabilities.allowed_actions` contains the requested
+   action exactly.
+4. Call `loxone_operate_control` once with that control UUID and `on` or `off`.
+5. Never automatically retry an uncertain or failed write. Ask the user before
+   any new attempt.
+
+Report `accepted`, `confirmed`, and `observed_state` separately. `accepted=true`
+means the command was accepted, not that the resulting physical state was
+confirmed. When `confirmed=false`, state the uncertainty and do not claim that
+the requested state was reached.
+
+## Safety boundaries
+
+- Do not broaden a request to other rooms, controls, or bulk operations.
+- Do not bypass the MCP server's OAuth scopes, visibility filtering, action
+  allowlist, validation, or rate limits.
+- Do not expose access tokens, credentials, private addresses, or session data.
+- If a required tool is unavailable, explain that the connected server or the
+  granted scope does not provide the capability.

--- a/src/mcpserver/skills/using-loxberry-mcp/agents/openai.yaml
+++ b/src/mcpserver/skills/using-loxberry-mcp/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Use LoxBerry MCP"
+  short_description: "Safely inspect and operate Loxone controls"
+  default_prompt: "Use $using-loxberry-mcp to inspect or operate my Loxone installation safely."
+policy:
+  allow_implicit_invocation: true

--- a/src/mcpserver/tools.py
+++ b/src/mcpserver/tools.py
@@ -27,6 +27,12 @@ from mcpserver.loxone.runtime import (
     RuntimeSnapshot,
     RuntimeUnavailable,
 )
+from mcpserver.skill_delivery import (
+    SKILL_MIME_TYPE,
+    SKILL_NAME,
+    SKILL_REVISION,
+    read_skill_markdown,
+)
 
 DEFAULT_PAGE_SIZE: Final = 50
 MAX_PAGE_SIZE: Final = 100
@@ -91,6 +97,13 @@ class StatesData(BaseModel):
     states: list[StateData]
 
 
+class SkillGuideData(BaseModel):
+    name: str
+    revision: int
+    media_type: str
+    content: str
+
+
 class SystemStatusData(BaseModel):
     reachable: bool
     miniserver_serial: str
@@ -125,6 +138,10 @@ class ControlDescriptionEnvelope(ToolEnvelope):
 
 class StatesEnvelope(ToolEnvelope):
     data: StatesData | ErrorData
+
+
+class SkillGuideEnvelope(ToolEnvelope):
+    data: SkillGuideData | ErrorData
 
 
 class ControlOperationData(BaseModel):
@@ -560,6 +577,31 @@ def register_read_tools(
             )
         except RuntimeUnavailable as exc:
             return _error(StatesEnvelope, "temporarily_unavailable", str(exc))
+
+
+def register_skill_tool(server: FastMCP) -> None:
+    """Publish a tool fallback for clients that do not consume MCP resources."""
+    annotations = ToolAnnotations(readOnlyHint=True, destructiveHint=False, openWorldHint=False)
+
+    @server.tool(
+        name="loxone_get_skill_guide",
+        description=(
+            "Get the bundled agent workflow for safe Loxone discovery, state reads, and "
+            "explicit control operations. Use when MCP resources are unavailable."
+        ),
+        annotations=annotations,
+        structured_output=True,
+    )
+    def get_skill_guide() -> SkillGuideEnvelope:
+        return _result(
+            SkillGuideEnvelope,
+            {
+                "name": SKILL_NAME,
+                "revision": SKILL_REVISION,
+                "media_type": SKILL_MIME_TYPE,
+                "content": read_skill_markdown(),
+            },
+        )
 
 
 def register_control_tool(server: FastMCP, runtime: LoxoneRuntime | None) -> None:

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -49,6 +49,9 @@ def test_mcp_client_smoke_covers_skill_delivery_surfaces() -> None:
     assert "method = 'resources/read'" in script
     assert "mcp_skill_delivery=pass" in script
     assert "[int]$CallbackPort" in script
+    assert "if ($proxyArguments[$index] -match '^https?://')" in script
+    assert "$callbackIndex = $serverUrlIndex + 1" in script
+    assert "$proxyArguments.Insert($callbackIndex, [string]$CallbackPort)" in script
 
 
 def test_plugin_identity_and_platform_contract() -> None:
@@ -145,14 +148,6 @@ def test_postinstall_rewrites_moved_venv_entrypoints() -> None:
     assert 'sed -i "1c\\\\#!$venv/bin/python"' in hook
     assert 'rm -rf -- "$venv"' in hook
     assert 'mv "$old_venv" "$venv"' in hook
-
-
-def test_postupgrade_rebuilds_runtime_through_postinstall() -> None:
-    hook = (ROOT / "postupgrade.sh").read_text(encoding="utf-8")
-
-    assert 'postinstall_hook="$hook_dir/postinstall.sh"' in hook
-    assert '[ ! -f "$postinstall_hook" ] || [ -L "$postinstall_hook" ]' in hook
-    assert 'exec /bin/bash "$postinstall_hook" "$@"' in hook
 
 
 def test_postinstall_project_pin_matches_plugin_version() -> None:

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -52,6 +52,8 @@ def test_mcp_client_smoke_covers_skill_delivery_surfaces() -> None:
     assert "if ($proxyArguments[$index] -match '^https?://')" in script
     assert "$callbackIndex = $serverUrlIndex + 1" in script
     assert "$proxyArguments.Insert($callbackIndex, [string]$CallbackPort)" in script
+    assert "$controlAdvertised = $actual -contains 'loxone_operate_control'" in script
+    assert "if ($ControlFixturePath -and -not $controlAdvertised)" in script
 
 
 def test_plugin_identity_and_platform_contract() -> None:

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -40,6 +40,17 @@ def test_agent_skill_is_declared_as_wheel_package_data() -> None:
     assert '"skills/using-loxberry-mcp/agents/openai.yaml"' in pyproject
 
 
+def test_mcp_client_smoke_covers_skill_delivery_surfaces() -> None:
+    script = (ROOT / "tools" / "test_mcp_client.ps1").read_text(encoding="utf-8")
+
+    assert "skill://using-loxberry-mcp/SKILL.md" in script
+    assert "loxone_get_skill_guide" in script
+    assert "method = 'resources/list'" in script
+    assert "method = 'resources/read'" in script
+    assert "mcp_skill_delivery=pass" in script
+    assert "[int]$CallbackPort" in script
+
+
 def test_plugin_identity_and_platform_contract() -> None:
     parser = configparser.ConfigParser()
     parser.read(ROOT / "plugin.cfg", encoding="utf-8")
@@ -134,6 +145,14 @@ def test_postinstall_rewrites_moved_venv_entrypoints() -> None:
     assert 'sed -i "1c\\\\#!$venv/bin/python"' in hook
     assert 'rm -rf -- "$venv"' in hook
     assert 'mv "$old_venv" "$venv"' in hook
+
+
+def test_postupgrade_rebuilds_runtime_through_postinstall() -> None:
+    hook = (ROOT / "postupgrade.sh").read_text(encoding="utf-8")
+
+    assert 'postinstall_hook="$hook_dir/postinstall.sh"' in hook
+    assert '[ ! -f "$postinstall_hook" ] || [ -L "$postinstall_hook" ]' in hook
+    assert 'exec /bin/bash "$postinstall_hook" "$@"' in hook
 
 
 def test_postinstall_project_pin_matches_plugin_version() -> None:

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -20,6 +20,26 @@ from tools.verify_plugin import PackageVerificationError, verify_archive
 ROOT = Path(__file__).resolve().parents[1]
 
 
+def _write_project_wheel(path: Path, *, include_openai_metadata: bool = True) -> None:
+    with zipfile.ZipFile(path, "w") as wheel:
+        wheel.writestr("mcpserver/skills/using-loxberry-mcp/SKILL.md", b"skill")
+        if include_openai_metadata:
+            wheel.writestr(
+                "mcpserver/skills/using-loxberry-mcp/agents/openai.yaml",
+                b"interface: {}\n",
+            )
+
+
+def test_agent_skill_is_declared_as_wheel_package_data() -> None:
+    pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    skill = ROOT / "src" / "mcpserver" / "skills" / "using-loxberry-mcp"
+
+    assert (skill / "SKILL.md").is_file()
+    assert (skill / "agents" / "openai.yaml").is_file()
+    assert '"skills/using-loxberry-mcp/SKILL.md"' in pyproject
+    assert '"skills/using-loxberry-mcp/agents/openai.yaml"' in pyproject
+
+
 def test_plugin_identity_and_platform_contract() -> None:
     parser = configparser.ConfigParser()
     parser.read(ROOT / "plugin.cfg", encoding="utf-8")
@@ -225,7 +245,8 @@ def test_plugin_archive_verifier_accepts_builder_output(tmp_path: Path) -> None:
     for name, version in _locked_requirements(ROOT / "requirements" / "runtime-arm64.lock").items():
         wheel_name = name.replace("-", "_")
         (wheelhouse / f"{wheel_name}-{version}-py3-none-any.whl").write_bytes(b"wheel")
-    (wheelhouse / "loxberry_mcpserver-0.2.0a1-py3-none-any.whl").write_bytes(b"project")
+    project_wheel = wheelhouse / "loxberry_mcpserver-0.2.0a1-py3-none-any.whl"
+    _write_project_wheel(project_wheel)
     output = tmp_path / "plugin.zip"
 
     subprocess.run(
@@ -242,6 +263,23 @@ def test_plugin_archive_verifier_accepts_builder_output(tmp_path: Path) -> None:
     )
 
     assert verify_archive(output) == hashlib.sha256(output.read_bytes()).hexdigest()
+
+    _write_project_wheel(project_wheel, include_openai_metadata=False)
+    missing_skill_metadata = tmp_path / "missing-skill-metadata.zip"
+    subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "tools" / "build_plugin.py"),
+            "--wheelhouse",
+            str(wheelhouse),
+            "--output",
+            str(missing_skill_metadata),
+        ],
+        check=True,
+        cwd=ROOT,
+    )
+    with pytest.raises(PackageVerificationError, match="project wheel entry is missing"):
+        verify_archive(missing_skill_metadata)
 
     with zipfile.ZipFile(output) as source:
         omitted = next(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -163,9 +163,12 @@ def test_mcp_initialize_uses_expected_protocol() -> None:
     assert response.status_code == 200
     assert response.json()["result"]["protocolVersion"] == "2025-11-25"
     assert response.json()["result"]["serverInfo"]["name"] == "LoxBerry MCP Server"
+    instructions = response.json()["result"]["instructions"]
+    assert "skill://using-loxberry-mcp/SKILL.md" in instructions
+    assert "loxone_get_skill_guide" in instructions
 
 
-def test_exact_phase1_read_only_tools_are_published() -> None:
+def test_exact_default_read_only_tools_are_published() -> None:
     app = create_server(_settings()).streamable_http_app()
     request = {
         "jsonrpc": "2.0",
@@ -184,6 +187,7 @@ def test_exact_phase1_read_only_tools_are_published() -> None:
     assert response.status_code == 200
     tools = response.json()["result"]["tools"]
     assert [tool["name"] for tool in tools] == [
+        "loxone_get_skill_guide",
         "loxone_get_system_status",
         "loxone_list_rooms",
         "loxone_list_categories",
@@ -195,6 +199,22 @@ def test_exact_phase1_read_only_tools_are_published() -> None:
     assert all(tool["annotations"]["destructiveHint"] is False for tool in tools)
     assert all(tool["outputSchema"]["properties"]["data"].get("anyOf") for tool in tools)
     assert all(tool["outputSchema"].get("$defs") for tool in tools)
+
+
+@pytest.mark.asyncio
+async def test_bundled_skill_is_published_as_an_mcp_resource() -> None:
+    server = create_server(_settings())
+
+    resources = await server.list_resources()
+    assert [(str(item.uri), item.mimeType) for item in resources] == [
+        ("skill://using-loxberry-mcp/SKILL.md", "text/markdown")
+    ]
+
+    contents = await server.read_resource("skill://using-loxberry-mcp/SKILL.md")
+    assert len(contents) == 1
+    assert contents[0].mime_type == "text/markdown"
+    assert contents[0].content.startswith("---\nname: using-loxberry-mcp\n")
+    assert "Never automatically retry an uncertain or failed write" in contents[0].content
 
 
 def test_oauth_routes_and_protected_resource_metadata_are_exact(tmp_path: Path) -> None:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -7,7 +7,14 @@ import mcpserver.tools as tools_module
 from mcpserver.auth.provider import CONTROL_SCOPE, READ_SCOPE, StoredAccessToken
 from mcpserver.loxone.models import Control, LoxoneIdentity, LoxoneStructure
 from mcpserver.loxone.runtime import RuntimeSnapshot
-from mcpserver.tools import _CursorCodec, _page, register_control_tool, register_read_tools
+from mcpserver.skill_delivery import read_skill_markdown
+from mcpserver.tools import (
+    _CursorCodec,
+    _page,
+    register_control_tool,
+    register_read_tools,
+    register_skill_tool,
+)
 
 
 def test_opaque_cursor_paginates_without_exposing_offset() -> None:
@@ -49,6 +56,29 @@ def test_control_tool_contract_is_explicitly_mutating_and_idempotent() -> None:
     assert tool.annotations.destructiveHint is True
     assert tool.annotations.idempotentHint is True
     assert set(tool.parameters["properties"]["action"]["enum"]) == {"on", "off"}
+
+
+def test_skill_guide_tool_is_read_only_and_matches_resource_content() -> None:
+    server = FastMCP("skill-contract")
+    register_skill_tool(server)
+
+    tool = server._tool_manager.list_tools()[0]
+    result = tool.fn()
+
+    assert tool.name == "loxone_get_skill_guide"
+    assert tool.parameters == {
+        "properties": {},
+        "title": "get_skill_guideArguments",
+        "type": "object",
+    }
+    assert tool.annotations is not None
+    assert tool.annotations.readOnlyHint is True
+    assert tool.annotations.destructiveHint is False
+    assert tool.annotations.openWorldHint is False
+    assert result.data.name == "using-loxberry-mcp"  # type: ignore[union-attr]
+    assert result.data.revision == 1  # type: ignore[union-attr]
+    assert result.data.media_type == "text/markdown"  # type: ignore[union-attr]
+    assert result.data.content == read_skill_markdown()  # type: ignore[union-attr]
 
 
 @pytest.mark.asyncio

--- a/tools/test_mcp_client.ps1
+++ b/tools/test_mcp_client.ps1
@@ -198,8 +198,12 @@ try {
         'loxone_find_controls', 'loxone_describe_control', 'loxone_get_states',
         'loxone_get_skill_guide'
     )
-    if ($ControlFixturePath) { $expected += 'loxone_operate_control' }
     $actual = @($toolsResponse.result.tools | ForEach-Object { $_.name } | Sort-Object)
+    $controlAdvertised = $actual -contains 'loxone_operate_control'
+    if ($controlAdvertised) { $expected += 'loxone_operate_control' }
+    if ($ControlFixturePath -and -not $controlAdvertised) {
+        throw 'ControlFixturePath requires the enabled loxone_operate_control tool.'
+    }
     if (($actual -join "`n") -ne (($expected | Sort-Object) -join "`n")) {
         throw 'MCP tool inventory differs from the expected enabled contract.'
     }

--- a/tools/test_mcp_client.ps1
+++ b/tools/test_mcp_client.ps1
@@ -3,6 +3,7 @@ param(
     [string]$ServerName = 'loxberry-mcp',
     [string]$VisibilityFixturePath,
     [string]$ControlFixturePath,
+    [int]$CallbackPort,
     [int]$TimeoutSeconds = 120,
     [switch]$CheckConfigurationOnly
 )
@@ -57,8 +58,13 @@ if ($CheckConfigurationOnly) {
 
 $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
 $startInfo.FileName = [string]$server.command
+$argumentIndex = 0
 foreach ($argument in $server.args) {
     [void]$startInfo.ArgumentList.Add([string]$argument)
+    if ($CallbackPort -and $argumentIndex -eq 1) {
+        [void]$startInfo.ArgumentList.Add([string]$CallbackPort)
+    }
+    $argumentIndex += 1
 }
 if ($server.env) {
     foreach ($property in $server.env.PSObject.Properties) {
@@ -158,7 +164,12 @@ try {
             clientInfo = @{ name = 'phase1-readonly-probe'; version = '0.1.0' }
         }
     }
-    if ((Read-JsonRpc 0).error) { throw 'MCP initialize failed.' }
+    $initializeResponse = Read-JsonRpc 0
+    if ($initializeResponse.error) { throw 'MCP initialize failed.' }
+    if ($initializeResponse.result.instructions -notlike '*skill://using-loxberry-mcp/SKILL.md*' -or
+        $initializeResponse.result.instructions -notlike '*loxone_get_skill_guide*') {
+        throw 'MCP initialize did not advertise the bundled skill.'
+    }
     Send-JsonRpc @{ jsonrpc = '2.0'; method = 'notifications/initialized'; params = @{} }
     Send-JsonRpc @{ jsonrpc = '2.0'; id = 1; method = 'tools/list'; params = @{} }
     $toolsResponse = Read-JsonRpc 1
@@ -166,7 +177,8 @@ try {
 
     $expected = @(
         'loxone_get_system_status', 'loxone_list_rooms', 'loxone_list_categories',
-        'loxone_find_controls', 'loxone_describe_control', 'loxone_get_states'
+        'loxone_find_controls', 'loxone_describe_control', 'loxone_get_states',
+        'loxone_get_skill_guide'
     )
     if ($ControlFixturePath) { $expected += 'loxone_operate_control' }
     $actual = @($toolsResponse.result.tools | ForEach-Object { $_.name } | Sort-Object)
@@ -188,7 +200,34 @@ try {
         }
     }
 
-    $script:nextId = 2
+    Send-JsonRpc @{ jsonrpc = '2.0'; id = 2; method = 'resources/list'; params = @{} }
+    $resourcesResponse = Read-JsonRpc 2
+    if ($resourcesResponse.error -or @($resourcesResponse.result.resources).Count -ne 1 -or
+        [string]$resourcesResponse.result.resources[0].uri -ne
+            'skill://using-loxberry-mcp/SKILL.md' -or
+        $resourcesResponse.result.resources[0].mimeType -ne 'text/markdown') {
+        throw 'MCP skill resource inventory differs from the expected contract.'
+    }
+    Send-JsonRpc @{
+        jsonrpc = '2.0'; id = 3; method = 'resources/read'
+        params = @{ uri = 'skill://using-loxberry-mcp/SKILL.md' }
+    }
+    $resourceResponse = Read-JsonRpc 3
+    $skillMarkdown = [string]$resourceResponse.result.contents[0].text
+    if ($resourceResponse.error -or
+        $resourceResponse.result.contents[0].mimeType -ne 'text/markdown' -or
+        $skillMarkdown -notlike "---`nname: using-loxberry-mcp`n*") {
+        throw 'MCP skill resource content differs from the expected contract.'
+    }
+
+    $script:nextId = 4
+    $skillGuide = Invoke-ReadTool (Get-NextId) 'loxone_get_skill_guide' @{}
+    if ($skillGuide.data.name -ne 'using-loxberry-mcp' -or
+        $skillGuide.data.revision -ne 1 -or
+        $skillGuide.data.media_type -ne 'text/markdown' -or
+        $skillGuide.data.content -ne $skillMarkdown) {
+        throw 'MCP skill guide tool differs from the canonical resource.'
+    }
     [void](Invoke-ReadTool (Get-NextId) 'loxone_get_system_status' @{})
     [void](Invoke-ReadTool (Get-NextId) 'loxone_list_rooms' @{ limit = 100 })
     [void](Invoke-ReadTool (Get-NextId) 'loxone_list_categories' @{ limit = 100 })
@@ -288,8 +327,9 @@ try {
     $hiddenUuid = $null
     $stateUuid = $null
     'mcp_tool_contract=pass'
-    if ($ControlFixturePath) { 'mcp_six_read_tools_plus_control=pass' }
-    else { 'mcp_six_read_tools=pass' }
+    'mcp_skill_delivery=pass'
+    if ($ControlFixturePath) { 'mcp_six_data_tools_plus_skill_guide_and_control=pass' }
+    else { 'mcp_six_data_tools_plus_skill_guide=pass' }
     if ($VisibilityFixturePath) { 'mcp_visibility_filter=pass' }
 } finally {
     try { $process.StandardInput.Close() } catch {}

--- a/tools/test_mcp_client.ps1
+++ b/tools/test_mcp_client.ps1
@@ -58,13 +58,31 @@ if ($CheckConfigurationOnly) {
 
 $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
 $startInfo.FileName = [string]$server.command
-$argumentIndex = 0
-foreach ($argument in $server.args) {
-    [void]$startInfo.ArgumentList.Add([string]$argument)
-    if ($CallbackPort -and $argumentIndex -eq 1) {
-        [void]$startInfo.ArgumentList.Add([string]$CallbackPort)
+$proxyArguments = [System.Collections.Generic.List[string]]::new()
+foreach ($argument in @($server.args)) {
+    $proxyArguments.Add([string]$argument)
+}
+if ($CallbackPort) {
+    $serverUrlIndex = -1
+    for ($index = 0; $index -lt $proxyArguments.Count; $index += 1) {
+        if ($proxyArguments[$index] -match '^https?://') {
+            $serverUrlIndex = $index
+            break
+        }
     }
-    $argumentIndex += 1
+    if ($serverUrlIndex -lt 0) {
+        throw 'CallbackPort requires an HTTP(S) server URL in the proxy arguments.'
+    }
+    $callbackIndex = $serverUrlIndex + 1
+    if ($callbackIndex -lt $proxyArguments.Count -and
+        $proxyArguments[$callbackIndex] -match '^\d+$') {
+        $proxyArguments[$callbackIndex] = [string]$CallbackPort
+    } else {
+        $proxyArguments.Insert($callbackIndex, [string]$CallbackPort)
+    }
+}
+foreach ($argument in $proxyArguments) {
+    [void]$startInfo.ArgumentList.Add($argument)
 }
 if ($server.env) {
     foreach ($property in $server.env.PSObject.Properties) {

--- a/tools/verify_plugin.py
+++ b/tools/verify_plugin.py
@@ -44,6 +44,10 @@ _EXECUTABLES: Final = {
 }
 _TEXT_SUFFIXES: Final = {".cfg", ".cgi", ".conf", ".html", ".ini", ".json", ".lock", ".sh", ".svg"}
 _TEXT_NAMES: Final = {"bin/healthcheck", "bin/mcpserver-admin"}
+_REQUIRED_PROJECT_WHEEL_ENTRIES: Final = {
+    "mcpserver/skills/using-loxberry-mcp/SKILL.md",
+    "mcpserver/skills/using-loxberry-mcp/agents/openai.yaml",
+}
 
 
 class PackageVerificationError(RuntimeError):
@@ -81,6 +85,19 @@ def _verify_checksum(archive: Path, digest: str) -> None:
     fields = sidecar.read_text(encoding="ascii").strip().split()
     if fields != [digest, archive.name]:
         raise PackageVerificationError("checksum sidecar does not match the archive")
+
+
+def _verify_project_wheel(content: bytes) -> None:
+    try:
+        wheel = zipfile.ZipFile(io.BytesIO(content))
+    except zipfile.BadZipFile as exc:
+        raise PackageVerificationError("project wheel is not a valid ZIP") from exc
+    with wheel:
+        missing = _REQUIRED_PROJECT_WHEEL_ENTRIES - set(wheel.namelist())
+        if missing:
+            raise PackageVerificationError(
+                f"required project wheel entry is missing: {min(missing)}"
+            )
 
 
 def verify_archive(archive: Path, *, require_checksum: bool = True) -> str:
@@ -152,6 +169,12 @@ def verify_archive(archive: Path, *, require_checksum: bool = True) -> str:
         ]
         if project_wheels != [expected_project]:
             raise PackageVerificationError("exactly one matching project wheel is required")
+        project_wheel_entry = next(
+            name
+            for name, identity in zip(wheelhouse_entries, wheel_identities, strict=True)
+            if identity == expected_project
+        )
+        _verify_project_wheel(package.read(project_wheel_entry))
         expected_runtime = _locked_requirements(
             package.read("bin/runtime-arm64.lock").decode("utf-8")
         )


### PR DESCRIPTION
## Summary
- bundle the portable `using-loxberry-mcp` Agent Skill with the server wheel
- advertise it through MCP instructions, a `skill://` resource, and a read-only fallback tool
- document automatic discovery and optional local installation in German and English
- verify the required skill files inside the embedded project wheel
- extend the Claude smoke to validate instructions, resource delivery, fallback parity, and optional control-tool inventories without invoking controls

## Validation
- skill-creator `quick_validate.py`: pass
- `PYTHONPATH=src python tools/test.py`: 215 passed; Ruff format/lint and mypy pass
- PowerShell and lifecycle shell syntax: pass
- reproducible release candidate: pass; SHA-256 `b7d758f5fc9090e3daeb30f239dcfefa370f4d4d919208ee9077a87fc6729f70`
- embedded wheel contains `SKILL.md` and `agents/openai.yaml`

## Phase-aware review
Iteration 1 found one low-severity packaging-test gap: the test checked only `pyproject.toml` declarations. The verifier now opens the actual embedded project wheel and requires both skill files, with a negative regression test. Iteration 2 found no relevant findings. After the target-driven smoke extension, iteration 3 found two medium findings: callback-port placement and an incorrect duplicate-upgrade lifecycle change. Both were corrected; the native lifecycle remains unchanged, and the callback/tool-inventory paths are covered by local and real-client evidence.

## Target acceptance
- native Plugin Manager upgrade on the authorized Loxberry-Test target: pass
- installer completion, service active, loopback health, Apache syntax, schema and restrictive secret modes: pass
- active installed `server.py` and `tools.py` match the release-candidate wheel
- installed MCP skill resource and read-only fallback tool return the same canonical Markdown: pass
- real Claude/mcp-remote read-only smoke: `mcp_tool_contract=pass`, `mcp_skill_delivery=pass`, `mcp_six_data_tools_plus_skill_guide=pass`
- OAuth granted required read scope only; no Loxone control command was invoked
- temporary target upload copies removed after acceptance