### PR TITLE
Optimize change-driven testing workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,14 @@
 # Project Instructions
 
-This repository contains the LoxBerry MCP Server plugin. Read the normative
-engineering rules in `docs/development/implementation-guidelines.md` and select
-verification from `docs/development/test-strategy.md` before changing code,
-configuration, MCP tools, authentication, authorization, lifecycle behavior, or
-the browser UI.
+This repository contains the LoxBerry MCP Server plugin. Apply the mandatory
+rules below to every change. Before implementation, read only the relevant
+sections of `docs/development/implementation-guidelines.md`: sections 3-6 for
+architecture, MCP contracts, security, or configuration; section 7 for UI;
+section 8 for lifecycle; section 9 for logging; and sections 10-11 for tests,
+documentation, or releases. Read the whole document only for cross-cutting or
+unclear changes. Select verification from
+`docs/development/test-strategy.md`; do not reread unchanged sections during the
+same task.
 
 ## Working rules
 
@@ -23,6 +27,9 @@ the browser UI.
   permissions, dependencies, compatibility, or upgrade changes.
 - Use change-driven tests. Documentation-only changes do not require device or
   browser acceptance unless they change generated or rendered behavior.
+- During iteration use `python tools/test.py --profile changed`; inspect the
+  selection first with `--plan` when scope is unclear. Reserve the Full profile
+  for the final revision, cross-cutting fallback, CI, and release packaging.
 - Do not claim platform, browser, device, or Miniserver compatibility without
   matching evidence.
 - Preserve unrelated worktree changes and inspect `git status --short` before

--- a/README.md
+++ b/README.md
@@ -53,11 +53,15 @@ Abhängigkeitsauflösung eingebunden:
 ```text
 python -m pip install -r requirements/runtime-arm64.lock -r requirements/dev.lock
 python -m pip install --no-deps -e .
-python tools/test.py
+python tools/test.py --profile changed --plan
+python tools/test.py --profile changed
 ```
 
-`python tools/test.py` ist der einheitliche lokale und CI-Testbefehl. Er führt
-Formatprüfung, Lint, strikte Typprüfung und die deterministischen Tests aus.
+Das Changed-Profil wählt während der Entwicklung nur betroffene Prüfungen aus.
+`python tools/test.py --profile full` beziehungsweise der rückwärtskompatible
+Aufruf `python tools/test.py` führt das vollständige Python-3.13-Gate für CI und
+finale Revisionen aus. Details stehen in der
+[Teststrategie](docs/development/test-strategy.md).
 
 ## Lizenz
 

--- a/docs/development/automation.md
+++ b/docs/development/automation.md
@@ -1,58 +1,80 @@
 # Development automation
 
 Use repository scripts for deterministic, shareable work. Keep target-specific
-authorization, connection profiles, credentials, and private test fixtures outside Git.
+authorization, credentials, connection profiles, and private fixtures outside Git.
 
-## Local and CI-safe commands
+## Change-driven local checks
 
-- `python tools/test.py` runs the deterministic formatting, lint, type, and test gate.
-  The complete gate requires Python 3.13, Perl, and Node.js on `PATH`; missing
-  runtimes are failures rather than silently skipped browser or CGI checks.
-- `python tools/build_release_candidate.py --runtime-wheelhouse <cache>` rebuilds the
-  project wheel, runs the full gate, builds the plugin twice, requires byte-identical
-  ZIPs, writes the checksum, and verifies the final archive. Omit the cache argument to
-  download the pinned Debian 13/arm64 wheels into a temporary directory.
-- `python tools/verify_plugin.py <archive.zip>` verifies checksum, paths, file modes,
-  LF text files, plugin identity, required entries, and the offline wheelhouse without
-  extracting or installing the archive.
-- `pwsh -File tools/test_mcp_client.ps1` detects the active Microsoft Store or
-  classic Claude profile, starts its configured MCP proxy, and
-  exercises the six read-only Loxone data tools plus both skill-delivery surfaces
-  (MCP resource and fallback tool). Use `-VisibilityFixturePath <private-json>` to
-  add a real visible/hidden-control boundary test. The private JSON contains only
-  `visible_control_uuid` and `hidden_control_uuid` and remains outside Git.
-- Use `-CallbackPort <unused-port>` when another running MCP proxy already owns
-  the callback port stored in the local OAuth client registration.
-- `-ControlFixturePath <private-json>` is a separate explicit opt-in for the Phase 2
-  target smoke. It expects only `control_uuid` and `initial_state` (`on` or `off`),
-  switches once to the opposite state and restores the recorded initial state. Use it
-  only for a previously approved non-critical Gen. 1 Switch; keep the fixture outside
-  Git.
+- `python tools/test.py --profile changed --plan` shows the checks selected from
+  the branch diff, staged and unstaged changes, and untracked files without running
+  them.
+- `python tools/test.py --profile changed` runs that focused selection.
+- `python tools/test.py --profile changed --files <path> [<path> ...]` selects from
+  explicit paths. Use `--base-ref <ref>` only when automatic `origin/master`
+  comparison is not appropriate.
+- `python tools/test.py --profile full` runs formatting, lint, strict typing, and
+  all deterministic tests. The backward-compatible `python tools/test.py` does the
+  same.
 
-`tools/build_plugin.py` and `tools/prepare_wheelhouse.py` remain useful low-level
-building blocks for focused development. Use the release-candidate wrapper for any
-artifact that is intended for target installation or publication.
+Changed selection maps known files to affected tests. Documentation-only changes
+run only `git diff --check`; unknown or cross-cutting paths fall back visibly to
+Full. An invalid explicit base ref fails instead of silently choosing another scope.
+Do not repeat an unchanged successful selection during the same iteration.
+
+Focused checks may run in the available development environment. Full evidence
+requires Python 3.13 plus Perl and Node.js; the runner exits `2` as incomplete when
+those requirements are missing. CI runs Full on Python 3.13. A green Full CI result
+for the same commit need not be duplicated locally.
+
+## Packages
+
+- `python tools/build_release_candidate.py --runtime-wheelhouse <cache>` runs Full,
+  rebuilds the project wheel, builds one plugin ZIP, writes SHA-256, and verifies the
+  archive.
+- `python tools/prepare_wheelhouse.py --runtime-only <cache>` prepares a persistent
+  external Debian 13/arm64 runtime-wheel cache. Recreate it after
+  `requirements/runtime-arm64.lock` changes and never commit it.
+- `python tools/verify_plugin.py <archive.zip>` verifies an existing archive without
+  extracting or installing it.
+
+Use `tools/build_plugin.py` and `tools/prepare_wheelhouse.py` only as low-level
+building blocks. Build no ZIP for ordinary local checks or focused feature
+acceptance. Use the release-candidate wrapper for installation, upgrade,
+publication, or final release evidence.
+
+## MCP client smokes
+
+`pwsh -File tools/test_mcp_client.ps1` detects the active Microsoft Store or classic
+Claude profile and exercises the read-only tools plus both skill-delivery surfaces.
+Use `-CallbackPort <unused-port>` only for a callback-port conflict. Supply private
+UUIDs only through an external `-VisibilityFixturePath` file.
+
+`-ControlFixturePath <private-json>` is a separate explicit opt-in. Use it only for
+a previously approved non-critical Gen. 1 Switch; it must restore the recorded
+initial state. Never place fixture values in argv, logs, Git, or evidence.
 
 ## Target-system workflow
 
