### PR TITLE
Fix and expand bounded Loxone controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Phase 1 und die ursprüngliche Phase 2 sind abgenommen. Der zugehörige
 Pre-Release `0.2.0-alpha.1` begrenzt das optionale Schreibwerkzeug noch auf
 `Switch`. Der aktuelle, noch nicht als Folgerelease veröffentlichte Stand
 erweitert dieses Werkzeug auf Gen.-1-Controls vom Typ `Switch`, `Dimmer`,
-`LightController`, `LightControllerV2` und `Jalousie` bereit. Es bleibt
+`LightController`, `LightControllerV2` und `Jalousie`. Es bleibt
 standardmäßig deaktiviert, akzeptiert ausschließlich typabhängige dokumentierte
 Aktionen und benötigt den separat bestätigten Scope `loxone:control`. Freie
 Kommandos, Namens- und Sammelziele sind ausgeschlossen. Die sechs stabilen

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # LoxBerry MCP Server
 
-Das McpServer-Plugin betreibt einen [Model Context Protocol (MCP)](https://modelcontextprotocol.io/)-Server direkt auf dem LoxBerry. Die aktuelle Alpha erlaubt KI-Assistenten und Agenten, den Zustand einer Loxone-Miniserver-Installation zu lesen. Optional kann sie genau ein kontrolliertes Schreibwerkzeug für Gen.-1-Steuerungen vom Typ `Switch` bereitstellen. Dabei verwendet das Plugin die vorhandenen Räume, Kategorien und Steuerungsnamen – ohne eigenen Cloud-Dienst.
-
-Die Steuerung bleibt standardmäßig deaktiviert. Weitere Control-Typen und
-LoxBerry-Werkzeuge sind nicht Bestandteil dieser Version.
+Das McpServer-Plugin betreibt einen [Model Context Protocol (MCP)](https://modelcontextprotocol.io/)-Server direkt auf dem LoxBerry. Die aktuelle Alpha erlaubt KI-Assistenten und Agenten standardmäßig ausschließlich, den Zustand einer Loxone-Miniserver-Installation zu lesen. Optional kann ein eng begrenztes Loxone-Schreibwerkzeug aktiviert werden. Dabei verwendet das Plugin die vorhandenen Räume, Kategorien und Steuerungsnamen – ohne eigenen Cloud-Dienst. LoxBerry-Werkzeuge sind nicht Bestandteil dieser Version.
 
 ## Sicherheit und Berechtigungen
 
@@ -13,12 +10,15 @@ Für jeden Assistenten sollte ein eigener Loxone-Benutzer mit den minimal erford
 
 ## Projektstatus
 
-Phase 1 und Phase 2 sind abgenommen. Phase 2 ergänzt optional genau ein
-kontrolliertes Schreibwerkzeug für Gen.-1-Controls vom Typ `Switch`. Es bleibt
-standardmäßig deaktiviert, akzeptiert ausschließlich `on` und `off` und benötigt
-den separat bestätigten Scope `loxone:control`. Die sechs stabilen lesenden
-Tools und bestehende Read-only-Sitzungen bleiben kompatibel. Der zugehörige
-Pre-Release ist `0.2.0-alpha.1`.
+Phase 1 und die ursprüngliche Phase 2 sind abgenommen. Der zugehörige
+Pre-Release `0.2.0-alpha.1` begrenzt das optionale Schreibwerkzeug noch auf
+`Switch`. Der aktuelle, noch nicht als Folgerelease veröffentlichte Stand
+erweitert dieses Werkzeug auf Gen.-1-Controls vom Typ `Switch`, `Dimmer`,
+`LightController`, `LightControllerV2` und `Jalousie` bereit. Es bleibt
+standardmäßig deaktiviert, akzeptiert ausschließlich typabhängige dokumentierte
+Aktionen und benötigt den separat bestätigten Scope `loxone:control`. Freie
+Kommandos, Namens- und Sammelziele sind ausgeschlossen. Die sechs stabilen
+lesenden Tools und bestehende Read-only-Sitzungen bleiben kompatibel.
 
 Bestätigte Kombinationen, Nachweise und bekannte Clientgrenzen stehen in der
 [Support-Matrix](docs/development/support-matrix.md), im

--- a/docs/clients/chatgpt-codex-desktop.de.md
+++ b/docs/clients/chatgpt-codex-desktop.de.md
@@ -66,8 +66,9 @@ loxone:read loxone:control
 Der Freigabedialog zeigt **Lesezugriff** verpflichtend und
 **Loxone-Steuerung** als optionale Checkbox. Nur wenn die Steuerung ausgewählt
 und bestätigt wird, stehen die sechs Lesewerkzeuge und das begrenzte
-Switch-Schreibwerkzeug zur Verfügung. Das Schreibwerkzeug kann ausschließlich
-freigegebene, sichtbare Gen.-1-Switches ein- oder ausschalten. Die tatsächlichen
+Control-Schreibwerkzeug zur Verfügung. Das Schreibwerkzeug kann ausschließlich
+freigegebene, sichtbare Gen.-1-Controls mit den von
+`loxone_describe_control` angebotenen Aktionen bedienen. Die tatsächlichen
 Möglichkeiten bleiben zusätzlich durch die Rechte des angemeldeten
 Loxone-Benutzers begrenzt.
 

--- a/docs/clients/chatgpt-codex-desktop.en.md
+++ b/docs/clients/chatgpt-codex-desktop.en.md
@@ -64,8 +64,9 @@ loxone:read loxone:control
 
 The consent dialog shows required **Read access** and optional **Loxone
 control** as a checkbox. Only when control is selected and confirmed are the six
-read tools and the narrowly limited Switch write tool available. The write tool
-can only turn permitted, visible Gen. 1 Switches on or off. The authenticated
+read tools and the narrowly limited control tool available. The write tool can
+only operate permitted, visible Gen. 1 controls with actions advertised by
+`loxone_describe_control`. The authenticated
 Loxone user's permissions further restrict what is actually possible.
 
 Write access is not silently added later: it must be selected and approved on

--- a/docs/development/adr/0003-phase-2-controlled-switch.md
+++ b/docs/development/adr/0003-phase-2-controlled-switch.md
@@ -1,6 +1,6 @@
 # ADR 0003: Phase-2 Controlled Switch Operations
 
-- **Status:** Accepted
+- **Status:** Superseded by ADR 0005
 - **Date:** 2026-08-04
 - **Accepted:** 2026-08-06
 - **Release:** `0.2.0-alpha.1`

--- a/docs/development/adr/0005-bounded-loxone-controls.md
+++ b/docs/development/adr/0005-bounded-loxone-controls.md
@@ -1,7 +1,8 @@
 # ADR 0005: Bounded Loxone Control Types
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-08-06
+- **Accepted:** 2026-08-06
 - **Supersedes:** ADR 0003
 
 ## Context
@@ -48,7 +49,10 @@ control type and identity:
 | automatic `Jalousie` | plus `enable_auto`, `disable_auto` | `auto`, `NoAuto` |
 
 Percentages are finite values from 0 through 100. Legacy scenes are decimal
-numbers from 0 through 99. V2 mood IDs are `0` or `ID1` through `ID99`.
+numbers from 0 through 99. V2 mood IDs are bounded decimal values returned by
+the control's current visible `moodList`; `0` remains the documented off target.
+The server validates nonzero V2 targets against that current list immediately
+before dispatch and rejects missing, stale, malformed, or unlisted mood targets.
 Parameters must match the selected action exactly; extra and missing parameters
 are rejected. Relative-motion pairs, scene/mood mutation, naming, presence,
 end-position adjustment, expert operations, arbitrary paths, name targets, and

--- a/docs/development/adr/0005-bounded-loxone-controls.md
+++ b/docs/development/adr/0005-bounded-loxone-controls.md
@@ -1,0 +1,70 @@
+# ADR 0005: Bounded Loxone Control Types
+
+- **Status:** Proposed
+- **Date:** 2026-08-06
+- **Supersedes:** ADR 0003
+
+## Context
+
+The original Phase-2 implementation normalized a control operation target from
+the non-standard field `action`. Loxone's official V17 Structure File defines
+the mandatory field as `uuidAction`. Consequently, real controls could be
+visible and operable in the Loxone visualization while the MCP server reported
+no allowed action.
+
+Phase 2 also needs bounded support for dimmers, lighting controllers, and normal
+or automatic blinds without exposing a raw Miniserver command surface. The
+[official Loxone V17 Structure File](https://www.loxone.com/enen/wp-content/uploads/sites/3/2026/04/1700_Structure-File.pdf)
+is normative. Other open-source Loxone MCP servers were considered only as a
+design comparison and do not override the official contract.
+
+## Decision
+
+### Structure and authorization
+
+The normalized operation target comes only from `uuidAction`. A missing target
+or a read-only internal or external restriction makes the control non-operable.
+`details.isAutomatic` is retained only as a boolean capability flag for a
+`Jalousie`; all other details remain excluded from the normalized model.
+
+The existing controls remain unchanged: the tool is disabled by default,
+requires `loxone:read` plus `loxone:control`, resolves an exact UUID in a freshly
+loaded user-filtered structure, rate-limits and serializes writes, audits the
+attempt, and never retries an uncertain dispatch.
+
+### Tool contract
+
+The stable `loxone_operate_control` tool is extended with optional typed
+parameters. `loxone_describe_control` advertises only actions supported by the
+control type and identity:
+
+| Type | MCP actions | Official Miniserver commands |
+| --- | --- | --- |
+| `Switch` | `on`, `off` | `on`, `off` |
+| `Dimmer` | `on`, `off`, `set_level` | `on`, `off`, `{position}` |
+| `LightController` | `on`, `off`, `set_mood` | `on`, `off`, `{sceneNumber}` |
+| `LightControllerV2` | `off`, `set_mood` | `changeTo/0`, `changeTo/{moodId}` |
+| `Jalousie` | `open`, `close`, `shade`, `stop`, position actions | `FullUp`, `FullDown`, `shade`, `stop`, `manualPosition`, `manualLamelle`, `manualPosBlind` |
+| automatic `Jalousie` | plus `enable_auto`, `disable_auto` | `auto`, `NoAuto` |
+
+Percentages are finite values from 0 through 100. Legacy scenes are decimal
+numbers from 0 through 99. V2 mood IDs are `0` or `ID1` through `ID99`.
+Parameters must match the selected action exactly; extra and missing parameters
+are rejected. Relative-motion pairs, scene/mood mutation, naming, presence,
+end-position adjustment, expert operations, arbitrary paths, name targets, and
+bulk operations remain unavailable.
+
+Command confirmation uses a newer matching official state when a deterministic
+target state exists. Actions without a deterministic documented result can be
+accepted but unconfirmed. The response retains the existing fields and adds the
+control type plus sanitized observed values.
+
+## Verification boundary
+
+Deterministic tests construct commands against mocks only and cover every
+supported type, invalid action/parameter combinations, range limits, scope and
+visibility failures, read-only restrictions, command encryption, and uncertain
+outcomes. Target validation for this change is strictly read-only: no real
+control command is dispatched and no physical device is moved or switched.
+Therefore the implementation can be reported as specification-aligned and
+package-tested, but not as hardware-confirmed control compatibility.

--- a/docs/development/plugin-concept.md
+++ b/docs/development/plugin-concept.md
@@ -726,7 +726,8 @@ Support-Matrix.
 
 ### Phase 2: Kontrollierte Loxone-Schreibaktionen
 
-- ausschließlich Gen.-1-`Switch` mit explizitem `on` und `off`
+- ausschließlich eng dokumentierte Aktionen für Gen.-1-`Switch`, `Dimmer`,
+  `LightController`, `LightControllerV2` und `Jalousie` gemäß ADR 0005
 - `loxone_operate_control` mit UUID-Ziel und beobachteter Zustandsbestätigung
 - kompaktes Audit im bestehenden Service-Log und separates Control-Rate-Limit
 - explizite Aktivierung und neuer OAuth-Consent für `loxone:control`
@@ -774,7 +775,7 @@ Support-Matrix.
 | 4 | öffentlicher Pluginpfad/Apache | exakte MCP-, OAuth- und Well-known-Pfade mit Apache 2.4.68 real bestätigt |
 | 5 | MCP-OAuth-Clientregistrierung und Sessionpersistenz | implementiert und automatisiert bestätigt: öffentliche Registrierung, PKCE S256, audience-gebundene opaque Tokens, Replay-Widerruf und atomare dateibasierte Persistenz; Claude Desktop vollständig real bestätigt; Codex Login und authentifizierter Aufruf bestätigt, Refresh und Revoke als dokumentierte Client-Limitierungen akzeptiert |
 | 6 | Miniserver-Firmware | Gen. 1 mindestens `17.1.7.27`; Gen.-2-Stände werden durch die öffentliche Beta bestätigt |
-| 7 | erste unterstützte Control-Typen | festgelegt für Phase 2: `Switch` mit explizitem `on` und `off` |
+| 7 | erste unterstützte Control-Typen | festgelegt für Phase 2: `Switch`, `Dimmer`, `LightController`, `LightControllerV2` und `Jalousie` mit den engen Aktionen aus ADR 0005 |
 | 8 | Zeitpunkt und Umfang von `loxberry:read` | festgelegt: erst Phase 3 mit eigener lokaler Freigabe |
 | 9 | externer HTTPS-Zugriff im ersten Test | festgelegt: nicht enthalten, erster Test nur lokal/LAN |
 

--- a/docs/development/support-matrix.md
+++ b/docs/development/support-matrix.md
@@ -1,8 +1,9 @@
 # Support-Matrix
 
-- **Stand:** Abnahmestand Phase 2, 2026-08-06
+- **Stand:** Erweiterter Phase-2-Implementierungsstand, 2026-08-06
 - **Aktueller Pre-Release:** `0.2.0-alpha.1`
-- **Nächster Meilenstein:** Phase 3 mit LoxBerry Read-only
+- **Nächster Meilenstein:** gezielte reale Abnahme der erweiterten
+  Gen.-1-Schreibaktionen und ein Folgerelease
 
 Diese Matrix unterscheidet reale Nachweise von implementierten, aber noch nicht
 real bestätigten Kombinationen. Phase 1 und Phase 2 sind abgenommen;
@@ -85,6 +86,9 @@ Der vollständige maskierte Nachweis steht im
 - Codex CLI wurde im finalen Abschlusslauf wegen der lokalen
   Windows-Ausführungsstörung nicht erneut abgenommen; der bekannte Clientfehler
   ist für den Server- und Claude-Nachweis nicht blockierend.
-- Phase 2 unterstützt ausschließlich Gen.-1-`Switch` mit `on` und `off`.
-  Weitere Control-Typen und Gen.-2-Schreibzugriff bleiben unbestätigt und sind
-  nicht freigegeben.
+- Phase 2 implementiert die in ADR 0005 begrenzten Aktionen für `Switch`,
+  `Dimmer`, `LightController`, `LightControllerV2` und `Jalousie`. Befehlspfad,
+  Validierung und Bestätigungslogik sind mit lokalen Testdoubles geprüft. In
+  diesem Lauf wird auf dem Zielsystem ausschließlich gelesen; die erweiterten
+  Schreibaktionen sind daher noch nicht als reale Hardwarekompatibilität
+  bestätigt.

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -4,7 +4,7 @@
 
 - LoxBerry 4.0.0 oder neuer; Referenzsystem ist 4.0.0.14 auf Debian 13/arm64.
 - Ein eigener Loxone-Benutzer mit möglichst kleinen Lese- und, falls benötigt,
-  gezielt vergebenen Switch-Rechten.
+  gezielt vergebenen Rechten für die unterstützten Controls.
 - Gen. 1: private lokale HTTP-Adresse. Gen. 2: gültige HTTPS-Adresse mit
   vertrauenswürdigem Zertifikat; derzeit experimentell.
 - Keine Zugangsdaten in URLs. Basic Auth wird nicht unterstützt.
@@ -43,8 +43,8 @@ beziehungsweise Schreibrechte. Dafür wird keine lokale Node.js-Bridge benötigt
 
 Die sechs lesenden Loxone-Datentools und das lesende Skill-Guide-Tool bleiben
 standardmäßig aktiv. Wähle unter **Zugriff auf den Miniserver über den MCP
-Server** die Option **Lesen und schalten**, um zusätzlich Gen.-1-Switches
-bedienen zu können. Danach ist eine neue OAuth-Freigabe mit `loxone:control`
+Server** die Option **Lesen und schalten**, um zusätzlich unterstützte
+Gen.-1-Controls bedienen zu können. Danach ist eine neue OAuth-Freigabe mit `loxone:control`
 erforderlich. Beim Zurückwechseln auf **Nur lesen** werden bestehende
 Control-Sitzungen widerrufen; reine Lesesitzungen bleiben gültig. Bei einem
 Gen.-2-/HTTPS-Ziel kann **Lesen und schalten** nicht aktiviert werden.
@@ -55,7 +55,7 @@ Der Server liefert den Agent Skill
 [`using-loxberry-mcp`](../src/mcpserver/skills/using-loxberry-mcp/SKILL.md)
 direkt über MCP aus. Er beschreibt den sicheren Ablauf für Suche, Pagination,
 Zustandsabfragen, mehrdeutige Namen und ausdrücklich angeforderte
-Switch-Aktionen. Die maschinenlesbaren JSON-Schemas bleiben Bestandteil der
+Control-Aktionen. Die maschinenlesbaren JSON-Schemas bleiben Bestandteil der
 MCP-Tools und werden im Skill nicht dupliziert.
 
 Beim Verbindungsaufbau weist der Server den Client in seinen MCP-Instructions
@@ -186,9 +186,14 @@ widerrufen werden.
 
 Die Alpha veröffentlicht sechs dokumentierte Loxone-Datentools, das lesende
 `loxone_get_skill_guide` und optional `loxone_operate_control`. Das Schreibtool
-akzeptiert ausschließlich eine
-sichtbare Control-UUID vom Typ `Switch` und die Aktion `on` oder `off`. Es bietet
-keine Namens-, Raum-, Bulk- oder freien Kommandos. Historie, LoxBerry-Tools und
+akzeptiert ausschließlich eine sichtbare Control-UUID und eine von
+`loxone_describe_control` ausdrücklich angebotene Aktion. Unterstützt werden
+`Switch`, `Dimmer`, `LightController`, `LightControllerV2` und `Jalousie`;
+Automatikaktionen einer Jalousie werden nur bei `details.isAutomatic=true`
+angeboten. Prozentwerte sind auf 0 bis 100 begrenzt, Lichtstimmungen auf
+dokumentierte Szenen- beziehungsweise Mood-IDs. Es gibt keine Namens-, Raum-,
+Bulk- oder freien Kommandos und keine Lern-, Umbenennungs- oder Expertenbefehle.
+Historie, LoxBerry-Tools und
 Basic Auth bleiben ausgeschlossen. Ergebnisse und Aktionen entsprechen den
 Rechten des angemeldeten Loxone-Benutzers.
 

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -191,7 +191,8 @@ akzeptiert ausschließlich eine sichtbare Control-UUID und eine von
 `Switch`, `Dimmer`, `LightController`, `LightControllerV2` und `Jalousie`;
 Automatikaktionen einer Jalousie werden nur bei `details.isAutomatic=true`
 angeboten. Prozentwerte sind auf 0 bis 100 begrenzt, Lichtstimmungen auf
-dokumentierte Szenen- beziehungsweise Mood-IDs. Es gibt keine Namens-, Raum-,
+dokumentierte Szenen- beziehungsweise die aktuell sichtbaren numerischen
+`moodList`-IDs. Es gibt keine Namens-, Raum-,
 Bulk- oder freien Kommandos und keine Lern-, Umbenennungs- oder Expertenbefehle.
 Historie, LoxBerry-Tools und
 Basic Auth bleiben ausgeschlossen. Ergebnisse und Aktionen entsprechen den

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -4,7 +4,7 @@
 
 - LoxBerry 4.0.0 or newer; the reference target is 4.0.0.14 on Debian 13/arm64.
 - A dedicated Loxone user with the smallest practical read permissions and,
-  when needed, narrowly assigned Switch permissions.
+  when needed, narrowly assigned permissions for the supported controls.
 - Gen. 1: a private local HTTP address. Gen. 2: a valid HTTPS address with a
   trusted certificate; currently experimental.
 - Never put credentials in URLs. Basic Auth is unsupported.
@@ -42,8 +42,8 @@ does not require a local Node.js bridge.
 
 The six read-only Loxone data tools and the read-only skill-guide tool remain
 enabled by default. Under **Miniserver access through the MCP server**, select
-**Read and switch** to additionally operate Gen. 1 Switches. A new OAuth grant
-with `loxone:control` is then required. Switching back to **Read only** revokes
+**Read and switch** to additionally operate supported Gen. 1 controls. A new
+OAuth grant with `loxone:control` is then required. Switching back to **Read only** revokes
 existing control sessions while read-only sessions remain valid. **Read and
 switch** cannot be enabled for a Gen. 2/HTTPS target.
 
@@ -52,7 +52,7 @@ switch** cannot be enabled for a Gen. 2/HTTPS target.
 The server delivers the
 [`using-loxberry-mcp`](../src/mcpserver/skills/using-loxberry-mcp/SKILL.md)
 Agent Skill directly through MCP. It describes the safe workflow for discovery,
-pagination, state reads, ambiguous names and explicitly requested Switch
+pagination, state reads, ambiguous names and explicitly requested control
 operations. Machine-readable JSON schemas remain part of the MCP tools and are
 not duplicated in the skill.
 
@@ -174,9 +174,13 @@ revocation it can still be revoked under **Clients and sessions**.
 
 The alpha publishes six documented Loxone data tools, the read-only
 `loxone_get_skill_guide`, and optionally `loxone_operate_control`. The control
-tool accepts only a visible `Switch`
-control UUID and the action `on` or `off`. It provides no name-, room-, bulk- or
-free-form commands. History, LoxBerry tools and Basic Auth remain excluded.
+tool accepts only a visible control UUID and an action explicitly advertised by
+`loxone_describe_control`. Supported types are `Switch`, `Dimmer`,
+`LightController`, `LightControllerV2`, and `Jalousie`; automatic blind actions
+are offered only when `details.isAutomatic=true`. Percentages are limited to 0
+through 100, and lighting moods to documented scene or mood IDs. The server
+provides no name-, room-, bulk-, free-form, learning, renaming, or expert
+commands. History, LoxBerry tools and Basic Auth remain excluded.
 Results and actions are limited to the authenticated Loxone user's permissions.
 
 The English healthcheck never repairs the system:

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -178,7 +178,8 @@ tool accepts only a visible control UUID and an action explicitly advertised by
 `loxone_describe_control`. Supported types are `Switch`, `Dimmer`,
 `LightController`, `LightControllerV2`, and `Jalousie`; automatic blind actions
 are offered only when `details.isAutomatic=true`. Percentages are limited to 0
-through 100, and lighting moods to documented scene or mood IDs. The server
+through 100, and lighting moods to documented scene IDs or currently visible
+numeric `moodList` IDs. The server
 provides no name-, room-, bulk-, free-form, learning, renaming, or expert
 commands. History, LoxBerry tools and Basic Auth remain excluded.
 Results and actions are limited to the authenticated Loxone user's permissions.

--- a/src/mcpserver/loxone/client.py
+++ b/src/mcpserver/loxone/client.py
@@ -44,7 +44,7 @@ _APP_PERMISSION: Final = 4
 _PERCENT_COMMAND = r"(?:100(?:\.0+)?|(?:[0-9]|[1-9][0-9])(?:\.[0-9]+)?)"
 _CONTROL_COMMAND = re.compile(
     rf"(?:on|off|FullUp|FullDown|shade|stop|auto|NoAuto|"
-    rf"changeTo/(?:0|ID(?:[1-9]|[1-9][0-9]))|"
+    rf"changeTo/(?:0|[1-9][0-9]{{0,9}})|"
     rf"manualPosition/{_PERCENT_COMMAND}|manualLamelle/{_PERCENT_COMMAND}|"
     rf"manualPosBlind/{_PERCENT_COMMAND}/{_PERCENT_COMMAND}|{_PERCENT_COMMAND})\Z"
 )

--- a/src/mcpserver/loxone/client.py
+++ b/src/mcpserver/loxone/client.py
@@ -41,6 +41,13 @@ _LOGGER = logging.getLogger(__name__)
 _MAX_RESPONSE_BYTES: Final = 8 * 1024 * 1024
 _DEFAULT_TIMEOUT_SECONDS: Final = 10.0
 _APP_PERMISSION: Final = 4
+_PERCENT_COMMAND = r"(?:100(?:\.0+)?|(?:[0-9]|[1-9][0-9])(?:\.[0-9]+)?)"
+_CONTROL_COMMAND = re.compile(
+    rf"(?:on|off|FullUp|FullDown|shade|stop|auto|NoAuto|"
+    rf"changeTo/(?:0|ID(?:[1-9]|[1-9][0-9]))|"
+    rf"manualPosition/{_PERCENT_COMMAND}|manualLamelle/{_PERCENT_COMMAND}|"
+    rf"manualPosBlind/{_PERCENT_COMMAND}/{_PERCENT_COMMAND}|{_PERCENT_COMMAND})\Z"
+)
 _GEN1_IPV4_NETWORKS: Final = tuple(
     ipaddress.ip_network(value) for value in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")
 )
@@ -590,12 +597,18 @@ class LoxoneWebSocketSession:
             # successful terminal response in that case.
             return
 
-    async def operate_switch(self, action_uuid: str, action: str) -> None:
-        """Execute the only Phase 2 control command through this authenticated session."""
-        if not action_uuid or len(action_uuid) > 128 or action not in {"on", "off"}:
-            raise ValueError("invalid Switch operation")
+    async def operate_control(self, action_uuid: str, command: str) -> None:
+        """Execute one command prepared by the bounded control contract."""
+        if (
+            not action_uuid
+            or len(action_uuid) > 128
+            or not command
+            or len(command) > 128
+            or _CONTROL_COMMAND.fullmatch(command) is None
+        ):
+            raise ValueError("invalid control operation")
         await self._command(
-            f"jdev/sps/io/{quote(action_uuid, safe='')}/{action}",
+            f"jdev/sps/io/{quote(action_uuid, safe='')}/{quote(command, safe='/')}",
             encrypted=not self._secure_transport,
         )
 

--- a/src/mcpserver/loxone/control.py
+++ b/src/mcpserver/loxone/control.py
@@ -1,0 +1,160 @@
+"""Officially documented, narrowly allowlisted Loxone control commands."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from decimal import Decimal
+
+from mcpserver.loxone.models import Control
+
+SUPPORTED_CONTROL_TYPES = frozenset(
+    {"Switch", "Dimmer", "LightController", "LightControllerV2", "Jalousie"}
+)
+_MOOD_ID = re.compile(r"(?:0|ID(?:[1-9]|[1-9][0-9]))\Z")
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedControlCommand:
+    command: str
+    expected_states: tuple[tuple[str, float | str], ...] = ()
+
+
+def allowed_actions(control: Control) -> list[str]:
+    """Return actions whose command contracts are documented for this control."""
+    if control.action_uuid is None or not 1 <= len(control.action_uuid) <= 128 or control.read_only:
+        return []
+    match control.control_type:
+        case "Switch":
+            return ["on", "off"]
+        case "Dimmer":
+            return ["on", "off", "set_level"]
+        case "LightController":
+            return ["on", "off", "set_mood"]
+        case "LightControllerV2":
+            return ["off", "set_mood"]
+        case "Jalousie":
+            actions = [
+                "open",
+                "close",
+                "shade",
+                "stop",
+                "set_position",
+                "set_slat_position",
+                "set_position_and_slats",
+            ]
+            if control.is_automatic:
+                actions.extend(["enable_auto", "disable_auto"])
+            return actions
+        case _:
+            return []
+
+
+def _percentage(value: float | None, name: str) -> float:
+    if value is None or isinstance(value, bool) or not 0 <= value <= 100:
+        raise ValueError(f"{name} must be a number from 0 to 100")
+    return float(value)
+
+
+def _number(value: float) -> str:
+    formatted = format(Decimal(str(value)), "f")
+    return formatted.rstrip("0").rstrip(".") if "." in formatted else formatted
+
+
+def prepare_control_command(
+    control: Control,
+    action: str,
+    *,
+    level: float | None = None,
+    mood_id: str | None = None,
+    position: float | None = None,
+    slat_position: float | None = None,
+) -> PreparedControlCommand:
+    """Validate one exact action/parameter combination and build its Loxone command."""
+    provided = {
+        "level": level,
+        "mood_id": mood_id,
+        "position": position,
+        "slat_position": slat_position,
+    }
+
+    def require_only(*names: str) -> None:
+        unexpected = [
+            name for name, value in provided.items() if value is not None and name not in names
+        ]
+        missing = [name for name in names if provided[name] is None]
+        if unexpected or missing:
+            expected = ", ".join(names) if names else "no parameters"
+            raise ValueError(f"action {action} requires {expected}")
+
+    if action not in allowed_actions(control):
+        raise ValueError(f"action {action} is not supported for {control.control_type}")
+
+    if control.control_type == "Switch":
+        require_only()
+        return PreparedControlCommand(action, (("active", 1.0 if action == "on" else 0.0),))
+
+    if control.control_type == "Dimmer":
+        if action in {"on", "off"}:
+            require_only()
+            expected = (("position", "__positive__"),) if action == "on" else (("position", 0.0),)
+            return PreparedControlCommand(action, expected)
+        require_only("level")
+        target = _percentage(level, "level")
+        return PreparedControlCommand(_number(target), (("position", target),))
+
+    if control.control_type == "LightController":
+        if action in {"on", "off"}:
+            require_only()
+            target = 9.0 if action == "on" else 0.0
+            return PreparedControlCommand(action, (("activeScene", target),))
+        require_only("mood_id")
+        if mood_id is None or not mood_id.isdecimal() or not 0 <= int(mood_id) <= 99:
+            raise ValueError("mood_id must be a decimal scene number from 0 to 99")
+        return PreparedControlCommand(mood_id, (("activeScene", float(mood_id)),))
+
+    if control.control_type == "LightControllerV2":
+        if action == "off":
+            require_only()
+            return PreparedControlCommand("changeTo/0", (("activeMoods", "0"),))
+        require_only("mood_id")
+        if mood_id is None or not _MOOD_ID.fullmatch(mood_id):
+            raise ValueError("mood_id must be 0 or an official ID from ID1 to ID99")
+        return PreparedControlCommand(f"changeTo/{mood_id}", (("activeMoods", mood_id),))
+
+    if action in {"open", "close", "shade", "stop", "enable_auto", "disable_auto"}:
+        require_only()
+        commands = {
+            "open": "FullUp",
+            "close": "FullDown",
+            "shade": "shade",
+            "stop": "stop",
+            "enable_auto": "auto",
+            "disable_auto": "NoAuto",
+        }
+        expected_by_action: dict[str, tuple[tuple[str, float | str], ...]] = {
+            "open": (("targetPosition", 0.0),),
+            "close": (("targetPosition", 1.0),),
+            "enable_auto": (("autoActive", 1.0),),
+            "disable_auto": (("autoActive", 0.0),),
+        }
+        return PreparedControlCommand(commands[action], expected_by_action.get(action, ()))
+    if action == "set_position":
+        require_only("position")
+        target = _percentage(position, "position")
+        return PreparedControlCommand(
+            f"manualPosition/{_number(target)}", (("targetPosition", target / 100),)
+        )
+    if action == "set_slat_position":
+        require_only("slat_position")
+        target = _percentage(slat_position, "slat_position")
+        return PreparedControlCommand(
+            f"manualLamelle/{_number(target)}", (("targetPositionLamelle", target / 100),)
+        )
+    require_only("position", "slat_position")
+    target = _percentage(position, "position")
+    slats = _percentage(slat_position, "slat_position")
+    return PreparedControlCommand(
+        f"manualPosBlind/{_number(target)}/{_number(slats)}",
+        (("targetPosition", target / 100), ("targetPositionLamelle", slats / 100)),
+    )

--- a/src/mcpserver/loxone/control.py
+++ b/src/mcpserver/loxone/control.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 import re
+from collections.abc import Mapping
 from dataclasses import dataclass
 from decimal import Decimal
 
@@ -11,13 +13,36 @@ from mcpserver.loxone.models import Control
 SUPPORTED_CONTROL_TYPES = frozenset(
     {"Switch", "Dimmer", "LightController", "LightControllerV2", "Jalousie"}
 )
-_MOOD_ID = re.compile(r"(?:0|ID(?:[1-9]|[1-9][0-9]))\Z")
+_MOOD_ID = re.compile(r"(?:0|[1-9][0-9]{0,9})\Z")
 
 
 @dataclass(frozen=True, slots=True)
 class PreparedControlCommand:
     command: str
     expected_states: tuple[tuple[str, float | str], ...] = ()
+
+
+def visible_mood_ids(value: object) -> frozenset[str] | None:
+    """Return bounded decimal IDs from one visible LightControllerV2 moodList state."""
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            return None
+    if not isinstance(value, list) or len(value) > 1000:
+        return None
+    result: set[str] = set()
+    for item in value:
+        if not isinstance(item, Mapping):
+            return None
+        mood_id = item.get("id")
+        if isinstance(mood_id, bool):
+            return None
+        normalized = str(mood_id) if isinstance(mood_id, int | str) else ""
+        if not _MOOD_ID.fullmatch(normalized):
+            return None
+        result.add(normalized)
+    return frozenset(result)
 
 
 def allowed_actions(control: Control) -> list[str]:
@@ -119,7 +144,7 @@ def prepare_control_command(
             return PreparedControlCommand("changeTo/0", (("activeMoods", "0"),))
         require_only("mood_id")
         if mood_id is None or not _MOOD_ID.fullmatch(mood_id):
-            raise ValueError("mood_id must be 0 or an official ID from ID1 to ID99")
+            raise ValueError("mood_id must be a decimal ID from the visible moodList")
         return PreparedControlCommand(f"changeTo/{mood_id}", (("activeMoods", mood_id),))
 
     if action in {"open", "close", "shade", "stop", "enable_auto", "disable_auto"}:

--- a/src/mcpserver/loxone/models.py
+++ b/src/mcpserver/loxone/models.py
@@ -38,6 +38,9 @@ class Control:
     category_uuid: str | None
     action_uuid: str | None
     state_uuids: tuple[tuple[str, str], ...]
+    restrictions: int = 0
+    read_only: bool = False
+    is_automatic: bool = False
     subcontrols: tuple[Control, ...] = ()
 
 

--- a/src/mcpserver/loxone/runtime.py
+++ b/src/mcpserver/loxone/runtime.py
@@ -21,7 +21,11 @@ from mcpserver.loxone.client import (
     LoxoneToken,
     LoxoneWebSocketSession,
 )
-from mcpserver.loxone.control import SUPPORTED_CONTROL_TYPES, prepare_control_command
+from mcpserver.loxone.control import (
+    SUPPORTED_CONTROL_TYPES,
+    prepare_control_command,
+    visible_mood_ids,
+)
 from mcpserver.loxone.events import LoxoneProtocolError
 from mcpserver.loxone.models import Control, Freshness, LoxoneStructure, StateRecord
 
@@ -247,6 +251,30 @@ class LoxoneRuntime:
                 except ValueError as exc:
                     raise ControlOperationError("invalid_input", str(exc)) from exc
                 state_uuids = dict(control.state_uuids)
+                if (
+                    control.control_type == "LightControllerV2"
+                    and action == "set_mood"
+                    and mood_id != "0"
+                ):
+                    mood_list_uuid = state_uuids.get("moodList")
+                    if mood_list_uuid is None:
+                        raise ControlOperationError(
+                            "unsupported_control", "control has no visible moodList state"
+                        )
+                    mood_list = self.cache.get(snapshot.subject, mood_list_uuid)
+                    if mood_list.freshness is not Freshness.CURRENT:
+                        raise ControlOperationError(
+                            "temporarily_unavailable", "visible moodList is not current"
+                        )
+                    available_moods = visible_mood_ids(mood_list.value)
+                    if available_moods is None:
+                        raise ControlOperationError(
+                            "unsupported_control", "visible moodList has an invalid format"
+                        )
+                    if mood_id not in available_moods:
+                        raise ControlOperationError(
+                            "invalid_input", "mood_id is not present in the visible moodList"
+                        )
                 missing = [
                     name for name, _target in prepared.expected_states if name not in state_uuids
                 ]

--- a/src/mcpserver/loxone/runtime.py
+++ b/src/mcpserver/loxone/runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import time
 from collections import defaultdict, deque
 from collections.abc import AsyncIterator
@@ -20,6 +21,7 @@ from mcpserver.loxone.client import (
     LoxoneToken,
     LoxoneWebSocketSession,
 )
+from mcpserver.loxone.control import SUPPORTED_CONTROL_TYPES, prepare_control_command
 from mcpserver.loxone.events import LoxoneProtocolError
 from mcpserver.loxone.models import Control, Freshness, LoxoneStructure, StateRecord
 
@@ -42,10 +44,12 @@ class ControlOperationError(RuntimeError):
 @dataclass(frozen=True, slots=True)
 class ControlOperation:
     control_uuid: str
+    control_type: str
     action: str
     accepted: bool
     confirmed: bool
     observed_state: str
+    observed_values: tuple[tuple[str, object], ...] = ()
 
 
 def _state_uuids(controls: tuple[Control, ...]) -> frozenset[str]:
@@ -141,14 +145,41 @@ class LoxoneRuntime:
             pending.extend(control.subcontrols)
         return None
 
-    async def operate_switch(
-        self, access: StoredAccessToken, control_uuid: str, action: str
+    @staticmethod
+    def _state_matches(value: object, target: float | str) -> bool:
+        if target == "__positive__":
+            return isinstance(value, int | float) and not isinstance(value, bool) and value > 0
+        if isinstance(target, float):
+            return (
+                isinstance(value, int | float)
+                and not isinstance(value, bool)
+                and abs(float(value) - target) <= 0.001
+            )
+        if target == "0" and isinstance(value, str) and value in {"[]", "[0]", '["0"]'}:
+            return True
+        if isinstance(value, str):
+            with suppress(json.JSONDecodeError):
+                value = json.loads(value)
+        if isinstance(value, list | tuple):
+            return target in {str(item) for item in value}
+        return str(value) == target
+
+    async def operate_control(
+        self,
+        access: StoredAccessToken,
+        control_uuid: str,
+        action: str,
+        *,
+        level: float | None = None,
+        mood_id: str | None = None,
+        position: float | None = None,
+        slat_position: float | None = None,
     ) -> ControlOperation:
-        """Execute a bounded Switch operation for the immutable OAuth identity."""
+        """Execute one bounded documented operation for the immutable OAuth identity."""
         if READ_SCOPE not in access.scopes or CONTROL_SCOPE not in access.scopes:
             raise ControlOperationError("permission_denied", "loxone:control is required")
-        if not control_uuid or len(control_uuid) > 128 or action not in {"on", "off"}:
-            raise ControlOperationError("invalid_input", "invalid Switch operation")
+        if not control_uuid or len(control_uuid) > 128 or not action or len(action) > 64:
+            raise ControlOperationError("invalid_input", "invalid control operation")
 
         now = time.monotonic()
         if not self._consume_rate(self._rate[access.family_id], self._rate_limit, now):
@@ -192,25 +223,42 @@ class LoxoneRuntime:
                 control = self._control(structure, control_uuid)
                 if control is None:
                     raise ControlOperationError("not_found", "control is not visible")
-                if control.control_type != "Switch":
-                    raise ControlOperationError(
-                        "unsupported_control", "only Switch controls are supported"
-                    )
-                if control.action_uuid is None:
+                if control.action_uuid is None or control.read_only:
                     raise ControlOperationError(
                         "permission_denied", "control is not operable for this identity"
                     )
                 if not 1 <= len(control.action_uuid) <= 128:
                     raise ControlOperationError(
-                        "unsupported_control", "Switch control has an invalid action target"
+                        "unsupported_control", "control has an invalid action target"
                     )
-                active_uuid = dict(control.state_uuids).get("active")
-                if active_uuid is None:
+                if control.control_type not in SUPPORTED_CONTROL_TYPES:
                     raise ControlOperationError(
-                        "unsupported_control", "Switch control has no active state"
+                        "unsupported_control", "control type is not supported"
                     )
-                before = self.cache.get(snapshot.subject, active_uuid).observed_at
-                await command_session.operate_switch(control.action_uuid, action)
+                try:
+                    prepared = prepare_control_command(
+                        control,
+                        action,
+                        level=level,
+                        mood_id=mood_id,
+                        position=position,
+                        slat_position=slat_position,
+                    )
+                except ValueError as exc:
+                    raise ControlOperationError("invalid_input", str(exc)) from exc
+                state_uuids = dict(control.state_uuids)
+                missing = [
+                    name for name, _target in prepared.expected_states if name not in state_uuids
+                ]
+                if missing:
+                    raise ControlOperationError(
+                        "unsupported_control", "control lacks a state required for confirmation"
+                    )
+                before = {
+                    name: self.cache.get(snapshot.subject, state_uuids[name]).observed_at
+                    for name, _target in prepared.expected_states
+                }
+                await command_session.operate_control(control.action_uuid, prepared.command)
             except ControlOperationError:
                 raise
             except LoxoneCommandRejected as exc:
@@ -225,23 +273,53 @@ class LoxoneRuntime:
             finally:
                 await command_session.close()
 
-            target = 1.0 if action == "on" else 0.0
+            if not prepared.expected_states:
+                return ControlOperation(
+                    control_uuid, control.control_type, action, True, False, "unknown"
+                )
             deadline = time.monotonic() + self._control_confirmation_seconds
-            observed = self.cache.get(snapshot.subject, active_uuid)
+            observed_values: dict[str, object] = {}
             while time.monotonic() < deadline:
-                observed = self.cache.get(snapshot.subject, active_uuid)
-                if (
-                    observed.freshness is Freshness.CURRENT
-                    and observed.observed_at is not None
-                    and (before is None or observed.observed_at > before)
-                    and observed.value == target
-                ):
-                    return ControlOperation(control_uuid, action, True, True, action)
+                confirmed = True
+                for name, target in prepared.expected_states:
+                    observed = self.cache.get(snapshot.subject, state_uuids[name])
+                    previous_observed_at = before[name]
+                    if observed.value is not None:
+                        observed_values[name] = observed.value
+                    if not (
+                        observed.freshness is Freshness.CURRENT
+                        and observed.observed_at is not None
+                        and (
+                            previous_observed_at is None
+                            or observed.observed_at > previous_observed_at
+                        )
+                        and self._state_matches(observed.value, target)
+                    ):
+                        confirmed = False
+                if confirmed:
+                    state = action if control.control_type == "Switch" else "confirmed"
+                    return ControlOperation(
+                        control_uuid,
+                        control.control_type,
+                        action,
+                        True,
+                        True,
+                        state,
+                        tuple(observed_values.items()),
+                    )
                 await asyncio.sleep(0.05)
             state = "unknown"
-            if observed.freshness is Freshness.CURRENT and observed.value in {0.0, 1.0}:
-                state = "on" if observed.value == 1.0 else "off"
-            return ControlOperation(control_uuid, action, True, False, state)
+            if control.control_type == "Switch" and observed_values.get("active") in {0.0, 1.0}:
+                state = "on" if observed_values["active"] == 1.0 else "off"
+            return ControlOperation(
+                control_uuid,
+                control.control_type,
+                action,
+                True,
+                False,
+                state,
+                tuple(observed_values.items()),
+            )
 
     async def snapshot(self, access: StoredAccessToken) -> RuntimeSnapshot:
         subject = access.family_id

--- a/src/mcpserver/loxone/structure.py
+++ b/src/mcpserver/loxone/structure.py
@@ -8,6 +8,9 @@ from typing import Any
 from mcpserver.loxone.models import Control, LoxoneIdentity, LoxoneStructure, NamedGroup
 
 _REFERENCED_ONLY_INTERNAL = 1 << 0
+_READ_ONLY_INTERNAL = 1 << 1
+_READ_ONLY_EXTERNAL = 1 << 5
+_READ_ONLY = _READ_ONLY_INTERNAL | _READ_ONLY_EXTERNAL
 
 
 class LoxoneStructureError(ValueError):
@@ -58,6 +61,12 @@ def _controls(value: object, *, referenced: bool = False) -> tuple[Control, ...]
             if isinstance(name, str) and isinstance(state_uuid, str)
         )
         subcontrols_value = item.get("subControls", {})
+        details = item.get("details", {})
+        if not isinstance(details, Mapping):
+            raise LoxoneStructureError("Control details must be an object")
+        is_automatic = details.get("isAutomatic", False)
+        if not isinstance(is_automatic, bool):
+            raise LoxoneStructureError("Control details.isAutomatic must be boolean")
         controls.append(
             Control(
                 uuid=uuid,
@@ -65,8 +74,11 @@ def _controls(value: object, *, referenced: bool = False) -> tuple[Control, ...]
                 control_type=_text(item.get("type"), field="controls.type"),
                 room_uuid=_optional_uuid(item.get("room")),
                 category_uuid=_optional_uuid(item.get("cat")),
-                action_uuid=_optional_uuid(item.get("action")),
+                action_uuid=_optional_uuid(item.get("uuidAction")),
                 state_uuids=states,
+                restrictions=restrictions,
+                read_only=bool(restrictions & _READ_ONLY),
+                is_automatic=is_automatic,
                 subcontrols=(
                     _controls(subcontrols_value, referenced=True) if subcontrols_value else ()
                 ),

--- a/src/mcpserver/skill_delivery.py
+++ b/src/mcpserver/skill_delivery.py
@@ -8,7 +8,7 @@ from typing import Final
 from mcp.server.fastmcp import FastMCP
 
 SKILL_NAME: Final = "using-loxberry-mcp"
-SKILL_REVISION: Final = 1
+SKILL_REVISION: Final = 2
 SKILL_MIME_TYPE: Final = "text/markdown"
 SKILL_RESOURCE_URI: Final = f"skill://{SKILL_NAME}/SKILL.md"
 SERVER_INSTRUCTIONS: Final = (

--- a/src/mcpserver/skills/using-loxberry-mcp/SKILL.md
+++ b/src/mcpserver/skills/using-loxberry-mcp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-loxberry-mcp
-description: Guides safe use of the LoxBerry MCP Server to find Loxone rooms, categories, controls, read current states, diagnose connectivity, and explicitly operate supported switches. Use when a user asks about or requests control of a Loxone installation through the LoxBerry MCP Server, including ambiguous control names, stale state, pagination, or unconfirmed operations.
+description: Guides safe use of the LoxBerry MCP Server to find Loxone rooms, categories, controls, read current states, diagnose connectivity, and explicitly operate supported switches, dimmers, lighting controllers, and blinds. Use when a user asks about or requests control of a Loxone installation through the LoxBerry MCP Server, including ambiguous control names, stale state, pagination, or unconfirmed operations.
 ---
 
 # Using LoxBerry MCP
@@ -25,7 +25,7 @@ Check the complete result envelope. Do not treat a response as successful when
 `ok` is false. Surface relevant `warnings`, and qualify answers when `stale` is
 true or a state has an old or missing `observed_at` value.
 
-## Operate a switch
+## Operate a supported control
 
 Only operate a control when the user has explicitly requested one unambiguous
 action on one identified target.
@@ -35,11 +35,16 @@ action on one identified target.
 2. Call `loxone_describe_control` immediately before the operation.
 3. Continue only when `capabilities.allowed_actions` contains the requested
    action exactly.
-4. Call `loxone_operate_control` once with that control UUID and `on` or `off`.
+4. Call `loxone_operate_control` once with that control UUID, the advertised
+   action and only its required parameters. Switches use `on` or `off`; dimmers
+   use `set_level` with `level`; lighting controllers use `set_mood` with
+   `mood_id`; blinds use the advertised explicit target action and, when
+   required, `position` and/or `slat_position`.
 5. Never automatically retry an uncertain or failed write. Ask the user before
    any new attempt.
 
-Report `accepted`, `confirmed`, and `observed_state` separately. `accepted=true`
+Report `accepted`, `confirmed`, `observed_state`, and relevant
+`observed_values` separately. `accepted=true`
 means the command was accepted, not that the resulting physical state was
 confirmed. When `confirmed=false`, state the uncertainty and do not claim that
 the requested state was reached.

--- a/src/mcpserver/tools.py
+++ b/src/mcpserver/tools.py
@@ -20,6 +20,7 @@ from mcp.types import ToolAnnotations
 from pydantic import BaseModel, Field, JsonValue
 
 from mcpserver.auth.provider import CONTROL_SCOPE, StoredAccessToken
+from mcpserver.loxone.control import allowed_actions
 from mcpserver.loxone.models import Control, Freshness, NamedGroup
 from mcpserver.loxone.runtime import (
     ControlOperationError,
@@ -173,10 +174,12 @@ class SkillGuideEnvelope(ToolEnvelope):
 
 class ControlOperationData(BaseModel):
     control_uuid: str
-    action: Literal["on", "off"]
+    control_type: str
+    action: str
     accepted: bool
     confirmed: bool
-    observed_state: Literal["on", "off", "unknown"]
+    observed_state: str
+    observed_values: dict[str, JsonValue] = Field(default_factory=dict)
 
 
 class ControlOperationEnvelope(ToolEnvelope):
@@ -265,7 +268,7 @@ def _control_envelope(
             _audit_identity(str(access.client_id)) if access is not None else "unknown",
             _audit_identity(access.identity_id) if access is not None else "unknown",
             json.dumps(control_uuid[:128]),
-            action if action in {"on", "off"} else "invalid",
+            action[:64] if action else "invalid",
             outcome,
         )
     data = (
@@ -558,11 +561,8 @@ def register_read_tools(
             value["capabilities"] = {
                 "readable": True,
                 "allowed_actions": (
-                    ["on", "off"]
-                    if control_enabled
-                    and CONTROL_SCOPE in access_token.scopes
-                    and control.control_type == "Switch"
-                    and control.action_uuid is not None
+                    allowed_actions(control)
+                    if control_enabled and CONTROL_SCOPE in access_token.scopes
                     else []
                 ),
             }
@@ -666,7 +666,7 @@ def register_skill_tool(server: FastMCP) -> None:
 
 
 def register_control_tool(server: FastMCP, runtime: LoxoneRuntime | None) -> None:
-    """Publish the single explicitly enabled Phase 2 Switch operation."""
+    """Publish the single explicitly enabled bounded control operation."""
     annotations = ToolAnnotations(
         readOnlyHint=False,
         destructiveHint=True,
@@ -677,7 +677,8 @@ def register_control_tool(server: FastMCP, runtime: LoxoneRuntime | None) -> Non
     @server.tool(
         name="loxone_operate_control",
         description=(
-            "Switch one visible and operable Loxone Switch control explicitly on or off. "
+            "Operate one visible and operable Switch, Dimmer, LightController, "
+            "LightControllerV2, or Jalousie with an explicit documented action. "
             "Requires loxone:control. Never retries an uncertain command."
         ),
         annotations=annotations,
@@ -686,12 +687,63 @@ def register_control_tool(server: FastMCP, runtime: LoxoneRuntime | None) -> Non
     async def operate_control(
         control_uuid: Annotated[
             str,
-            Field(description="Exact operable Switch UUID returned by loxone_find_controls."),
+            Field(description="Exact operable control UUID returned by loxone_find_controls."),
         ],
         action: Annotated[
-            Literal["on", "off"],
-            Field(description="Explicit Switch action: on or off."),
+            Literal[
+                "on",
+                "off",
+                "set_level",
+                "set_mood",
+                "open",
+                "close",
+                "shade",
+                "stop",
+                "enable_auto",
+                "disable_auto",
+                "set_position",
+                "set_slat_position",
+                "set_position_and_slats",
+            ],
+            Field(description="Explicit action advertised by loxone_describe_control."),
         ],
+        level: Annotated[
+            float | None,
+            Field(
+                description="Dimmer level from 0 to 100; required only for set_level.",
+                json_schema_extra={"minimum": 0, "maximum": 100},
+            ),
+        ] = None,
+        mood_id: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Legacy scene number 0 to 99 or LightControllerV2 mood ID such as ID1; "
+                    "required only for set_mood."
+                ),
+                json_schema_extra={"maxLength": 4},
+            ),
+        ] = None,
+        position: Annotated[
+            float | None,
+            Field(
+                description=(
+                    "Jalousie target from 0 (fully open) to 100 (fully closed); required "
+                    "for set_position and set_position_and_slats."
+                ),
+                json_schema_extra={"minimum": 0, "maximum": 100},
+            ),
+        ] = None,
+        slat_position: Annotated[
+            float | None,
+            Field(
+                description=(
+                    "Jalousie slat target from 0 (horizontal) to 100 (vertical); required "
+                    "for set_slat_position and set_position_and_slats."
+                ),
+                json_schema_extra={"minimum": 0, "maximum": 100},
+            ),
+        ] = None,
     ) -> ControlOperationEnvelope:
         access: StoredAccessToken | None = None
         try:
@@ -700,7 +752,15 @@ def register_control_tool(server: FastMCP, runtime: LoxoneRuntime | None) -> Non
                 raise ControlOperationError(
                     "temporarily_unavailable", "the service is not configured"
                 )
-            operation = await runtime.operate_switch(access, control_uuid, action)
+            operation = await runtime.operate_control(
+                access,
+                control_uuid,
+                action,
+                level=level,
+                mood_id=mood_id,
+                position=position,
+                slat_position=slat_position,
+            )
             warnings = (
                 []
                 if operation.confirmed
@@ -712,10 +772,12 @@ def register_control_tool(server: FastMCP, runtime: LoxoneRuntime | None) -> Non
                 action,
                 result={
                     "control_uuid": operation.control_uuid,
+                    "control_type": operation.control_type,
                     "action": operation.action,
                     "accepted": operation.accepted,
                     "confirmed": operation.confirmed,
                     "observed_state": operation.observed_state,
+                    "observed_values": dict(operation.observed_values),
                 },
                 warnings=warnings,
             )

--- a/src/mcpserver/tools.py
+++ b/src/mcpserver/tools.py
@@ -718,10 +718,10 @@ def register_control_tool(server: FastMCP, runtime: LoxoneRuntime | None) -> Non
             str | None,
             Field(
                 description=(
-                    "Legacy scene number 0 to 99 or LightControllerV2 mood ID such as ID1; "
-                    "required only for set_mood."
+                    "Legacy scene number 0 to 99 or decimal LightControllerV2 mood ID "
+                    "returned by its visible moodList; required only for set_mood."
                 ),
-                json_schema_extra={"maxLength": 4},
+                json_schema_extra={"maxLength": 10},
             ),
         ] = None,
         position: Annotated[

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -174,10 +174,10 @@ async def test_transport_failure_after_dispatch_has_unknown_outcome(
         (
             "LightControllerV2",
             "set_mood",
-            {"mood_id": "ID12"},
-            "changeTo/ID12",
+            {"mood_id": "314"},
+            "changeTo/314",
             "activeMoods",
-            '["ID12"]',
+            "[314]",
         ),
         (
             "Jalousie",
@@ -205,11 +205,20 @@ async def test_supported_control_operation_is_bounded_and_confirmed(
         control_confirmation_seconds=0.2,
     )
     runtime.cache.begin_connection("family")
+    states = ((state_name, "state-1"),)
+    if control_type == "LightControllerV2":
+        states += (("moodList", "state-2"),)
     structure = _structure(
         control_type,
-        states=((state_name, "state-1"),),
+        states=states,
         automatic=action == "enable_auto",
     )
+    if control_type == "LightControllerV2":
+        runtime.cache.apply(
+            "family",
+            [StateEvent("state-2", '[{"name":"Synthetic Mood","id":314}]')],
+            allowed_uuids={"state-1", "state-2"},
+        )
 
     async def snapshot(_access: StoredAccessToken) -> RuntimeSnapshot:
         return RuntimeSnapshot("family", structure, True)
@@ -244,6 +253,52 @@ async def test_supported_control_operation_is_bounded_and_confirmed(
     assert result.control_type == control_type
     assert result.confirmed is True
     assert dict(result.observed_values)[state_name] == state_value
+
+
+@pytest.mark.asyncio
+async def test_light_controller_v2_rejects_mood_not_in_visible_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = LoxoneRuntime(
+        MiniserverEndpoint.parse_gen1("http://192.168.1.10"),
+        _TokenStore(),  # type: ignore[arg-type]
+    )
+    runtime.cache.begin_connection("family")
+    structure = _structure(
+        "LightControllerV2",
+        states=(("activeMoods", "state-1"), ("moodList", "state-2")),
+    )
+    runtime.cache.apply(
+        "family",
+        [StateEvent("state-2", '[{"name":"Allowed Test Mood","id":314}]')],
+        allowed_uuids={"state-1", "state-2"},
+    )
+
+    async def snapshot(_access: StoredAccessToken) -> RuntimeSnapshot:
+        return RuntimeSnapshot("family", structure, True)
+
+    class Session:
+        async def load_structure(self) -> LoxoneStructure:
+            return structure
+
+        async def close(self) -> None:
+            return None
+
+    class Client:
+        async def open_session(self, _token: LoxoneToken) -> Session:
+            return Session()
+
+    monkeypatch.setattr(runtime, "snapshot", snapshot)
+    runtime.client = Client()  # type: ignore[assignment]
+
+    with pytest.raises(ControlOperationError) as captured:
+        await runtime.operate_control(
+            _access(READ_SCOPE, CONTROL_SCOPE),
+            "control-1",
+            "set_mood",
+            mood_id="315",
+        )
+    assert captured.value.code == "invalid_input"
 
 
 @pytest.mark.asyncio

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -28,7 +28,13 @@ def _access(*scopes: str) -> StoredAccessToken:
     )
 
 
-def _structure(control_type: str = "Switch") -> LoxoneStructure:
+def _structure(
+    control_type: str = "Switch",
+    *,
+    states: tuple[tuple[str, str], ...] = (("active", "state-1"),),
+    automatic: bool = False,
+    read_only: bool = False,
+) -> LoxoneStructure:
     return LoxoneStructure(
         identity=LoxoneIdentity("user", "serial"),
         last_modified="1",
@@ -42,7 +48,9 @@ def _structure(control_type: str = "Switch") -> LoxoneStructure:
                 room_uuid=None,
                 category_uuid=None,
                 action_uuid="action-1",
-                state_uuids=(("active", "state-1"),),
+                state_uuids=states,
+                is_automatic=automatic,
+                read_only=read_only,
             ),
         ),
     )
@@ -69,8 +77,8 @@ async def test_switch_operation_is_sent_and_confirmed(monkeypatch: pytest.Monkey
         async def load_structure(self) -> LoxoneStructure:
             return _structure()
 
-        async def operate_switch(self, action_uuid: str, action: str) -> None:
-            assert (action_uuid, action) == ("action-1", "on")
+        async def operate_control(self, action_uuid: str, command: str) -> None:
+            assert (action_uuid, command) == ("action-1", "on")
             runtime.cache.apply("family", [StateEvent("state-1", 1.0)], allowed_uuids={"state-1"})
 
         async def close(self) -> None:
@@ -83,7 +91,7 @@ async def test_switch_operation_is_sent_and_confirmed(monkeypatch: pytest.Monkey
     monkeypatch.setattr(runtime, "snapshot", snapshot)
     runtime.client = Client()  # type: ignore[assignment]
 
-    result = await runtime.operate_switch(_access(READ_SCOPE, CONTROL_SCOPE), "control-1", "on")
+    result = await runtime.operate_control(_access(READ_SCOPE, CONTROL_SCOPE), "control-1", "on")
 
     assert result.accepted is True
     assert result.confirmed is True
@@ -100,7 +108,7 @@ async def test_control_requires_scope_and_supported_type(
     )
 
     with pytest.raises(ControlOperationError, match="loxone:control"):
-        await runtime.operate_switch(_access(READ_SCOPE), "control-1", "on")
+        await runtime.operate_control(_access(READ_SCOPE), "control-1", "on")
 
     async def snapshot(_access: StoredAccessToken) -> RuntimeSnapshot:
         return RuntimeSnapshot("family", _structure(), True)
@@ -119,8 +127,8 @@ async def test_control_requires_scope_and_supported_type(
     monkeypatch.setattr(runtime, "snapshot", snapshot)
     runtime.client = Client()  # type: ignore[assignment]
     with pytest.raises(ControlOperationError) as captured:
-        await runtime.operate_switch(_access(READ_SCOPE, CONTROL_SCOPE), "control-1", "on")
-    assert captured.value.code == "unsupported_control"
+        await runtime.operate_control(_access(READ_SCOPE, CONTROL_SCOPE), "control-1", "set_mood")
+    assert captured.value.code == "invalid_input"
 
 
 @pytest.mark.asyncio
@@ -139,7 +147,7 @@ async def test_transport_failure_after_dispatch_has_unknown_outcome(
         async def load_structure(self) -> LoxoneStructure:
             return _structure()
 
-        async def operate_switch(self, _action_uuid: str, _action: str) -> None:
+        async def operate_control(self, _action_uuid: str, _command: str) -> None:
             raise TimeoutError
 
         async def close(self) -> None:
@@ -153,5 +161,117 @@ async def test_transport_failure_after_dispatch_has_unknown_outcome(
     runtime.client = Client()  # type: ignore[assignment]
 
     with pytest.raises(ControlOperationError) as captured:
-        await runtime.operate_switch(_access(READ_SCOPE, CONTROL_SCOPE), "control-1", "off")
+        await runtime.operate_control(_access(READ_SCOPE, CONTROL_SCOPE), "control-1", "off")
     assert captured.value.code == "outcome_unknown"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("control_type", "action", "kwargs", "command", "state_name", "state_value"),
+    [
+        ("Dimmer", "set_level", {"level": 40}, "40", "position", 40.0),
+        ("LightController", "set_mood", {"mood_id": "7"}, "7", "activeScene", 7.0),
+        (
+            "LightControllerV2",
+            "set_mood",
+            {"mood_id": "ID12"},
+            "changeTo/ID12",
+            "activeMoods",
+            '["ID12"]',
+        ),
+        (
+            "Jalousie",
+            "set_position",
+            {"position": 25},
+            "manualPosition/25",
+            "targetPosition",
+            0.25,
+        ),
+        ("Jalousie", "enable_auto", {}, "auto", "autoActive", 1.0),
+    ],
+)
+async def test_supported_control_operation_is_bounded_and_confirmed(
+    monkeypatch: pytest.MonkeyPatch,
+    control_type: str,
+    action: str,
+    kwargs: dict[str, object],
+    command: str,
+    state_name: str,
+    state_value: float | str,
+) -> None:
+    runtime = LoxoneRuntime(
+        MiniserverEndpoint.parse_gen1("http://192.168.1.10"),
+        _TokenStore(),  # type: ignore[arg-type]
+        control_confirmation_seconds=0.2,
+    )
+    runtime.cache.begin_connection("family")
+    structure = _structure(
+        control_type,
+        states=((state_name, "state-1"),),
+        automatic=action == "enable_auto",
+    )
+
+    async def snapshot(_access: StoredAccessToken) -> RuntimeSnapshot:
+        return RuntimeSnapshot("family", structure, True)
+
+    class Session:
+        async def load_structure(self) -> LoxoneStructure:
+            return structure
+
+        async def operate_control(self, action_uuid: str, actual: str) -> None:
+            assert (action_uuid, actual) == ("action-1", command)
+            runtime.cache.apply(
+                "family", [StateEvent("state-1", state_value)], allowed_uuids={"state-1"}
+            )
+
+        async def close(self) -> None:
+            return None
+
+    class Client:
+        async def open_session(self, _token: LoxoneToken) -> Session:
+            return Session()
+
+    monkeypatch.setattr(runtime, "snapshot", snapshot)
+    runtime.client = Client()  # type: ignore[assignment]
+
+    result = await runtime.operate_control(
+        _access(READ_SCOPE, CONTROL_SCOPE),
+        "control-1",
+        action,
+        **kwargs,  # type: ignore[arg-type]
+    )
+
+    assert result.control_type == control_type
+    assert result.confirmed is True
+    assert dict(result.observed_values)[state_name] == state_value
+
+
+@pytest.mark.asyncio
+async def test_read_only_restriction_prevents_dispatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime = LoxoneRuntime(
+        MiniserverEndpoint.parse_gen1("http://192.168.1.10"),
+        _TokenStore(),  # type: ignore[arg-type]
+    )
+    structure = _structure(read_only=True)
+
+    async def snapshot(_access: StoredAccessToken) -> RuntimeSnapshot:
+        return RuntimeSnapshot("family", structure, True)
+
+    class Session:
+        async def load_structure(self) -> LoxoneStructure:
+            return structure
+
+        async def close(self) -> None:
+            return None
+
+    class Client:
+        async def open_session(self, _token: LoxoneToken) -> Session:
+            return Session()
+
+    monkeypatch.setattr(runtime, "snapshot", snapshot)
+    runtime.client = Client()  # type: ignore[assignment]
+
+    with pytest.raises(ControlOperationError) as captured:
+        await runtime.operate_control(_access(READ_SCOPE, CONTROL_SCOPE), "control-1", "on")
+
+    assert captured.value.code == "permission_denied"

--- a/tests/test_control_commands.py
+++ b/tests/test_control_commands.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import pytest
+
+from mcpserver.loxone.control import allowed_actions, prepare_control_command
+from mcpserver.loxone.models import Control
+
+
+def _control(control_type: str, *, automatic: bool = False, read_only: bool = False) -> Control:
+    return Control(
+        uuid="control",
+        name="Control",
+        control_type=control_type,
+        room_uuid=None,
+        category_uuid=None,
+        action_uuid="action",
+        state_uuids=(),
+        read_only=read_only,
+        is_automatic=automatic,
+    )
+
+
+@pytest.mark.parametrize(
+    ("control_type", "action", "kwargs", "command"),
+    [
+        ("Switch", "on", {}, "on"),
+        ("Dimmer", "set_level", {"level": 42.5}, "42.5"),
+        ("LightController", "set_mood", {"mood_id": "7"}, "7"),
+        ("LightControllerV2", "off", {}, "changeTo/0"),
+        ("LightControllerV2", "set_mood", {"mood_id": "ID12"}, "changeTo/ID12"),
+        ("Jalousie", "open", {}, "FullUp"),
+        ("Jalousie", "close", {}, "FullDown"),
+        ("Jalousie", "set_position", {"position": 25}, "manualPosition/25"),
+        ("Jalousie", "set_slat_position", {"slat_position": 60}, "manualLamelle/60"),
+        (
+            "Jalousie",
+            "set_position_and_slats",
+            {"position": 20, "slat_position": 70},
+            "manualPosBlind/20/70",
+        ),
+    ],
+)
+def test_official_commands_are_mapped_without_raw_command_input(
+    control_type: str, action: str, kwargs: dict[str, object], command: str
+) -> None:
+    prepared = prepare_control_command(_control(control_type), action, **kwargs)  # type: ignore[arg-type]
+
+    assert prepared.command == command
+
+
+def test_automatic_actions_are_advertised_only_for_automatic_jalousie() -> None:
+    assert "enable_auto" not in allowed_actions(_control("Jalousie"))
+    assert "enable_auto" in allowed_actions(_control("Jalousie", automatic=True))
+    assert allowed_actions(_control("Jalousie", automatic=True, read_only=True)) == []
+
+
+@pytest.mark.parametrize(
+    ("control", "action", "kwargs"),
+    [
+        (_control("Dimmer"), "set_level", {"level": 101}),
+        (_control("Dimmer"), "set_level", {"level": -1}),
+        (_control("LightController"), "set_mood", {"mood_id": "ID1"}),
+        (_control("LightControllerV2"), "set_mood", {"mood_id": "../../on"}),
+        (_control("Jalousie"), "set_position", {}),
+        (_control("Jalousie"), "open", {"position": 10}),
+        (_control("Jalousie"), "enable_auto", {}),
+    ],
+)
+def test_invalid_or_mismatched_parameters_are_rejected(
+    control: Control, action: str, kwargs: dict[str, object]
+) -> None:
+    with pytest.raises(ValueError):
+        prepare_control_command(control, action, **kwargs)  # type: ignore[arg-type]

--- a/tests/test_control_commands.py
+++ b/tests/test_control_commands.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from mcpserver.loxone.control import allowed_actions, prepare_control_command
+from mcpserver.loxone.control import allowed_actions, prepare_control_command, visible_mood_ids
 from mcpserver.loxone.models import Control
 
 
@@ -27,7 +27,7 @@ def _control(control_type: str, *, automatic: bool = False, read_only: bool = Fa
         ("Dimmer", "set_level", {"level": 42.5}, "42.5"),
         ("LightController", "set_mood", {"mood_id": "7"}, "7"),
         ("LightControllerV2", "off", {}, "changeTo/0"),
-        ("LightControllerV2", "set_mood", {"mood_id": "ID12"}, "changeTo/ID12"),
+        ("LightControllerV2", "set_mood", {"mood_id": "314"}, "changeTo/314"),
         ("Jalousie", "open", {}, "FullUp"),
         ("Jalousie", "close", {}, "FullDown"),
         ("Jalousie", "set_position", {"position": 25}, "manualPosition/25"),
@@ -60,6 +60,7 @@ def test_automatic_actions_are_advertised_only_for_automatic_jalousie() -> None:
         (_control("Dimmer"), "set_level", {"level": 101}),
         (_control("Dimmer"), "set_level", {"level": -1}),
         (_control("LightController"), "set_mood", {"mood_id": "ID1"}),
+        (_control("LightControllerV2"), "set_mood", {"mood_id": "ID1"}),
         (_control("LightControllerV2"), "set_mood", {"mood_id": "../../on"}),
         (_control("Jalousie"), "set_position", {}),
         (_control("Jalousie"), "open", {"position": 10}),
@@ -71,3 +72,10 @@ def test_invalid_or_mismatched_parameters_are_rejected(
 ) -> None:
     with pytest.raises(ValueError):
         prepare_control_command(control, action, **kwargs)  # type: ignore[arg-type]
+
+
+def test_visible_mood_ids_accepts_numeric_target_data() -> None:
+    value = '[{"name":"Synthetic A","id":314},{"name":"Synthetic B","id":999}]'
+
+    assert visible_mood_ids(value) == frozenset({"314", "999"})
+    assert visible_mood_ids('[{"name":"Unsafe","id":"../../on"}]') is None

--- a/tests/test_loxone_client.py
+++ b/tests/test_loxone_client.py
@@ -88,6 +88,30 @@ async def test_control_operation_rejects_unprepared_command() -> None:
 
 
 @pytest.mark.asyncio
+async def test_control_operation_accepts_bounded_numeric_mood_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = LoxoneWebSocketSession(
+        cast(Any, object()),
+        public_key="",
+        token=LoxoneToken("jwt", "user", "key", "SHA256", 1),
+        timeout_seconds=1,
+        max_payload_bytes=1024,
+    )
+    commands: list[tuple[str, bool]] = []
+
+    async def command(value: str, *, encrypted: bool = False) -> object:
+        commands.append((value, encrypted))
+        return None
+
+    monkeypatch.setattr(session, "_command", command)
+
+    await session.operate_control("action-1", "changeTo/314")
+
+    assert commands == [("jdev/sps/io/action-1/changeTo/314", True)]
+
+
+@pytest.mark.asyncio
 async def test_websocket_receive_returns_complete_payload_without_waiting_again() -> None:
     class FakeWebSocket:
         def __init__(self) -> None:

--- a/tests/test_loxone_client.py
+++ b/tests/test_loxone_client.py
@@ -50,7 +50,7 @@ async def test_websocket_close_is_bounded() -> None:
 
 
 @pytest.mark.asyncio
-async def test_switch_operation_uses_encrypted_explicit_command(
+async def test_control_operation_uses_encrypted_explicit_command(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     session = LoxoneWebSocketSession(
@@ -68,9 +68,23 @@ async def test_switch_operation_uses_encrypted_explicit_command(
 
     monkeypatch.setattr(session, "_command", command)
 
-    await session.operate_switch("action-1", "off")
+    await session.operate_control("action-1", "manualPosition/40")
 
-    assert commands == [("jdev/sps/io/action-1/off", True)]
+    assert commands == [("jdev/sps/io/action-1/manualPosition/40", True)]
+
+
+@pytest.mark.asyncio
+async def test_control_operation_rejects_unprepared_command() -> None:
+    session = LoxoneWebSocketSession(
+        cast(Any, object()),
+        public_key="",
+        token=LoxoneToken("jwt", "user", "key", "SHA256", 1),
+        timeout_seconds=1,
+        max_payload_bytes=1024,
+    )
+
+    with pytest.raises(ValueError, match="invalid control operation"):
+        await session.operate_control("action-1", "99/delete")
 
 
 @pytest.mark.asyncio

--- a/tests/test_loxone_structure.py
+++ b/tests/test_loxone_structure.py
@@ -21,7 +21,8 @@ def test_structure_is_reduced_to_user_visible_domain_fields() -> None:
                 "type": "Switch",
                 "room": "room-1",
                 "cat": "cat-1",
-                "action": "action-1",
+                "uuidAction": "action-1",
+                "action": "must-not-be-used",
                 "restrictions": 0,
                 "states": {"active": "state-1"},
                 "details": {"password": "must not leak"},
@@ -51,11 +52,38 @@ def test_structure_is_reduced_to_user_visible_domain_fields() -> None:
     assert structure.identity.miniserver_serial == "000000000000"
     assert structure.rooms[0].name == "Kitchen"
     assert structure.controls[0].state_uuids == (("active", "state-1"),)
+    assert structure.controls[0].action_uuid == "action-1"
     assert structure.controls[0].subcontrols[0].uuid == "sub-1"
     assert {control.uuid for control in structure.controls} == {"control-1"}
     assert {room.uuid for room in structure.rooms} == {"room-1"}
     assert {category.uuid for category in structure.categories} == {"cat-1"}
     assert "must not leak" not in repr(structure)
+
+
+def test_structure_preserves_operability_flags_without_exposing_details() -> None:
+    raw = {
+        "lastModified": "now",
+        "msInfo": {"serialNr": "000000000000"},
+        "rooms": {},
+        "cats": {},
+        "controls": {
+            "blind": {
+                "name": "Blind",
+                "type": "Jalousie",
+                "uuidAction": "blind-action",
+                "restrictions": 32,
+                "details": {"isAutomatic": True, "private": "ignored"},
+                "states": {},
+            }
+        },
+    }
+
+    control = normalize_structure(raw, username="reader").controls[0]
+
+    assert control.action_uuid == "blind-action"
+    assert control.read_only is True
+    assert control.is_automatic is True
+    assert "private" not in repr(control)
 
 
 def test_absent_controls_remain_absent() -> None:

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import pytest
 
+from mcpserver.skill_delivery import SKILL_REVISION
 from tools.build_plugin import (
     _EXECUTABLES,
     _add,
@@ -78,6 +79,7 @@ def test_mcp_client_smoke_covers_skill_delivery_surfaces() -> None:
     assert "method = 'resources/list'" in script
     assert "method = 'resources/read'" in script
     assert "mcp_skill_delivery=pass" in script
+    assert f"$skillGuide.data.revision -ne {SKILL_REVISION}" in script
     assert "[int]$CallbackPort" in script
     assert "if ($proxyArguments[$index] -match '^https?://')" in script
     assert "$callbackIndex = $serverUrlIndex + 1" in script

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -132,6 +132,9 @@ def test_tool_input_schemas_explain_every_argument() -> None:
     assert find_properties["query"]["maxLength"] == 200
     assert find_properties["limit"]["minimum"] == 1
     assert find_properties["limit"]["maximum"] == 100
+    assert (
+        published["loxone_operate_control"].parameters["properties"]["mood_id"]["maxLength"] == 10
+    )
     state_uuids = published["loxone_get_states"].parameters["properties"]["state_uuids"]
     assert state_uuids["minItems"] == 1
     assert state_uuids["maxItems"] == 100

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -55,7 +55,21 @@ def test_control_tool_contract_is_explicitly_mutating_and_idempotent() -> None:
     assert tool.annotations.readOnlyHint is False
     assert tool.annotations.destructiveHint is True
     assert tool.annotations.idempotentHint is True
-    assert set(tool.parameters["properties"]["action"]["enum"]) == {"on", "off"}
+    assert set(tool.parameters["properties"]["action"]["enum"]) == {
+        "on",
+        "off",
+        "set_level",
+        "set_mood",
+        "open",
+        "close",
+        "shade",
+        "stop",
+        "enable_auto",
+        "disable_auto",
+        "set_position",
+        "set_slat_position",
+        "set_position_and_slats",
+    }
 
 
 def test_skill_guide_tool_is_read_only_and_matches_resource_content() -> None:
@@ -76,7 +90,7 @@ def test_skill_guide_tool_is_read_only_and_matches_resource_content() -> None:
     assert tool.annotations.destructiveHint is False
     assert tool.annotations.openWorldHint is False
     assert result.data.name == "using-loxberry-mcp"  # type: ignore[union-attr]
-    assert result.data.revision == 1  # type: ignore[union-attr]
+    assert result.data.revision == 2  # type: ignore[union-attr]
     assert result.data.media_type == "text/markdown"  # type: ignore[union-attr]
     assert result.data.content == read_skill_markdown()  # type: ignore[union-attr]
 
@@ -100,7 +114,14 @@ def test_tool_input_schemas_explain_every_argument() -> None:
         },
         "loxone_describe_control": {"control_uuid"},
         "loxone_get_states": {"state_uuids"},
-        "loxone_operate_control": {"control_uuid", "action"},
+        "loxone_operate_control": {
+            "control_uuid",
+            "action",
+            "level",
+            "mood_id",
+            "position",
+            "slat_position",
+        },
     }
     for tool_name, field_names in expected_fields.items():
         properties = published[tool_name].parameters["properties"]
@@ -114,6 +135,10 @@ def test_tool_input_schemas_explain_every_argument() -> None:
     state_uuids = published["loxone_get_states"].parameters["properties"]["state_uuids"]
     assert state_uuids["minItems"] == 1
     assert state_uuids["maxItems"] == 100
+    operation = published["loxone_operate_control"].parameters["properties"]
+    for name in ("level", "position", "slat_position"):
+        assert operation[name]["minimum"] == 0
+        assert operation[name]["maximum"] == 100
 
 
 @pytest.mark.asyncio

--- a/tools/test_mcp_client.ps1
+++ b/tools/test_mcp_client.ps1
@@ -245,7 +245,7 @@ try {
     $script:nextId = 4
     $skillGuide = Invoke-ReadTool (Get-NextId) 'loxone_get_skill_guide' @{}
     if ($skillGuide.data.name -ne 'using-loxberry-mcp' -or
-        $skillGuide.data.revision -ne 1 -or
+        $skillGuide.data.revision -ne 2 -or
         $skillGuide.data.media_type -ne 'text/markdown' -or
         $skillGuide.data.content -ne $skillMarkdown) {
         throw 'MCP skill guide tool differs from the canonical resource.'


### PR DESCRIPTION
## What changed

- fix Structure File parsing to use the official mandatory `uuidAction` field
- honor internal and external read-only restriction bits before advertising or dispatching operations
- extend the bounded `loxone_operate_control` contract to `Dimmer`, `LightController`, `LightControllerV2`, and normal or automatic `Jalousie`
- validate numeric LightControllerV2 mood targets against the current visible `moodList` before dispatch
- keep both runtime and WebSocket command paths UUID-only, type-specific, parameter-bounded, rate-limited, audited, and free of raw, bulk, learning, naming, or expert commands
- update the bundled agent skill, bilingual user documentation, support matrix, tests, and ADR

## Why

Real controls were visible to the authenticated Loxone identity but appeared non-operable because the parser read the non-standard field `action`. Loxone V17 specifies `uuidAction`. Read-only target evidence also confirmed that LightControllerV2 uses numeric mood IDs, including values above 99.

Official reference: https://www.loxone.com/enen/wp-content/uploads/sites/3/2026/04/1700_Structure-File.pdf

## Validation

- rebased onto current `master`
- deterministic repository gate: formatting, Ruff, strict mypy, 293 tests
- focused control tests: command mapping, scope, visibility, restriction flags, parameter combinations, current mood-list membership, numeric state confirmation, client allowlist, and unknown outcomes
- reproducible double-build and archive verification passed before final review
- existing target service health and all six MCP data tools plus both skill-delivery surfaces passed read-only
- three phase-aware independent review iterations completed; no relevant findings remain
- final GitHub `deterministic` check passed
- no real Loxone command was sent and no physical control was switched or moved

## Acceptance boundary

The expanded real hardware write behavior remains unconfirmed. The implementation and package are deterministically verified, while the target interaction in this workflow stayed read-only.