### PR TITLE
Show endpoint only for manual Miniserver setup

### DIFF
--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -17,7 +17,8 @@ alle Python-Wheels offline mit. Öffne danach **LoxBerry MCP Server**:
 1. Trage die lokale HTTPS-Origin des LoxBerry ein, z. B.
    `https://loxberry.local`.
 2. Wähle einen der in LoxBerry konfigurierten Miniserver. Alternativ kannst du
-   den kanonischen Endpunkt manuell eintragen: Gen. 1 beispielsweise
+   „Endpunkt manuell eingeben“ wählen; nur dann wird das Feld für den
+   kanonischen Endpunkt angezeigt. Gen. 1 verwendet beispielsweise
    `http://192.168.1.20`, Gen. 2 ausschließlich `https://miniserver.example`.
    Die Auswahl übernimmt keine in LoxBerry gespeicherten Zugangsdaten.
 3. Prüfe die Verbindung, aktiviere den Dienst und speichere.

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -16,9 +16,10 @@ all Python wheels for offline installation. Then open **LoxBerry MCP Server**:
 
 1. Enter the LoxBerry's local HTTPS origin, for example
    `https://loxberry.local`.
-2. Select one of the Miniservers configured in LoxBerry. Alternatively, enter
-   its canonical endpoint manually: for example `http://192.168.1.20` for
-   Gen. 1, or HTTPS only for Gen. 2. The selection does not copy credentials
+2. Select one of the Miniservers configured in LoxBerry. Alternatively, select
+   “Enter endpoint manually”; the canonical endpoint field is shown only in
+   that mode. Use `http://192.168.1.20` for Gen. 1, or HTTPS only for Gen. 2.
+   The selection does not copy credentials
    stored by LoxBerry.
 3. Test the connection, enable the service and save.
 4. Connect Codex CLI or Claude Desktop to

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,6 +5,7 @@
   .mcp-form { display: grid; gap: .85rem; }
   .mcp-field { display: grid; gap: .3rem; min-width: 0; }
   .mcp-field input, .mcp-field select { box-sizing: border-box; width: 100%; max-width: 100%; min-height: 2.75rem; }