-Automate orchestration, evidence collection, and sanitized checks, but keep explicit
-boundaries around state-changing operations:
+For focused development or feature acceptance, transfer only changed plugin-owned
+files with a recoverable backup, preserved owner/mode, and atomic replacement.
+Restart only `loxberry-mcpserver.service` when runtime code changed, then run the
+narrow smoke that motivated the transfer. This is feature evidence, not package or
+lifecycle evidence.
 
-1. Verify the exact target profile and strict host key before transfer.
-2. Compare local and remote SHA-256 before installation.
-3. Prefer the native LoxBerry Plugin Manager or its exact installer command for install,
-   upgrade, and uninstall.
-4. Read the SecurePIN only from an approved external file or interactive input. Never
-   place it in arguments, logs, repository files, or generated evidence.
-5. Run health, service, Apache, ownership, configuration-schema, and MCP read-only
-   smokes after the lifecycle action.
-6. Preserve the installed plugin and configured MCP clients unless the requested test
-   explicitly includes removal.
+For native install, upgrade, or uninstall:
 
-Replacing individual installed files is a diagnostic shortcut, not release evidence.
-Limit it to plugin-owned paths, save a recoverable copy, preserve owner and mode,
-restart only the affected plugin service, and follow it with a normal package upgrade
-before claiming lifecycle acceptance.
+1. Verify the exact target profile, strict host key, local ZIP, checksum, and remote
+   checksum.
+2. Use the native Plugin Manager or its exact authorized installer command. Read the
+   SecurePIN only from approved external input, never argv or logs.
+3. Wait for terminal installer status before starting another lifecycle action.
+4. Always verify installed version, service state, and loopback health.
+5. Add Apache, ownership, secret modes, schema, persistence, browser, or MCP client
+   checks only when affected by the diff or required for final release acceptance.
+6. Preserve the installed plugin and configured clients unless removal is explicitly
+   requested.
 
-Never automate changes to a Loxone Miniserver, access to a production LoxBerry, or the
-publication of private addresses, identities, configuration, or test fixtures.
+Batch browser DOM, overflow, focus, and console checks per viewport. Reuse an
+authenticated session and capture screenshots only for visual changes or failures.
+Never access production, change the Miniserver without explicit control authorization,
+or publish private configuration or identities.

--- a/docs/development/implementation-guidelines.md
+++ b/docs/development/implementation-guidelines.md
@@ -209,6 +209,9 @@ Die verbindliche Auswahl steht in der [Teststrategie](test-strategy.md).
 Grundsätzlich gilt:
 
 - Tests werden durch tatsächliche Änderungen ausgelöst, nicht periodisch.
+- Während der Implementierung wird die Changed-Auswahl verwendet und nur nach
+  relevanten weiteren Änderungen wiederholt. Full läuft einmal auf der finalen
+  Revision oder als gleichwertiges CI-Gate desselben Commits.
 - Deterministische Logik wird lokal und in CI ohne echten Miniserver oder
   LoxBerry getestet.
 - MCP-Schemas, Berechtigungsgrenzen, Konfigurationsmigrationen und Fehlerpfade

--- a/docs/development/test-strategy.md
+++ b/docs/development/test-strategy.md
@@ -3,144 +3,111 @@
 - **Zielgruppe:** Entwickler, Maintainer, Reviewer, Tester und KI-Agenten
 - **Status:** Verbindliche Ausgangsbasis
 
-Tests werden durch tatsächliche Entwicklungsänderungen ausgelöst. Es gibt keine
-täglichen oder wöchentlichen Pflichtläufe. Gewählt wird der kleinste
-reproduzierbare Prüfumfang, der die Wirkung und das Risiko des Diffs abdeckt.
-Die vollständige deterministische Suite ist das Gate für Pull Requests und
-`master`, seit ausführbarer Code vorhanden ist.
+Tests werden durch tatsächliche Änderungen ausgelöst. Gewählt wird der kleinste
+reproduzierbare Prüfumfang, der Wirkung und Risiko des Diffs abdeckt. Es gibt keine
+periodischen Pflichtläufe und keine ZIP-, Browser- oder Geräteabnahme ohne betroffene
+Grenze.
+
+## Ausführungsprofile
+
+- **Changed:** Während Analyse und Implementierung betroffene statische Prüfungen und
+  Tests ausführen. Auswahl mit `python tools/test.py --profile changed --plan` prüfen
+  und anschließend ohne `--plan` starten. Eine unveränderte erfolgreiche Auswahl wird
+  nicht wiederholt.
+- **Full:** Format, Lint, strikte Typprüfung und alle deterministischen Tests. Full ist
+  für unbekannte oder querschnittliche Pfade, die finale Revision ohne gleichwertige
+  CI-Evidenz, Release-Pakete und CI vorgesehen.
+- **CI:** Ein grünes Full-Gate auf demselben Commit ist die maßgebliche PR-Evidenz und
+  muss lokal nicht erneut ausgeführt werden.
+
+Changed darf in der vorhandenen Entwicklungsumgebung laufen. Vollständige lokale,
+CI- oder Release-Evidenz benötigt Python 3.13, Perl und Node.js. Fehlt eine
+Pflichtlaufzeit, ist das Ergebnis `incomplete` (Exitcode `2`), nicht bestanden.
 
 ## Testebenen
 
