### PR TITLE
Ignore local research notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,11 @@ tmp/
 .tmp/
 temp/
 
+# Local research notes
+/docs/research/Loxberry Plugin Konzept.md
+/docs/research/Loxone eigener MCP-Server.md
+/docs/research/Projekte mit Loxone MCP-Server.md
+
 # Logs
 *.log
 __pycache__/


### PR DESCRIPTION
## What changed

- ignore exactly three local research-note files
- keep the remainder of `docs/research/` trackable

## Why

The notes are local working material and should not appear as untracked repository changes. Narrow file-specific rules avoid hiding future research documents that may belong in version control.

## Validation

- `git diff --check`
- `git check-ignore -v --no-index` for all three files
- negative `git check-ignore` check for another file under `docs/research/`

No runtime, browser, or device testing is required for this repository-hygiene-only change.