+  .mcp-manual-endpoint[hidden] { display: none; }
   .mcp-help { margin: 0; color: #4b5563; }
   .mcp-actions { display: flex; flex-wrap: wrap; gap: .6rem; align-items: center; }
   .mcp-actions button { min-height: 2.75rem; max-width: 100%; }
@@ -41,8 +42,10 @@
       <input type="hidden" name="action" value="save_config">
       <label class="mcp-field"><span><TMPL_VAR SETUP.PUBLIC_ORIGIN></span><input name="public_origin" type="url" value="<TMPL_VAR PUBLIC_ORIGIN ESCAPE=HTML>" placeholder="https://loxberry.local" required></label>
       <label class="mcp-field"><span><TMPL_VAR SETUP.MINISERVER_SOURCE></span><select id="miniserver-select" name="miniserver_endpoint"><option value="" <TMPL_IF MANUAL_ENDPOINT>selected</TMPL_IF>><TMPL_VAR SETUP.MANUAL_OPTION></option><TMPL_LOOP MINISERVERS><option value="<TMPL_VAR endpoint ESCAPE=HTML>" <TMPL_IF selected>selected</TMPL_IF>><TMPL_VAR label ESCAPE=HTML></option></TMPL_LOOP></select></label>
-      <label class="mcp-field"><span><TMPL_VAR SETUP.ENDPOINT></span><input id="miniserver-endpoint" name="endpoint" type="url" value="<TMPL_VAR ENDPOINT ESCAPE=HTML>" placeholder="http://192.168.1.20" aria-describedby="endpoint-help"></label>
-      <p id="endpoint-help" class="mcp-help"><TMPL_VAR SETUP.ENDPOINT_HELP></p>
+      <div id="manual-endpoint-fields" class="mcp-manual-endpoint" <TMPL_UNLESS MANUAL_ENDPOINT>hidden</TMPL_UNLESS>>
+        <label class="mcp-field"><span><TMPL_VAR SETUP.ENDPOINT></span><input id="miniserver-endpoint" name="endpoint" type="url" value="<TMPL_VAR ENDPOINT ESCAPE=HTML>" placeholder="http://192.168.1.20" aria-describedby="endpoint-help" <TMPL_IF MANUAL_ENDPOINT>required<TMPL_ELSE>readonly</TMPL_IF>></label>
+        <p id="endpoint-help" class="mcp-help"><TMPL_VAR SETUP.ENDPOINT_HELP></p>
+      </div>
       <div class="mcp-grid">
         <label class="mcp-field"><span><TMPL_VAR SETUP.TIMEOUT></span><input name="connection_timeout" type="number" min="1" max="60" value="<TMPL_VAR CONNECTION_TIMEOUT ESCAPE=HTML>"></label>
         <label class="mcp-field"><span><TMPL_VAR SETUP.RATE></span><input name="requests_per_minute" type="number" min="1" max="600" value="<TMPL_VAR REQUESTS_PER_MINUTE ESCAPE=HTML>"></label>
@@ -103,6 +106,7 @@
 (() => {
   const status = document.getElementById('ajax-status');
   const miniserverSelect = document.getElementById('miniserver-select');
+  const manualEndpointFields = document.getElementById('manual-endpoint-fields');
   const miniserverEndpoint = document.getElementById('miniserver-endpoint');
   const testEndpoint = document.querySelector('form[data-ajax="test_connection"] input[name="endpoint"]');
   const syncTestEndpoint = () => { testEndpoint.value = miniserverEndpoint.value; };
@@ -111,6 +115,7 @@
     if (selectedEndpoint) miniserverEndpoint.value = selectedEndpoint;
     miniserverEndpoint.readOnly = Boolean(selectedEndpoint);
     miniserverEndpoint.required = !selectedEndpoint;
+    manualEndpointFields.hidden = Boolean(selectedEndpoint);
     syncTestEndpoint();
   };
   miniserverSelect.addEventListener('change', syncMiniserverSelection);

--- a/tests/test_admin_ui.py
+++ b/tests/test_admin_ui.py
@@ -43,9 +43,13 @@ def test_miniserver_selection_uses_local_sanitized_loxberry_metadata() -> None:
     assert "Credentials" not in cgi + template
     assert 'id="miniserver-select"' in template
     assert "<TMPL_LOOP MINISERVERS>" in template
+    assert 'id="manual-endpoint-fields"' in template
+    assert "<TMPL_UNLESS MANUAL_ENDPOINT>hidden</TMPL_UNLESS>" in template
     assert 'id="miniserver-endpoint"' in template
+    assert "<TMPL_IF MANUAL_ENDPOINT>required<TMPL_ELSE>readonly</TMPL_IF>" in template
     assert "miniserverEndpoint.readOnly = Boolean(selectedEndpoint)" in template
     assert "miniserverEndpoint.required = !selectedEndpoint" in template
+    assert "manualEndpointFields.hidden = Boolean(selectedEndpoint)" in template
     assert "miniserverEndpoint.addEventListener('input', syncTestEndpoint)" in template
 
 


### PR DESCRIPTION
## What changed

- hide the Miniserver endpoint field and its help text while a configured LoxBerry Miniserver is selected
- show the field only for the “Enter endpoint manually” choice
- preserve progressive enhancement with server-rendered `hidden`, `required`, and `readonly` states
- synchronize the German and English user guides
- add regression assertions for the rendered contract

## Why

The endpoint is derived from the selected LoxBerry Miniserver, so showing a read-only duplicate adds noise and suggests that it can be edited. Manual entry should be the only mode that exposes the endpoint field.

## Validation

- deterministic gate: formatting, Ruff, mypy, 217 tests passed
- reproducible release candidate built and verified
- native Plugin Manager upgrade on the authorized test system passed
- service active, `/healthz` healthy, persistent plugin data unchanged
- browser acceptance at 1280×800 and 390×844 passed
- configured/manual switching, required/read-only state, DE/EN parity, keyboard focus, overflow, and fresh-page console checked