-1. **Statische Prüfungen:** Format, Syntax, Lint, Dokumentationslinks und
-   maschinenlesbare Schemas
-2. **Unit-Tests:** Validierung, Mapping, Rechteentscheidungen, Konfiguration,
-   Migrationen und andere deterministische Logik
-3. **MCP-Vertragstests:** Tool-Liste, Eingabe-/Ausgabeschemas, Fehlercodes,
-   Zeitlimits und Abbruch mit simulierten Backends
-4. **Integrationstests:** Loxone- und LoxBerry-Adapter gegen kontrollierte Mocks
-   oder Fixtures; keine echten Zugangsdaten
-5. **Sicherheitstests:** Authentifizierung, fehlende Rechte, Allowlist-Grenzen,
-   Injection, Pfade, URLs, Secret-Maskierung und Rate Limits
-6. **Browserprüfungen:** betroffene Weboberfläche auf Desktop und Mobile
-7. **Zielgerätetests:** nur Grenzen, die lokal nicht zuverlässig beweisbar sind,
-   etwa LoxBerry-APIs, Rechte, Dienste, Installation und Upgrade
+1. **Statisch:** Format, Syntax, Lint, Dokumentationsdiffs und Schemas
+2. **Unit:** Validierung, Mapping, Rechte, Konfiguration und Migrationen
+3. **MCP-Vertrag:** Tool-Liste, Schemas, Fehlercodes, Zeitlimits und Abbruch
+4. **Integration:** Adapter gegen kontrollierte Mocks oder Fixtures
+5. **Sicherheit:** Authentifizierung, Rechte, Allowlist, Injection, Pfade und Maskierung
+6. **Browser:** nur betroffene Oberfläche auf notwendigen Viewports
+7. **Zielgerät:** nur lokal nicht beweisbare LoxBerry-, Lifecycle- oder Gerätegrenzen
 
 ## Änderungs- und Risikomatrix
 
 | Änderung | Automatisierte Prüfung | Browser | LoxBerry/Miniserver |
 | --- | --- | --- | --- |
-| Rechtschreibung, Links, reine redaktionelle Klarstellung | Link-/Formatprüfung, sofern vorhanden | Nein | Nein |
-| Normative Spezifikation ohne Codeänderung | Konsistenzprüfung und Review | Nur bei gerendertem Inhalt | Nein |
+| Rechtschreibung, Links, redaktionelle Klarstellung | `git diff --check`, Linkprüfung falls vorhanden | Nein | Nein |
+| Normative Spezifikation ohne Code | Konsistenzprüfung | Nur bei gerendertem Verhalten | Nein |
 | Deterministische Logik oder Schema | betroffene Unit-/Vertragstests | Nein | Normalerweise nein |
-| Authentifizierung, Autorisierung oder schreibendes Tool | Unit-, Vertrag-, Negativ- und Sicherheitstests | betroffener Ablauf | gezielter End-to-End-Test |
-| Konfigurationswert, Default oder Migration | Validierung und Migrationsregression | betroffener Ablauf | bei LoxBerry-Pfaden/Rechten |
-| UI-Verhalten ohne Layoutwirkung | UI-/Sprachtests | `1280x800` und `390x844` | nur wenn installierter Pfad nötig |
-| Responsives/shared Layout, Dialog oder Navigation | UI-/Sprachtests | vollständige Viewport-Matrix | installierte Seite |
-| Dienst, Systemrechte, Plugin-Lifecycle oder Hardware | Syntax plus Regressionen | nur betroffene UI-Flows | gezielte betroffene Szenarien |
-| Abhängigkeit oder Runtime-Upgrade | vollständige deterministische Suite | nach Auswirkung | Installations-/Start-Smoke |
+| Defektbehebung mit Verhaltenswirkung | reproduzierender Regressionstest plus betroffene Tests | nach Wirkung | nach betroffener Grenze |
+| Authentifizierung, Autorisierung oder schreibendes Tool | Vertrag-, Negativ- und Sicherheitstests | betroffener Ablauf | gezielter End-to-End-Test |
+| Konfigurationswert, Default oder Migration | Validierung und Migrationsregression | betroffener Ablauf | bei Pfaden/Rechten/Persistenz |
+| UI-Verhalten ohne Layoutwirkung | betroffene UI-/Sprachtests | `1280x800`, `390x844` | nur wenn installierter Pfad nötig |
+| Shared Layout, Dialog oder Navigation | UI-/Sprachtests | vollständige Viewport-Matrix | installierte Seite falls nötig |
+| Dienst, Systemrechte oder Lifecycle | Syntax plus betroffene Regressionen | nur betroffene Flows | gezielter Lifecycle-Smoke |
+| Abhängigkeit oder Runtime | Full | nach Wirkung | Installations-/Start-Smoke |
 
-Unbekannte Laufzeit- oder Konfigurationspfade wählen sicherheitshalber die
-vollständige automatisierte Suite. Das löst nicht automatisch eine komplette
-Geräte- oder Browserabnahme aus.
+Unbekannte Laufzeit- oder Konfigurationspfade fallen auf Full zurück. Das löst nicht
+automatisch Browser-, Geräte- oder Paketabnahme aus.
 
-## Desktop- und Mobile-Prüfung
+## Browserprüfung
 
-Für UI-Verhalten ohne gemeinsames Layout werden nur der geänderte Ablauf bei
-`1280x800` und `390x844` geprüft. Bei Änderungen an Layout, Navigation,
-Dialogen, gemeinsamen Controls oder responsivem Verhalten gilt:
+Für Verhalten ohne Shared-Layout-Wirkung genügen `1280x800` und `390x844`. Bei
+Layout, Navigation, Dialogen oder gemeinsamen Controls zusätzlich `900x768`,
+`360x800` und `320x568` prüfen. Reine Übersetzungen werden in DE und EN bei
+`390x844` geprüft; weitere Größen nur bei erkennbarem Umbruchrisiko.
 
