### PR TITLE
Prepare 0.2.0-alpha.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ kontrolliertes Schreibwerkzeug für Gen.-1-Controls vom Typ `Switch`. Es bleibt
 standardmäßig deaktiviert, akzeptiert ausschließlich `on` und `off` und benötigt
 den separat bestätigten Scope `loxone:control`. Die sechs stabilen lesenden
 Tools und bestehende Read-only-Sitzungen bleiben kompatibel. Der zugehörige
-Releasekandidat `0.2.0-alpha.1` ist noch nicht veröffentlicht.
+Pre-Release ist `0.2.0-alpha.1`.
 
 Bestätigte Kombinationen, Nachweise und bekannte Clientgrenzen stehen in der
 [Support-Matrix](docs/development/support-matrix.md), im

--- a/docs/development/adr/0003-phase-2-controlled-switch.md
+++ b/docs/development/adr/0003-phase-2-controlled-switch.md
@@ -3,7 +3,7 @@
 - **Status:** Accepted
 - **Date:** 2026-08-04
 - **Accepted:** 2026-08-06
-- **Release candidate:** `0.2.0-alpha.1`
+- **Release:** `0.2.0-alpha.1`
 
 ## Context
 

--- a/docs/development/phase-2-acceptance.md
+++ b/docs/development/phase-2-acceptance.md
@@ -1,9 +1,9 @@
 # Phase-2-Abnahmenachweis
 
 - **Stand:** 2026-08-06
-- **Releasekandidat:** `0.2.0-alpha.1`
+- **Release:** `0.2.0-alpha.1`
+- **SHA-256:** `3b746201c71dcdffbe5dd600b347979ea6a849842790521f133ecefdc5db3b3b`
 - **Ergebnis:** Phase 2 abgenommen
-- **Release:** noch nicht veröffentlicht
 
 Dieser Nachweis dokumentiert die bestätigten Realtests für die kontrollierte
 Gen.-1-`Switch`-Steuerung. Er enthält keine Zugangsdaten, internen Adressen,
@@ -60,7 +60,6 @@ ausdrücklich freigegebenen Switch-Test begrenzt.
 
 ## Verbleibende Grenzen
 
-- Der Releasekandidat `0.2.0-alpha.1` ist noch nicht auf GitHub veröffentlicht.
 - Dimmer, Lichtsteuerungen, Jalousien und weitere Control-Typen sind nicht Teil
   dieser Phase-2-Abnahme.
 - Gen. 2/Compact bleibt für Schreibzugriffe nicht freigegeben.

--- a/docs/development/support-matrix.md
+++ b/docs/development/support-matrix.md
@@ -1,11 +1,12 @@
 # Support-Matrix
 
 - **Stand:** Abnahmestand Phase 2, 2026-08-06
-- **Nächster Meilenstein:** Veröffentlichung von `0.2.0-alpha.1`
+- **Aktueller Pre-Release:** `0.2.0-alpha.1`
+- **Nächster Meilenstein:** Phase 3 mit LoxBerry Read-only
 
 Diese Matrix unterscheidet reale Nachweise von implementierten, aber noch nicht
-real bestätigten Kombinationen. Phase 1 und Phase 2 sind abgenommen; der
-Releasekandidat `0.2.0-alpha.1` ist noch nicht veröffentlicht.
+real bestätigten Kombinationen. Phase 1 und Phase 2 sind abgenommen;
+`0.2.0-alpha.1` bleibt wegen seines Vorabversionsstatus ein Pre-Release.
 
 ## Plattformen und Geräte
 

--- a/prerelease.cfg
+++ b/prerelease.cfg
@@ -1,4 +1,4 @@
 [AUTOUPDATE]
 VERSION=0.2.0-alpha.1
-ARCHIVEURL=
+ARCHIVEURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/download/v0.2.0-alpha.1/LoxBerry-MCP-Server-0.2.0-alpha.1.zip
 INFOURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases


### PR DESCRIPTION
## Summary

- publish the prerelease update URL for 0.2.0-alpha.1
- record the final reproducible archive checksum in the Phase 2 acceptance evidence
- update README, ADR 0003, and the support matrix from release candidate to prerelease

## Release artifact

- archive: LoxBerry-MCP-Server-0.2.0-alpha.1.zip
- SHA-256: 3b746201c71dcdffbe5dd600b347979ea6a849842790521f133ecefdc5db3b3b
- the release-candidate builder produced two byte-identical archives
- the package verifier passed for layout, modes, line endings, identity, and offline wheels

## Validation

- Ruff format and lint passed
- mypy passed for 24 source files
- 263 pytest tests passed
- prerelease metadata inside the ZIP matches the future GitHub asset URL
- no Loxone control action was executed during release preparation

The GitHub release remains a prerelease. Phase 2 support is limited to explicitly enabled Gen. 1 Switch controls with on and off actions.
