### PR TITLE
Document Phase 2 acceptance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,29 @@
 # LoxBerry MCP Server
 
-Das McpServer-Plugin betreibt einen [Model Context Protocol (MCP)](https://modelcontextprotocol.io/)-Server direkt auf dem LoxBerry. Die aktuelle Alpha erlaubt KI-Assistenten und Agenten ausschließlich, den Zustand einer Loxone-Miniserver-Installation zu lesen. Dabei verwendet das Plugin die vorhandenen Räume, Kategorien und Steuerungsnamen – ohne eigenen Cloud-Dienst.
+Das McpServer-Plugin betreibt einen [Model Context Protocol (MCP)](https://modelcontextprotocol.io/)-Server direkt auf dem LoxBerry. Die aktuelle Alpha erlaubt KI-Assistenten und Agenten, den Zustand einer Loxone-Miniserver-Installation zu lesen. Optional kann sie genau ein kontrolliertes Schreibwerkzeug für Gen.-1-Steuerungen vom Typ `Switch` bereitstellen. Dabei verwendet das Plugin die vorhandenen Räume, Kategorien und Steuerungsnamen – ohne eigenen Cloud-Dienst.
 
-Schreibaktionen und LoxBerry-Werkzeuge sind nicht Bestandteil dieser Version.
+Die Steuerung bleibt standardmäßig deaktiviert. Weitere Control-Typen und
+LoxBerry-Werkzeuge sind nicht Bestandteil dieser Version.
 
 ## Sicherheit und Berechtigungen
 
-Der Zugriff auf Loxone-Funktionen ist durch den Loxone-Login geschützt. Ein verbindender Assistent muss sich mit einem Loxone-Benutzerkonto anmelden und kann nur die Elemente lesen, für die dieses Konto berechtigt ist.
+Der Zugriff auf Loxone-Funktionen ist durch den Loxone-Login geschützt. Ein verbindender Assistent muss sich mit einem Loxone-Benutzerkonto anmelden und kann nur die Elemente lesen oder bedienen, für die dieses Konto berechtigt ist. Steuerzugriff benötigt zusätzlich die bewusste Aktivierung im Plugin und den separat bestätigten Scope `loxone:control`.
 
 Für jeden Assistenten sollte ein eigener Loxone-Benutzer mit den minimal erforderlichen Rechten angelegt werden. Zugangsdaten und andere Geheimnisse dürfen nicht im Repository gespeichert werden.
 
 ## Projektstatus
 
-Phase 1 ist abgeschlossen. Phase 2 ergänzt als nächstes optional genau ein
+Phase 1 und Phase 2 sind abgenommen. Phase 2 ergänzt optional genau ein
 kontrolliertes Schreibwerkzeug für Gen.-1-Controls vom Typ `Switch`. Es bleibt
 standardmäßig deaktiviert, akzeptiert ausschließlich `on` und `off` und benötigt
 den separat bestätigten Scope `loxone:control`. Die sechs stabilen lesenden
-Tools und bestehende Read-only-Sitzungen bleiben kompatibel.
+Tools und bestehende Read-only-Sitzungen bleiben kompatibel. Der zugehörige
+Releasekandidat `0.2.0-alpha.1` ist noch nicht veröffentlicht.
 
 Bestätigte Kombinationen, Nachweise und bekannte Clientgrenzen stehen in der
-[Support-Matrix](docs/development/support-matrix.md) und im
-[Phase-1-Abnahmebericht](docs/development/phase-1-acceptance.md).
+[Support-Matrix](docs/development/support-matrix.md), im
+[Phase-1-Abnahmebericht](docs/development/phase-1-acceptance.md) und im
+[Phase-2-Abnahmebericht](docs/development/phase-2-acceptance.md).
 
 ## Nutzung
 

--- a/docs/clients/claude-desktop.de.md
+++ b/docs/clients/claude-desktop.de.md
@@ -122,10 +122,10 @@ Freigabeseite im Browser.
 
 ## Optionale Loxone-Steuerung
 
-> **Experimentell und noch nicht mit Claude abgenommen:** Der folgende Ablauf
-> beschreibt die erwartete Einrichtung, wurde aber noch nicht durch einen
-> vollständigen Claude-Test von Registrierung, Freigabe und Werkzeugaufruf
-> bestätigt. Der dokumentierte und geprüfte Standard bleibt Read-only.
+> **Mit Claude abgenommen:** Registrierung, Freigabe mit `loxone:control`,
+> Werkzeugsichtbarkeit und ein realer Aufruf wurden vollständig bestätigt. Der
+> sichere Standard bleibt Read-only. Der Nachweis steht im
+> [Phase-2-Abnahmebericht](../development/phase-2-acceptance.md).
 
 Dieser Abschnitt gilt nur, wenn in der Plugin-Oberfläche unter **Zugriff auf den
 Miniserver über den MCP Server** bewusst **Lesen und schalten** gewählt wurde.

--- a/docs/clients/claude-desktop.en.md
+++ b/docs/clients/claude-desktop.en.md
@@ -116,10 +116,10 @@ the browser consent page before approving access.
 
 ## Optional Loxone control
 
-> **Experimental and not yet accepted with Claude:** The following workflow
-> describes the expected setup, but a complete Claude test of registration,
-> consent, and tool availability has not yet confirmed it. Read-only remains the
-> documented and tested default.
+> **Accepted with Claude:** Registration, consent with `loxone:control`, tool
+> visibility, and a real invocation were fully confirmed. Read-only remains the
+> safe default. The evidence is recorded in the
+> [Phase-2 acceptance report](../development/phase-2-acceptance.md).
 
 This section applies only when **Read and switch** was deliberately selected
 under **Miniserver access through the MCP server** in the plugin UI. It is

--- a/docs/development/adr/0003-phase-2-controlled-switch.md
+++ b/docs/development/adr/0003-phase-2-controlled-switch.md
@@ -1,7 +1,8 @@
 # ADR 0003: Phase-2 Controlled Switch Operations
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-08-04
+- **Accepted:** 2026-08-06
 - **Release candidate:** `0.2.0-alpha.1`
 
 ## Context
@@ -79,3 +80,7 @@ mobile viewports plus one native upgrade and one approved non-critical Gen. 1
 Switch toggled on and off, restoring its initial state. Gen. 2, external access,
 fresh installation, uninstall and exhaustive negative paths are outside this
 acceptance run.
+
+The required real Switch operation and the complete control-client flow were
+confirmed on 2026-08-06. The sanitized evidence and remaining boundaries are
+recorded in the [Phase-2 acceptance report](../phase-2-acceptance.md).

--- a/docs/development/phase-2-acceptance.md
+++ b/docs/development/phase-2-acceptance.md
@@ -1,0 +1,69 @@
+# Phase-2-Abnahmenachweis
+
+- **Stand:** 2026-08-06
+- **Releasekandidat:** `0.2.0-alpha.1`
+- **Ergebnis:** Phase 2 abgenommen
+- **Release:** noch nicht veröffentlicht
+
+Dieser Nachweis dokumentiert die bestätigten Realtests für die kontrollierte
+Gen.-1-`Switch`-Steuerung. Er enthält keine Zugangsdaten, internen Adressen,
+Identitäten, Steuerungsnamen, UUIDs oder Zustandswerte.
+
+## Abgenommener Umfang
+
+Phase 2 ergänzt das weiterhin standardmäßig deaktivierte MCP-Tool
+`loxone_operate_control`. Abgenommen ist ausschließlich ein für die angemeldete
+Loxone-Identität sichtbares und bedienbares Gen.-1-Control vom exakten Typ
+`Switch` mit den expliziten Aktionen `on` und `off`.
+
+Die Steuerung erfordert die bewusste Aktivierung im Plugin sowie eine neue
+OAuth-Freigabe mit `loxone:read loxone:control`. Bestehende Read-only-Sitzungen
+erhalten den Control-Scope nicht automatisch.
+
+## Realer Switch-Test
+
+Ein ausdrücklich freigegebener, unkritischer Gen.-1-`Switch` wurde real über
+das MCP-Tool ein- und ausgeschaltet. Beide Aktionen bestätigten die vorgesehene
+Funktionalität; anschließend wurde der vor dem Test bestehende Ausgangszustand
+wiederhergestellt.
+
+Der Test bestätigt den eng begrenzten realen End-to-End-Schreibpfad von der
+autorisierten Werkzeugauswahl bis zur beobachteten Zustandsrückmeldung. Die
+Loxone-Berechtigungsprüfung und verschlüsselte Gen.-1-Kommunikation sind
+zusätzlich durch die Implementierungs- und Adaptertests abgedeckt. Daraus wird
+keine Freigabe für andere Control-Typen oder beliebige Kommandos abgeleitet.
+
+## Vollständiger Control-Client-Ablauf
+
+Der vollständige Ablauf mit Claude Desktop und der lokalen `mcp-remote`-Bridge
+wurde bestätigt:
+
+1. öffentliche OAuth-Clientregistrierung,
+2. Anmeldung und Consent mit `loxone:read loxone:control`,
+3. Sichtbarkeit von `loxone_operate_control` nur mit aktivierter Steuerung und
+   passendem Scope,
+4. realer Werkzeugaufruf an einem freigegebenen Gen.-1-`Switch`,
+5. Wiederherstellung des ursprünglichen Zustands.
+
+Read-only bleibt der sichere und dokumentierte Standard. Die zusätzliche
+Control-Berechtigung wird ausdrücklich ausgewählt und niemals stillschweigend
+zu einer bestehenden Sitzung hinzugefügt.
+
+## Automatisierte und installierte Nachweise
+
+Die Implementierung wurde vor der formalen Abnahme durch das vollständige
+deterministische Gate sowie durch native Upgrades auf dem autorisierten
+LoxBerry-Testsystem geprüft. Dienst, Loopback-Healthcheck, Apache-Konfiguration,
+OAuth-Metadaten und die Beibehaltung der vorhandenen Konfiguration wurden
+read-only bestätigt. Die realen Steueraktionen waren auf den oben beschriebenen,
+ausdrücklich freigegebenen Switch-Test begrenzt.
+
+## Verbleibende Grenzen
+
+- Der Releasekandidat `0.2.0-alpha.1` ist noch nicht auf GitHub veröffentlicht.
+- Dimmer, Lichtsteuerungen, Jalousien und weitere Control-Typen sind nicht Teil
+  dieser Phase-2-Abnahme.
+- Gen. 2/Compact bleibt für Schreibzugriffe nicht freigegeben.
+- Externer oder cloudbasierter MCP-Zugriff ist nicht freigegeben.
+- Freie Kommandos, Bulk-Aktionen und schreibende LoxBerry-MCP-Tools bleiben
+  ausgeschlossen.

--- a/docs/development/support-matrix.md
+++ b/docs/development/support-matrix.md
@@ -1,12 +1,11 @@
 # Support-Matrix
 
-- **Stand:** Abnahmestand Phase 1, 2026-08-04
-- **Nächster Meilenstein:** Phase 2 nur nach separater Freigabe; bis dahin Pflege
-  der Read-only Alpha
+- **Stand:** Abnahmestand Phase 2, 2026-08-06
+- **Nächster Meilenstein:** Veröffentlichung von `0.2.0-alpha.1`
 
 Diese Matrix unterscheidet reale Nachweise von implementierten, aber noch nicht
-real bestätigten Kombinationen. Phase 1 ist abgenommen; das Alpha-Paket bleibt
-wegen seines Vorabversionsstatus ein Prerelease.
+real bestätigten Kombinationen. Phase 1 und Phase 2 sind abgenommen; der
+Releasekandidat `0.2.0-alpha.1` ist noch nicht veröffentlicht.
 
 ## Plattformen und Geräte
 
@@ -24,9 +23,9 @@ abgeleitet.
 
 ## MCP-Clients
 
-| Client | Getesteter Stand | Phase-0-Ergebnis | Bekannte Grenze |
+| Client | Getesteter Stand | Ergebnis | Bekannte Grenze |
 | --- | --- | --- | --- |
-| Claude Desktop mit `mcp-remote` | Desktop `1.24012.9`, Bridge `0.1.38` | [Login, MCP-Initialisierung, authentifizierter Aufruf, Refresh und RFC-7009-Widerruf erfolgreich](phase-0-oauth-test.md#reale-clientabnahme) | lokale Bridge mit `http-only`; kein Nachweis für den cloudbasierten Connector |
+| Claude Desktop mit `mcp-remote` | Desktop `1.24012.9`, Bridge `0.1.38` | [Read-only-Ablauf sowie Registrierung, Consent, Werkzeugsichtbarkeit und realer Phase-2-Control-Aufruf bestätigt](phase-2-acceptance.md#vollständiger-control-client-ablauf) | lokale Bridge mit `http-only`; kein Nachweis für den cloudbasierten Connector |
 | Codex CLI | `0.146.0` | [Login, MCP-Initialisierung und authentifizierter Aufruf erfolgreich](phase-0-oauth-test.md#reale-clientabnahme) | Refresh sendet keinen verpflichtenden RFC-8707-Parameter `resource`; Logout löscht nur lokale Credentials und ruft `/revoke` nicht auf |
 
 Die Codex-Grenzen sind bestätigtes Clientverhalten und werden für den Abschluss
@@ -63,6 +62,19 @@ Der vollständige maskierte Nachweis steht im
   Speichern, Status, Verbindungstest, Widerruf und Diagnose bestätigten den
   funktionalen No-JavaScript-Fallback.
 
+## Phase-2-Abnahmenachweis
+
+Der vollständige maskierte Nachweis steht im
+[Phase-2-Abnahmebericht](phase-2-acceptance.md).
+
+- Ein ausdrücklich freigegebener, unkritischer Gen.-1-`Switch` wurde real mit
+  `on` und `off` bedient; der Ausgangszustand wurde wiederhergestellt.
+- Der vollständige Control-Client-Ablauf mit Registrierung, Consent für
+  `loxone:read loxone:control`, Werkzeugsichtbarkeit und realem Aufruf wurde
+  bestätigt.
+- Steuerung bleibt standardmäßig deaktiviert und auf sichtbare, bedienbare
+  Gen.-1-Controls vom Typ `Switch` sowie die Aktionen `on` und `off` begrenzt.
+
 ## Verbleibende Grenzen
 
 - Die globale JavaScript-Berechtigung von Chrome durfte die Browserautomation
@@ -72,4 +84,6 @@ Der vollständige maskierte Nachweis steht im
 - Codex CLI wurde im finalen Abschlusslauf wegen der lokalen
   Windows-Ausführungsstörung nicht erneut abgenommen; der bekannte Clientfehler
   ist für den Server- und Claude-Nachweis nicht blockierend.
-- Schreibende MCP-Tools sind nicht Bestandteil von Phase 0 oder Phase 1.
+- Phase 2 unterstützt ausschließlich Gen.-1-`Switch` mit `on` und `off`.
+  Weitere Control-Typen und Gen.-2-Schreibzugriff bleiben unbestätigt und sind
+  nicht freigegeben.


### PR DESCRIPTION
## Summary

- mark ADR 0003 as accepted after the maintainer-confirmed real Switch test
- record the complete control-client registration, consent, tool visibility, and invocation flow
- update README, Claude guides, and support matrix to the Phase 2 acceptance state
- add a sanitized Phase 2 acceptance report and keep the unpublished release explicit

## Scope and impact

This documentation-only change records the confirmed Phase 2 acceptance. It does not change runtime behavior, configuration, permissions, or release artifacts. The accepted control scope remains limited to Gen. 1 Switch controls with explicit on and off actions; other control types remain outside this acceptance.

## Validation

- full deterministic gate passed
- Ruff format and lint passed
- mypy passed for 24 source files
- 263 pytest tests passed
- git diff check passed

Known non-blocking warnings remain unchanged: the Starlette httpx deprecation and the local pytest cache permission warning.