-- `1280x800` Desktop
-- `900x768` schmales Desktop/Tablet
-- `390x844` primäres Mobile
-- `360x800` und `320x568` als kurze Overflow-Smokes
-
-Geprüft werden der effektive Viewport, horizontales Overflow, abgeschnittene
-Inhalte, Touch-/Tastaturbedienung, sichtbarer Fokus, Lade-/Fehlerzustände und die
-Browserkonsole. Screenshots werden für visuelle Änderungen und Fehler erstellt,
-nicht routinemäßig nach jedem Schritt.
-
-Reine Übersetzungsänderungen werden in Deutsch und Englisch bei `390x844`
-geprüft; weitere Größen sind nur bei erkennbarem Umbruchrisiko nötig.
+DOM-, Overflow-, Touch-/Tastatur-, Fokus- und Konsolenprüfungen je Viewport gebündelt
+ausführen und vorhandene authentifizierte Sitzungen wiederverwenden. Lade-, Fehler-
+und gespeicherte/ungespeicherte Zustände nur prüfen, wenn der Diff sie berührt.
+Screenshots nur für visuelle Änderungen oder Fehler erstellen.
 
 ## Zielgerät und Lifecycle
 
-Ein echtes LoxBerry-/Loxone-System wird verwendet, wenn Mocks die geänderte
-Grenze nicht beweisen können:
+Ein echtes Zielsystem ist nötig, wenn Mocks die betroffene Grenze nicht beweisen:
+native Pfade/APIs, Benutzer und Rechte, systemd, Netzwerkbindung, reale Loxone-
+Authentifizierung/Berechtigungen sowie Installation, Upgrade oder Deinstallation.
 
-- native LoxBerry-Pfade oder APIs
-- Benutzer, Gruppen, Dateirechte oder `sudo`
-- systemd und Prozess-Lifecycle
-- Netzwerkbindung und Verbindung zum Miniserver
-- Gen.-1-JWT-Anforderung und -Authentifizierung mit Command Encryption auf
-  Firmware `17.1.7.27`
-- Prüfung, dass Basic Auth, Zugangsdaten in URLs und Klartextpasswörter abgelehnt
-  beziehungsweise niemals erzeugt werden
-- Installation, Upgrade oder Deinstallation
-- reale Berechtigungsfilter des Loxone-Benutzers
+Für einen plugin-eigenen Datei-Hot-Swap genügen Backup, Hash, atomarer Austausch,
+erhaltene Rechte, gegebenenfalls Dienstneustart, `/healthz` und der betroffene
+Feature-Smoke. Das ist keine Installations- oder Upgrade-Evidenz.
 
-Es werden nur betroffene Dateien und Abläufe getestet. Bestehende Konfiguration,
-Dateirechte und Dienstzustände werden vorher gesichert und danach
-wiederhergestellt. Eine Änderung am Installer benötigt den normalen
-Plugin-Manager-Weg; ein Merge allein benötigt keine vollständige
-Installationsabnahme.
+Nach einem nativen Lifecycle-Vorgang immer terminalen Installerstatus, installierte
+Version, Dienst und Loopback-Health prüfen. Apache, Dateirechte, Secret-Modi, Schema,
+Persistenz, Browser und MCP-Client nur ergänzen, wenn der Diff diese Grenzen berührt
+oder eine finale Release-Abnahme verlangt. Ein Merge allein benötigt keine
+Plugin-Manager-Abnahme.
 
-## Öffentliche Betatests für nicht vorhandene Hardware
+Bestehende Konfiguration und Dienstzustände werden erhalten. Zugangsdaten, Tokens,
+interne Adressen und unmaskierte Gerätedaten erscheinen weder in Befehlen noch
+Evidenz. Schreibtests bleiben ein separates Opt-in an ausdrücklich genehmigten,
+unkritischen Steuerungen mit Wiederherstellung.
 
-Steht eine zugesagte Hardwaregeneration den Maintainern nicht zur Verfügung,
-wird die fehlende reale Prüfung ausdrücklich als `unverified` beziehungsweise
-`experimental` ausgewiesen. Sie wird nicht durch Mocks als bestanden erklärt.
+## Nicht vorhandene Hardware
 
-Tests auf einem Miniserver Gen. 2 werden durch freiwillige Dritte über eine
-öffentliche Beta erbracht. Dafür stellt das Projekt ein versioniertes
-Pre-Release-Paket, Prüfsumme, Testplan, Rücksetzweg, maskierten Diagnoseexport
-und ein strukturiertes GitHub-Issue-Formular bereit. Der Test startet read-only
-und verwendet einen dedizierten Loxone-Benutzer mit Minimalrechten.
+Nicht real geprüfte Kombinationen bleiben `unverified` oder `experimental`; Mocks
+ersetzen keine Hardware-Evidenz. Für Gen. 2 gilt der separate
+[Beta-Testplan](gen2-beta-test.md). Maintainer und AI-Agenten greifen nur mit einer
+separaten ausdrücklichen Zustimmung auf Geräte Dritter zu.
 
-Die Gen.-2-Beta prüft zusätzlich HTTPS/WSS mit gültiger Hostnamen- und
-Zertifikatsprüfung, JWT-Anforderung/-Erneuerung und den fehlenden Klartext-
-Fallback nach einem TLS-Fehler. Der jeweilige Firmwarestand wird im Bericht
-festgehalten und erst danach in die Support-Matrix aufgenommen.
+## Mindestanforderungen
 
-Ein verwertbarer Bericht enthält:
+- Tests sind deterministisch und enthalten keine Secrets oder privaten Gerätedaten.
+- Defektbehebungen und relevante Verhaltensänderungen erhalten einen Test, der den
+  Fehler beziehungsweise Vertrag vor der Korrektur nachweisbar abdeckt. Rein
+  redaktionelle oder mechanische Änderungen benötigen keinen künstlichen Test.
+- Sicherheits- und Schreibpfade decken Fehler, Berechtigungen, Grenzen, Timeout und
+  bei Schreibaktionen Wiederholung beziehungsweise Idempotenz ab.
+- Mocks bilden nur benötigte externe Verträge ab.
+- Fehlende Pflichtprüfungen werden als unvollständig ausgewiesen.
+- Der Abschlussbericht nennt einmalig Prüfumfang, Umgebung und nicht geprüfte Grenzen;
+  Zwischenstände benötigen keine wiederholte vollständige Evidenzliste.
 
-- Plugin-, LoxBerry- und Miniserver-Version
-- CPU-Architektur sowie MCP-Client und dessen Version
-- ausgeführte Testfälle mit erwartetem und beobachtetem Ergebnis
-- ausschließlich maskierte relevante Logauszüge
-- Kennzeichnung, ob nur gelesen oder ausdrücklich eine Teststeuerung bedient
-  wurde
+## CI
 
