### PR TITLE
Expire cached Explorer client registrations

### DIFF
--- a/docs/development/adr/0004-integrated-tool-explorer.md
+++ b/docs/development/adr/0004-integrated-tool-explorer.md
@@ -38,8 +38,10 @@ A Web Lock tied to a random session identifier prevents a duplicated tab from
 automatically replaying the same single-use refresh token. The resumable record
 is removed before every rotation, so a reload that interrupts an in-flight
 rotation fails closed instead of replaying a possibly consumed token. The
-non-secret public `client_id` may be retained by origin and scope to avoid
-consuming a new dynamic registration on each visit.
+non-secret public `client_id` is retained only in that tab's `sessionStorage`
+and for at most eight hours. Older persistent `localStorage` registrations are
+discarded so a browser cannot reuse an identifier after the server has removed
+the corresponding dynamic client registration.
 
 `sessionStorage` is isolated by origin and top-level browsing context, not by URL
 path. The LoxBerry admin origin is therefore part of the Explorer trust boundary:

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -166,6 +166,9 @@ verwirft der Browser diesen lokalen Wert normalerweise, kann die Serversitzung
 aber nicht zuverlässig sofort widerrufen. Explorer-Sitzungen laufen deshalb
 spätestens nach acht Stunden ab. **Trennen und widerrufen** beendet sie sofort
 und bleibt vor dem Schließen der zuverlässige Abmeldeweg.
+Auch die öffentliche OAuth-Clientregistrierung ist auf den Tab und höchstens
+acht Stunden begrenzt; veraltete Registrierungen früherer Plugin-Versionen
+werden automatisch verworfen und neu angelegt.
 
 Im Berechtigungs-Dropdown ist **Nur lesen** vorausgewählt. **Lesen und steuern**
 ist nur bei global aktivierter Loxone-Steuerung auswählbar und erfordert

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -156,6 +156,9 @@ discards that local value, but the browser cannot reliably revoke the server
 session immediately. Explorer sessions therefore expire after eight hours at the
 latest. **Disconnect and revoke** ends the session immediately and remains the
 reliable sign-out path before closing the tab.
+The public OAuth client registration is likewise limited to the tab and at most
+eight hours; stale registrations from earlier plugin versions are discarded and
+registered again automatically.
 
 The permissions dropdown defaults to **Read only**. **Read and control** is
 selectable only when Loxone control is globally enabled and requires fresh consent for

--- a/tests/test_explorer_ui.py
+++ b/tests/test_explorer_ui.py
@@ -474,6 +474,38 @@ def test_explorer_resume_record_contains_only_valid_tab_scoped_refresh_data() ->
     )
 
 
+def test_explorer_client_registration_is_tab_scoped_and_expires_before_server_cleanup() -> None:
+    client_id = "a" * 43
+    registered_at = 1_000_000
+    record = run_core(f"core.clientRegistration('{client_id}',{registered_at})")
+
+    assert record == {"version": 1, "clientId": client_id, "registeredAt": registered_at}
+    encoded = json.dumps(record)
+    assert run_core(f"core.validateClientRegistration({encoded},{registered_at})") == record
+    assert (
+        run_core(
+            f"core.validateClientRegistration({encoded},"
+            f"{registered_at}+core.EXPLORER_CLIENT_REGISTRATION_MS-1)"
+        )
+        == record
+    )
+    assert (
+        run_core(
+            f"core.validateClientRegistration({encoded},"
+            f"{registered_at}+core.EXPLORER_CLIENT_REGISTRATION_MS)"
+        )
+        is None
+    )
+    assert (
+        run_core(
+            f"core.validateClientRegistration("
+            f"{json.dumps({'version': 1, 'clientId': 'invalid', 'registeredAt': registered_at})},"
+            f"{registered_at})"
+        )
+        is None
+    )
+
+
 @pytest.mark.parametrize("exchange_fails", [False, True])
 def test_explorer_refresh_removes_replayable_state_before_rotation(
     exchange_fails: bool,
@@ -596,14 +628,10 @@ def test_explorer_ui_is_local_scoped_and_progressively_safe() -> None:
     assert "state.history.length > core.MAX_CALL_HISTORY" in source
     assert "fetchWithTimeout('/plugins/mcpserver/mcp'" in source
     assert "}, 70000)" in source
-    assert "localStorage.setItem" in source
-    assert "/^[A-Za-z0-9_-]{43}$/" in source
-    assert (
-        "accessToken"
-        not in source[
-            source.index("localStorage.setItem") - 100 : source.index("localStorage.setItem") + 200
-        ]
-    )
+    assert "localStorage.setItem" not in source
+    assert "window.localStorage.removeItem(key)" in source
+    assert "core.validateClientRegistration" in source
+    assert "JSON.stringify(core.clientRegistration(clientId, Date.now()))" in source
     assert "sessionStorage.setItem" in source
     assert "core.validateResumableSession" in source
     assert "readStoredSession(discovered.resourceMetadata.resource)" in source

--- a/webfrontend/htmlauth/explorer.js
+++ b/webfrontend/htmlauth/explorer.js
@@ -11,6 +11,7 @@
   const MAX_TRANSCRIPT = 100;
   const REVOCATION_TIMEOUT_MS = 5000;
   const EXPLORER_SESSION_MS = 8 * 60 * 60 * 1000;
+  const EXPLORER_CLIENT_REGISTRATION_MS = EXPLORER_SESSION_MS;
   const MCP_RESOURCE_PATH = '/plugins/mcpserver/mcp';
   const EXPLORER_PATH = '/admin/plugins/mcpserver/explorer.cgi';
   const OPAQUE_VALUE = /^[A-Za-z0-9_-]{32,512}$/;
@@ -393,6 +394,18 @@
     return resumableSession(value);
   }
 