-Passwörter, Tokens, vollständige Strukturdateien, interne Adressen und
-unmaskierte Zustandsdaten werden nicht angefordert. Schreibtests sind ein
-separater Opt-in-Schritt an unkritischen Steuerungen mit dokumentierter
-Wiederherstellung. Maintainer und KI-Agenten greifen nicht ohne eine separate,
-ausdrückliche Zustimmung remote auf Geräte der Betatester zu.
-
-Die Support-Matrix unterscheidet selbst getestete, durch mindestens einen
-vollständigen unabhängigen Bericht bestätigte, experimentelle und nicht
-unterstützte Kombinationen. Ein fehlender Betatester ist kein fehlgeschlagener
-Test, aber die betreffende Kombination bleibt unbestätigt.
-
-## Mindestanforderungen an Tests
-
-- Tests sind deterministisch, wiederholbar und enthalten keine echten Secrets,
-  IP-Adressen oder benutzerspezifischen Gerätedaten.
-- Erfolgs-, Fehler-, Berechtigungs- und Timeoutpfade werden abgedeckt.
-- Schreibende Tools prüfen zusätzlich Wiederholung beziehungsweise Idempotenz.
-- Mocks bilden nur benötigte externe Verträge ab und definieren nicht heimlich
-  das Produktverhalten neu.
-- Ein Regressionstest schlägt vor dem Fix fehl und danach erfolgreich an.
-- Fehlende Pflichtabhängigkeiten oder nicht ausführbare Prüfungen werden als
-  unvollständig gemeldet, nicht als bestanden.
-- Testergebnisse nennen Umfang, Umgebung und nicht geprüfte Grenzen.
-
-## CI-Aufbau
-
-Der einheitliche lokale Testbefehl und derselbe CI-Pfad wurden mit dem ersten
-ausführbaren Stand eingeführt. CI läuft auf Pull Requests und Pushes nach
-`master` und umfasst Syntax/Lint, Unit- und MCP-Vertragstests.
-
-Ein GitHub-Pflichtcheck wird erst aktiviert, wenn sein Name und seine Runtime
-stabil sind. Zielgeräte und echte Miniserver werden nicht aus öffentlicher CI
-angesprochen. Zugangsdaten werden auch nicht als Workaround in Repository-
-Secrets für Fork-PRs verfügbar gemacht.
+PRs und Pushes nach `master` führen das Full-Profil mit Python 3.13 aus. Öffentliche
+CI greift nicht auf Zielgeräte oder echte Miniserver zu und erhält keine privaten
+Zugangsdaten als Workaround. Der Full-Check auf dem finalen Commit ist das Gate für
+den Merge; lokale Full-Wiederholungen nach unverändert grüner CI sind unnötig.

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -23,6 +23,8 @@ from tools.build_plugin import (
     _verify_project_wheel as verify_project_wheel_input,
 )
 from tools.build_release_candidate import _copy_runtime_wheels, _publish
+from tools.build_release_candidate import main as build_release_candidate
+from tools.prepare_wheelhouse import main as prepare_wheelhouse
 from tools.verify_plugin import (
     PackageVerificationError,
     verify_archive,
@@ -521,7 +523,58 @@ def test_release_helpers_exclude_stale_project_wheel_and_refuse_overwrite(
         _publish(candidate, output, hashlib.sha256(candidate.read_bytes()).hexdigest())
 
 
-@pytest.mark.parametrize("script", ["tools/verify_plugin.py", "tools/build_release_candidate.py"])
+def test_release_candidate_builds_plugin_archive_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    build_calls: list[tuple[str, ...]] = []
+
+    def run(*arguments: str, root: Path, environment: dict[str, str] | None = None) -> None:
+        del root, environment
+        if "tools/build_plugin.py" in arguments:
+            build_calls.append(arguments)
+            output = Path(arguments[arguments.index("--output") + 1])
+            output.write_bytes(b"candidate")
+
+    monkeypatch.setattr("tools.build_release_candidate._run", run)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["build_release_candidate.py", "--output-dir", str(tmp_path)],
+    )
+
+    assert build_release_candidate() == 0
+    assert len(build_calls) == 1
+
+
+def test_prepare_runtime_wheelhouse_skips_project_wheel(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    commands: list[list[str]] = []
+
+    def run(arguments: list[str], **_kwargs: object) -> None:
+        commands.append(arguments)
+
+    monkeypatch.setattr("tools.prepare_wheelhouse.subprocess.run", run)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["prepare_wheelhouse.py", "--runtime-only", str(tmp_path)],
+    )
+
+    assert prepare_wheelhouse() == 0
+    assert len(commands) == 1
+    assert commands[0][2:4] == ["pip", "download"]
+    assert (tmp_path / "runtime-arm64.lock").is_file()
+
+
+@pytest.mark.parametrize(
+    "script",
+    [
+        "tools/verify_plugin.py",
+        "tools/build_release_candidate.py",
+        "tools/prepare_wheelhouse.py",
+    ],
+)
 def test_documented_python_automation_clis_start_without_pythonpath(script: str) -> None:
     result = subprocess.run(
         [sys.executable, script, "--help"],

--- a/tests/test_test_runner.py
+++ b/tests/test_test_runner.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from tools.test import TestPlan as RunnerPlan
+from tools.test import create_plan, discover_changed_files, main
+
+
+def _pytest_targets(plan: RunnerPlan) -> set[str]:
+    for command in plan.commands:
+        if command[1:4] == ("-m", "pytest", "-q"):
+            return set(command[4:])
+    return set()
+
+
+def test_changed_packaging_selects_package_contract_tests() -> None:
+    plan = create_plan("changed", ("tools/build_release_candidate.py",))
+
+    assert plan.effective_profile == "changed"
+    assert _pytest_targets(plan) == {
+        "tests/test_apache_config.py",
+        "tests/test_plugin_package.py",
+    }
+
+
+def test_changed_ui_selects_only_affected_ui_groups() -> None:
+    plan = create_plan("changed", ("webfrontend/htmlauth/explorer.js",))
+
+    assert plan.effective_profile == "changed"
+    assert _pytest_targets(plan) == {
+        "tests/test_explorer_ui.py",
+        "tests/test_oauth.py",
+    }
+
+
+def test_shared_language_files_select_both_ui_groups() -> None:
+    plan = create_plan("changed", ("templates/lang/language_de.ini",))
+
+    assert plan.effective_profile == "changed"
+    assert _pytest_targets(plan) == {
+        "tests/test_admin.py",
+        "tests/test_admin_ui.py",
+        "tests/test_apache_config.py",
+        "tests/test_explorer_ui.py",
+        "tests/test_oauth.py",
+    }
+
+
+def test_changed_documentation_uses_only_diff_check() -> None:
+    plan = create_plan("changed", ("docs/development/automation.md",))
+
+    assert plan.effective_profile == "changed"
+    assert plan.commands == (("git", "diff", "--check"),)
+
+
+def test_packaged_skill_markdown_selects_contract_tests() -> None:
+    plan = create_plan("changed", ("src/mcpserver/skills/using-loxberry-mcp/SKILL.md",))
+
+    assert plan.effective_profile == "changed"
+    assert _pytest_targets(plan) == {
+        "tests/test_plugin_package.py",
+        "tests/test_tools.py",
+    }
+
+
+def test_unknown_runtime_path_falls_back_to_full() -> None:
+    plan = create_plan("changed", ("src/mcpserver/future_module.py",))
+
+    assert plan.effective_profile == "full"
+    assert plan.reason == "unmapped or cross-cutting paths: src/mcpserver/future_module.py"
+    assert any(command[1:4] == ("-m", "pytest", "-q") for command in plan.commands)
+
+
+def test_changed_explicit_plan_cli_does_not_run_commands(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "test.py",
+            "--profile",
+            "changed",
+            "--files",
+            "tools/test.py",
+            "--plan",
+        ],
+    )
+
+    assert main() == 0
+    output = capsys.readouterr().out
+    assert "requested=changed effective=changed" in output
+    assert "tests/test_test_runner.py" in output
+
+
+def test_full_profile_keeps_ci_commands_quiet() -> None:
+    plan = create_plan("full")
+
+    assert plan.commands[-1][1:] == ("-m", "pytest", "-q")
+    assert plan.commands[0] == ("git", "diff", "--check")
+
+
+def test_invalid_explicit_base_ref_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def failed_run(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess([], 1, "", "unknown revision")
+
+    monkeypatch.setattr("tools.test.subprocess.run", failed_run)
+
+    with pytest.raises(RuntimeError, match="invalid base ref"):
+        discover_changed_files("missing-ref", explicit=True)
+
+
+def test_documented_test_cli_starts_without_pythonpath() -> None:
+    result = subprocess.run(
+        [sys.executable, "tools/test.py", "--help"],
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    assert result.returncode == 0

--- a/tools/build_release_candidate.py
+++ b/tools/build_release_candidate.py
@@ -127,26 +127,21 @@ def main() -> int:
             _copy_runtime_wheels(args.runtime_wheelhouse.resolve(), wheelhouse, requirements)
             _build_project_wheel(root, wheelhouse, environment)
 
-        first = work / "candidate-a.zip"
-        second = work / "candidate-b.zip"
-        for candidate in (first, second):
-            _run(
-                sys.executable,
-                "tools/build_plugin.py",
-                "--wheelhouse",
-                str(wheelhouse),
-                "--output",
-                str(candidate),
-                root=root,
-                environment=environment,
-            )
-        first_digest = hashlib.sha256(first.read_bytes()).hexdigest()
-        second_digest = hashlib.sha256(second.read_bytes()).hexdigest()
-        if first_digest != second_digest:
-            raise RuntimeError("repeated plugin builds are not byte-identical")
+        candidate = work / "candidate.zip"
+        _run(
+            sys.executable,
+            "tools/build_plugin.py",
+            "--wheelhouse",
+            str(wheelhouse),
+            "--output",
+            str(candidate),
+            root=root,
+            environment=environment,
+        )
+        digest = hashlib.sha256(candidate.read_bytes()).hexdigest()
 
         output = output_dir / f"LoxBerry-MCP-Server-{_version(root)}.zip"
-        _publish(first, output, first_digest)
+        _publish(candidate, output, digest)
         _run(
             sys.executable,
             "tools/verify_plugin.py",
@@ -156,7 +151,7 @@ def main() -> int:
         )
 
     print(f"RELEASE_CANDIDATE=pass path={output}")
-    print(f"SHA256={first_digest}")
+    print(f"SHA256={digest}")
     return 0
 
 

--- a/tools/prepare_wheelhouse.py
+++ b/tools/prepare_wheelhouse.py
@@ -1,4 +1,4 @@
-"""Build the project wheel and download exact Debian 13 arm64 runtime wheels."""
+"""Prepare exact Debian 13 arm64 wheels for packaging or a runtime cache."""
 
 from __future__ import annotations
 
@@ -13,6 +13,11 @@ from pathlib import Path
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("output", type=Path)
+    parser.add_argument(
+        "--runtime-only",
+        action="store_true",
+        help="Download only the pinned arm64 runtime wheels for a reusable cache.",
+    )
     args = parser.parse_args()
     root = Path(__file__).resolve().parents[1]
     output = args.output.resolve()
@@ -47,23 +52,24 @@ def main() -> int:
         cwd=root,
         env=build_environment,
     )
-    subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "pip",
-            "wheel",
-            "--ignore-requires-python",
-            "--no-deps",
-            "--no-cache-dir",
-            "--wheel-dir",
-            str(output),
-            ".",
-        ],
-        check=True,
-        cwd=root,
-        env=build_environment,
-    )
+    if not args.runtime_only:
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "wheel",
+                "--ignore-requires-python",
+                "--no-deps",
+                "--no-cache-dir",
+                "--wheel-dir",
+                str(output),
+                ".",
+            ],
+            check=True,
+            cwd=root,
+            env=build_environment,
+        )
     shutil.copy2(root / "requirements" / "runtime-arm64.lock", output / "runtime-arm64.lock")
     return 0
 

--- a/tools/test.py
+++ b/tools/test.py
@@ -1,23 +1,364 @@
-"""Run the deterministic checks used locally and in CI."""
+"""Run change-driven checks locally and the complete deterministic CI gate."""
 
 from __future__ import annotations
 
+import argparse
+import fnmatch
+import os
+import shutil
 import subprocess
 import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final, cast