+  function clientRegistration(clientId, registeredAt) {
+    return {version: 1, clientId, registeredAt};
+  }
+
+  function validateClientRegistration(value, now) {
+    if (!value || typeof value !== 'object' || Array.isArray(value) || value.version !== 1) return null;
+    if (!/^[A-Za-z0-9_-]{43}$/.test(value.clientId || '')) return null;
+    if (!Number.isSafeInteger(value.registeredAt) || value.registeredAt > now ||
+      value.registeredAt <= now - EXPLORER_CLIENT_REGISTRATION_MS) return null;
+    return clientRegistration(value.clientId, value.registeredAt);
+  }
+
   async function rotateRefreshToken(oauth, exchange, clearResume, saveResume, now) {
     if (oauth.resumeEnabled) clearResume();
     const token = await exchange(refreshTokenFields(oauth.clientId, oauth.refreshToken, oauth.resource));
@@ -472,6 +485,7 @@
     MAX_TRANSCRIPT,
     REVOCATION_TIMEOUT_MS,
     EXPLORER_SESSION_MS,
+    EXPLORER_CLIENT_REGISTRATION_MS,
     clone,
     resolveRef,
     effectiveSchema,
@@ -495,6 +509,8 @@
     refreshTokenFields,
     resumableSession,
     validateResumableSession,
+    clientRegistration,
+    validateClientRegistration,
     rotateRefreshToken,
     clearSensitiveState,
     revokeThenClear,
@@ -727,16 +743,28 @@
   }
 
   function readClientId(scope) {
+    const key = clientStorageKey(scope);
+    // Older releases retained this identifier beyond the server-side DCR lifetime.
+    try { window.localStorage.removeItem(key); } catch (_error) { /* migration only */ }
     try {
-      const value = window.localStorage.getItem(clientStorageKey(scope));
-      if (value && /^[A-Za-z0-9_-]{43}$/.test(value)) return value;
-      if (value) window.localStorage.removeItem(clientStorageKey(scope));
-      return null;
-    } catch (_error) { return null; }
+      const serialized = window.sessionStorage.getItem(key);
+      if (!serialized) return null;
+      const registration = core.validateClientRegistration(JSON.parse(serialized), Date.now());
+      if (registration) return registration.clientId;
+      window.sessionStorage.removeItem(key);
+    } catch (_error) {
+      try { window.sessionStorage.removeItem(key); } catch (_ignored) { /* optional */ }
+    }
+    return null;
   }
 
   function saveClientId(scope, clientId) {
-    try { window.localStorage.setItem(clientStorageKey(scope), clientId); } catch (_error) { /* optional */ }
+    try {
+      window.sessionStorage.setItem(
+        clientStorageKey(scope),
+        JSON.stringify(core.clientRegistration(clientId, Date.now())),
+      );
+    } catch (_error) { /* optional */ }
   }
 
   async function discover() {


### PR DESCRIPTION
## What changed

- store the Tool Explorer's public OAuth `client_id` in tab-scoped `sessionStorage` instead of persistent `localStorage`
- attach a registration timestamp and reject cached registrations after eight hours
- remove legacy `localStorage` registrations before looking for a current tab-scoped record
- add deterministic boundary and migration-contract tests
- document the registration lifetime in German and English

## Why

The Explorer previously retained a dynamically registered client identifier indefinitely in `localStorage`. The server can garbage-collect that registration, leaving Firefox or another browser to reuse a client ID that no longer exists. OAuth authorization then fails until the browser entry is deleted manually.

The cached identifier is public, but its lifetime must remain shorter than the server-side registration cleanup window. A stale or malformed record now fails closed and causes a fresh dynamic registration automatically.

## Compatibility and security

- existing legacy records are removed automatically
- registrations remain reusable across reloads in the same tab for up to eight hours
- no access token, refresh token, credential, or authorization rule changes
- the local hostname/IP origin support remains unchanged

## Validation

- targeted Explorer suite: 27 passed
- complete `python tools/test.py` gate: 294 passed
- Ruff formatting and lint passed
- mypy passed
- `git diff --check` passed

No Loxone control, target-device write, or deployment was performed.