+
+ROOT: Final = Path(__file__).resolve().parents[1]
+Command = tuple[str, ...]
+
+_DOCUMENTATION_PATTERNS: Final = (
+    "AGENTS.md",
+    "CONTRIBUTING.md",
+    "docs/**",
+    "LICENSE",
+    "README.md",
+)
+_FULL_PATTERNS: Final = (
+    ".github/**",
+    "pyproject.toml",
+    "requirements/**",
+    "src/mcpserver/__init__.py",
+)
+_TEST_GROUPS: Final = (
+    (
+        (
+            ".gitattributes",
+            "bin/**",
+            "config/apache/**",
+            "config/systemd/**",
+            "icons/**",
+            "plugin.cfg",
+            "preinstall.sh",
+            "preupgrade.sh",
+            "postinstall.sh",
+            "postroot.sh",
+            "postupgrade.sh",
+            "prerelease.cfg",
+            "release.cfg",
+            "tools/build_plugin.py",
+            "tools/build_release_candidate.py",
+            "tools/prepare_wheelhouse.py",
+            "tools/verify_plugin.py",
+            "uninstall/**",
+        ),
+        ("tests/test_plugin_package.py", "tests/test_apache_config.py"),
+    ),
+    (
+        (
+            "src/mcpserver/admin.py",
+            "templates/index.html",
+            "templates/lang/**",
+            "webfrontend/htmlauth/index.cgi",
+        ),
+        (
+            "tests/test_admin.py",
+            "tests/test_admin_ui.py",
+            "tests/test_apache_config.py",
+        ),
+    ),
+    (
+        (
+            "templates/explorer.html",
+            "templates/lang/**",
+            "webfrontend/htmlauth/explorer.cgi",
+            "webfrontend/htmlauth/explorer_callback.cgi",
+            "webfrontend/htmlauth/explorer.js",
+        ),
+        ("tests/test_explorer_ui.py", "tests/test_oauth.py"),
+    ),
+    (
+        ("config/default-config.json", "src/mcpserver/config.py"),
+        (
+            "tests/test_admin.py",
+            "tests/test_config.py",
+            "tests/test_settings.py",
+        ),
+    ),
+    (
+        ("src/mcpserver/certificates.py", "bin/renew-web-certificate"),
+        ("tests/test_admin.py", "tests/test_certificates.py"),
+    ),
+    (
+        ("src/mcpserver/auth/**",),
+        (
+            "tests/test_auth_store.py",
+            "tests/test_explorer_ui.py",
+            "tests/test_loxone_store.py",
+            "tests/test_oauth.py",
+            "tests/test_server.py",
+        ),
+    ),
+    (
+        ("src/mcpserver/loxone/**", "tools/test_loxone_target.py"),
+        (
+            "tests/test_control.py",
+            "tests/test_control_commands.py",
+            "tests/test_loxone_cache.py",
+            "tests/test_loxone_client.py",
+            "tests/test_loxone_events.py",
+            "tests/test_loxone_security.py",
+            "tests/test_loxone_structure.py",
+            "tests/test_loxone_target.py",
+            "tests/test_tools.py",
+        ),
+    ),
+    (
+        ("src/mcpserver/server.py",),
+        ("tests/test_oauth.py", "tests/test_server.py", "tests/test_tools.py"),
+    ),
+    (
+        ("src/mcpserver/settings.py",),
+        ("tests/test_config.py", "tests/test_server.py", "tests/test_settings.py"),
+    ),
+    (
+        ("src/mcpserver/skill_delivery.py", "src/mcpserver/skills/**"),
+        ("tests/test_plugin_package.py", "tests/test_tools.py"),
+    ),
+    (
+        ("src/mcpserver/tools.py",),
+        (
+            "tests/test_control.py",
+            "tests/test_control_commands.py",
+            "tests/test_server.py",
+            "tests/test_tools.py",
+        ),
+    ),
+    (
+        ("tools/test.py",),
+        ("tests/test_test_runner.py",),
+    ),
+)
 
 
-def main() -> int:
-    commands = (
+@dataclass(frozen=True)
+class TestPlan:
+    requested_profile: str
+    effective_profile: str
+    files: tuple[str, ...]
+    commands: tuple[Command, ...]
+    reason: str | None = None
+
+
+def _matches(path: str, patterns: tuple[str, ...]) -> bool:
+    return any(fnmatch.fnmatchcase(path, pattern) for pattern in patterns)
+
+
+def _normalize_file(value: str) -> str:
+    path = Path(value)
+    if path.is_absolute():
+        try:
+            path = path.resolve().relative_to(ROOT)
+        except ValueError as exc:
+            raise ValueError(f"changed path is outside the repository: {value}") from exc
+    normalized = path.as_posix().removeprefix("./")
+    if normalized == ".." or normalized.startswith("../"):
+        raise ValueError(f"changed path is outside the repository: {value}")
+    return normalized
+
+
+def _full_commands() -> tuple[Command, ...]:
+    return (
+        ("git", "diff", "--check"),
         (sys.executable, "-m", "ruff", "format", "--check", "."),
         (sys.executable, "-m", "ruff", "check", "."),
         (sys.executable, "-m", "mypy"),
-        (sys.executable, "-m", "pytest"),
+        (sys.executable, "-m", "pytest", "-q"),
     )
-    for command in commands:
-        completed = subprocess.run(command, check=False)
+
+
+def create_plan(profile: str, files: tuple[str, ...] = ()) -> TestPlan:
+    normalized = tuple(sorted({_normalize_file(path) for path in files}))
+    if profile == "full":
+        return TestPlan("full", "full", normalized, _full_commands())
+    if profile != "changed":
+        raise ValueError(f"unsupported test profile: {profile}")
+
+    selected_tests: set[str] = set()
+    python_files: set[str] = set()
+    needs_mypy = False
+    fallback_reasons: list[str] = []
+
+    for path in normalized:
+        repository_path = ROOT / path
+        if path.endswith(".py") and repository_path.is_file():
+            python_files.add(path)
+        if path.startswith("tests/test_") and path.endswith(".py"):
+            if repository_path.is_file():
+                selected_tests.add(path)
+            else:
+                fallback_reasons.append(path)
+            continue
+        if _matches(path, _DOCUMENTATION_PATTERNS):
+            continue
+        if _matches(path, _FULL_PATTERNS):
+            fallback_reasons.append(path)
+            continue
+
+        matched = False
+        for patterns, tests in _TEST_GROUPS:
+            if _matches(path, patterns):
+                matched = True
+                selected_tests.update(tests)
+        if path.startswith("src/"):
+            needs_mypy = True
+        if not matched:
+            fallback_reasons.append(path)
+
+    if fallback_reasons:
+        reason = "unmapped or cross-cutting paths: " + ", ".join(sorted(fallback_reasons))
+        return TestPlan("changed", "full", normalized, _full_commands(), reason)
+
+    commands: list[Command] = [("git", "diff", "--check")]
+    if python_files:
+        ordered_python = tuple(sorted(python_files))
+        commands.append((sys.executable, "-m", "ruff", "format", "--check", *ordered_python))
+        commands.append((sys.executable, "-m", "ruff", "check", *ordered_python))
+    if needs_mypy:
+        commands.append((sys.executable, "-m", "mypy"))
+    if selected_tests:
+        commands.append((sys.executable, "-m", "pytest", "-q", *tuple(sorted(selected_tests))))
+    return TestPlan("changed", "changed", normalized, tuple(commands))
+
+
+def _git_lines(*arguments: str) -> tuple[str, ...]:
+    completed = subprocess.run(
+        ("git", *arguments),
+        check=False,
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode:
+        detail = completed.stderr.strip() or "git command failed"
+        raise RuntimeError(detail)
+    return tuple(line for line in completed.stdout.splitlines() if line)
+
+
+def _resolve_base_ref(base_ref: str, *, explicit: bool) -> bool:
+    completed = subprocess.run(
+        ("git", "rev-parse", "--verify", f"{base_ref}^{{commit}}"),
+        check=False,
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode and explicit:
+        raise RuntimeError(f"invalid base ref: {base_ref}")
+    return completed.returncode == 0
+
+
+def discover_changed_files(base_ref: str, *, explicit: bool) -> tuple[str, ...] | None:
+    if not _resolve_base_ref(base_ref, explicit=explicit):
+        return None
+    files: set[str] = set()
+    files.update(_git_lines("diff", "--name-only", "--diff-filter=ACDMRT", f"{base_ref}...HEAD"))
+    files.update(_git_lines("diff", "--name-only", "--diff-filter=ACDMRT"))
+    files.update(_git_lines("diff", "--cached", "--name-only", "--diff-filter=ACDMRT"))
+    files.update(_git_lines("ls-files", "--others", "--exclude-standard"))
+    return tuple(sorted({_normalize_file(path) for path in files}))
+
+
+def _runtime_issues() -> tuple[str, ...]:
+    issues: list[str] = []
+    if sys.version_info[:2] != (3, 13):
+        issues.append(
+            f"Python 3.13 required, found {sys.version_info.major}.{sys.version_info.minor}"
+        )
+    for runtime in ("perl", "node"):
+        if shutil.which(runtime) is None:
+            issues.append(f"{runtime} is required")
+    return tuple(issues)
+
+
+def _format_command(command: Command) -> str:
+    return subprocess.list2cmdline(command)
+
+
+def _print_plan(plan: TestPlan) -> None:
+    print(
+        f"TEST_PLAN requested={plan.requested_profile} effective={plan.effective_profile} "
+        f"files={len(plan.files)}",
+        flush=True,
+    )
+    if plan.reason:
+        print(f"TEST_PLAN_REASON={plan.reason}", flush=True)
+    for command in plan.commands:
+        print(f"TEST_COMMAND={_format_command(command)}", flush=True)
+    if plan.effective_profile == "full":
+        for issue in _runtime_issues():
+            print(f"TEST_ENVIRONMENT={issue}", flush=True)
+
+
+def _run(plan: TestPlan) -> int:
+    if plan.effective_profile == "full":
+        issues = _runtime_issues()
+        if issues:
+            for issue in issues:
+                print(f"INCOMPLETE={issue}", file=sys.stderr)
+            return 2
+
+    environment = {**os.environ, "PYTHONPATH": str(ROOT / "src")}
+    for command in plan.commands:
+        completed = subprocess.run(command, check=False, cwd=ROOT, env=environment)
         if completed.returncode:
             return completed.returncode
+    print(
+        f"TEST_RESULT=pass profile={plan.effective_profile} "
+        f"commands={len(plan.commands)} files={len(plan.files)}"
+    )
     return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", choices=("changed", "full"), default="full")
+    parser.add_argument(
+        "--files", nargs="+", help="Explicit changed paths for the Changed profile."
+    )
+    parser.add_argument("--base-ref", help="Git base ref for automatic Changed selection.")
+    parser.add_argument(
+        "--plan", action="store_true", help="Print selected checks without running them."
+    )
+    args = parser.parse_args()
+    profile = cast(str, args.profile)
+    explicit_files = tuple(cast(list[str] | None, args.files) or ())
+    base_ref = cast(str | None, args.base_ref)
+
+    if profile == "full" and (explicit_files or base_ref):
+        parser.error("--files and --base-ref require --profile changed")
+
+    try:
+        if profile == "changed" and not explicit_files:
+            changed = discover_changed_files(
+                base_ref or "origin/master", explicit=base_ref is not None
+            )
+            if changed is None:
+                plan = TestPlan(
+                    "changed",
+                    "full",
+                    (),
+                    _full_commands(),
+                    "default base ref origin/master is unavailable",
+                )
+            else:
+                plan = create_plan("changed", changed)
+        else:
+            plan = create_plan(profile, explicit_files)
+    except (RuntimeError, ValueError) as exc:
+        print(f"TEST_SELECTION_ERROR={exc}", file=sys.stderr)
+        return 2
+
+    _print_plan(plan)
+    return 0 if args.plan else _run(plan)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add a change-driven `Changed` test profile with explicit planning and safe Full fallback
- build release-candidate ZIPs once instead of repeating the deterministic package build
- add a reusable external arm64 runtime-wheel cache mode
- align automation, implementation, and test-strategy documentation with focused development and target testing
- add regression coverage for test selection, runtime-only wheel preparation, and single-build release packaging

## Why

The previous workflow repeatedly rebuilt ZIPs and selected broad validation even when only a small feature boundary changed. This increased development time and agent overhead without adding equivalent evidence.

## Validation

- `tools/test.py --profile changed`: 46 tests passed
- Ruff format/check passed for all changed Python files
- `git diff --check` passed
- verified test ZIP built with the external arm64 wheel cache
- native LoxBerry Plugin Manager upgrade completed with terminal status `0`
- Chrome Plugin Manager upgrade reached visible success
- final service, loopback health, and Apache syntax checks passed

Full Python 3.13 validation is delegated to CI on this exact commit.