### PR TITLE
Fix admin UI refresh and Explorer performance

### DIFF
--- a/src/mcpserver/admin.py
+++ b/src/mcpserver/admin.py
@@ -207,9 +207,9 @@ def _save(payload: object) -> dict[str, Any]:
         raise AdminError(
             "configuration was not applied; previous configuration restored"
         ) from apply_error
-    for family_id in control_families:
-        _revoke(
-            family_id,
+    if control_families:
+        _revoke_many(
+            control_families,
             endpoint=previous.loxone_endpoint,
             timeout_seconds=previous.connection_timeout,
         )
@@ -274,6 +274,19 @@ def _revoke(
     endpoint: str | None = None,
     timeout_seconds: float | None = None,
 ) -> int:
+    return _revoke_many(
+        None if family_id is None else [family_id],
+        endpoint=endpoint,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+def _revoke_many(
+    family_ids: list[str] | None,
+    *,
+    endpoint: str | None = None,
+    timeout_seconds: float | None = None,
+) -> int:
     from mcpserver.auth.loxone_store import LoxoneTokenStoreError
     from mcpserver.loxone.client import LoxoneConnectionError, MiniserverEndpoint
     from mcpserver.loxone.events import LoxoneProtocolError
@@ -283,8 +296,8 @@ def _revoke(
 
     def mutate(document: dict[str, Any]) -> None:
         targets = (
-            [family_id]
-            if family_id is not None
+            family_ids
+            if family_ids is not None
             else [key for key, item in document["families"].items() if not item.get("revoked")]
         )
         for target in targets:
@@ -320,15 +333,27 @@ def _revoke(
             timeout_seconds=selected_timeout,
         )
 
+        async def kill_token(binding: tuple[str, str, str]) -> None:
+            target, miniserver_id, identity_id = binding
+            try:
+                token = token_store.get(target, miniserver_id, identity_id)
+            except LoxoneTokenStoreError:
+                token = None
+            if token is not None:
+                with suppress(
+                    TimeoutError,
+                    LoxoneConnectionError,
+                    LoxoneProtocolError,
+                ):
+                    await asyncio.wait_for(
+                        client.kill_token(token),
+                        timeout=selected_timeout + 5,
+                    )
+
         async def kill_tokens() -> None:
-            for target, miniserver_id, identity_id in bindings:
-                try:
-                    token = token_store.get(target, miniserver_id, identity_id)
-                except LoxoneTokenStoreError:
-                    token = None
-                if token is not None:
-                    with suppress(LoxoneConnectionError, LoxoneProtocolError):
-                        await client.kill_token(token)
+            async with asyncio.TaskGroup() as group:
+                for binding in bindings:
+                    group.create_task(kill_token(binding))
 
         asyncio.run(kill_tokens())
     if token_store is not None:
@@ -373,7 +398,12 @@ def dispatch(request: object) -> dict[str, Any]:
     if action == "save_config":
         return _save(payload)
     if action == "status":
-        return {"version": __version__, "service_active": _service_active()}
+        return {
+            "version": __version__,
+            "service_active": _service_active(),
+            "sessions": _sessions(),
+            "certificate": _certificate_status(),
+        }
     if action == "test_connection":
         return asyncio.run(_test_connection(payload))
     if action == "list_sessions":

--- a/templates/explorer.html
+++ b/templates/explorer.html
@@ -90,6 +90,7 @@
   data-origin-mismatch="<TMPL_VAR EXPLORER.ORIGIN_MISMATCH ESCAPE=HTML>">
 
   <section class="mcp-explorer-card" aria-labelledby="explorer-title">
+    <p><a class="lb-button" href="index.cgi"><TMPL_VAR EXPLORER.BACK></a></p>
     <h1 id="explorer-title"><TMPL_VAR EXPLORER.TITLE></h1>
     <p><TMPL_VAR EXPLORER.INTRO></p>
     <div class="mcp-explorer-actions">

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,5 +1,5 @@
 <style>
-  .mcp-page { max-width: 76rem; margin: 0 auto; padding: .5rem; overflow-wrap: anywhere; }
+  .mcp-page { display: grid; gap: 1rem; max-width: 76rem; margin: 0 auto; padding: .5rem; overflow-wrap: anywhere; }
   .mcp-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 20rem), 1fr)); gap: 1rem; }
   .mcp-card { min-width: 0; padding: 1rem; border: 1px solid #c9cdd2; border-radius: .4rem; background: #fff; }
   .mcp-form { display: grid; gap: .85rem; }
@@ -130,7 +130,9 @@
     <TMPL_ELSE><p class="mcp-status" data-kind="error"><TMPL_VAR CERTIFICATE.UNAVAILABLE></p></TMPL_IF>
   </section>
 
-  <section id="sessions" class="mcp-card" aria-labelledby="sessions-title" data-empty-label="<TMPL_VAR SESSIONS.EMPTY ESCAPE=HTML>">
+  <section id="sessions" class="mcp-card" aria-labelledby="sessions-title"
+    data-empty-label="<TMPL_VAR SESSIONS.EMPTY ESCAPE=HTML>"
+    data-unnamed-label="<TMPL_VAR SESSIONS.UNNAMED ESCAPE=HTML>">
     <h2 id="sessions-title"><TMPL_VAR SESSIONS.TITLE></h2>
     <div id="session-list">
     <TMPL_IF HAS_SESSIONS>
@@ -140,6 +142,10 @@
       <form method="post" action="index.cgi" data-ajax="revoke_all"><input type="hidden" name="action" value="revoke_all"><button class="lb-button" type="submit"><TMPL_VAR ACTION.REVOKE_ALL></button></form>
     <TMPL_ELSE><p><TMPL_VAR SESSIONS.EMPTY></p></TMPL_IF>
     </div>
+    <template id="session-table-template">
+      <div class="mcp-table-wrap"><table class="mcp-table"><thead><tr><th><TMPL_VAR SESSIONS.CLIENT></th><th><TMPL_VAR SESSIONS.INSTANCE></th><th><TMPL_VAR SESSIONS.IDENTITY></th><th><TMPL_VAR SESSIONS.SCOPES></th><th><TMPL_VAR SESSIONS.EXPIRES></th><th><TMPL_VAR SESSIONS.ACTION></th></tr></thead><tbody></tbody></table></div>
+      <form method="post" action="index.cgi" data-ajax="revoke_all"><input type="hidden" name="action" value="revoke_all"><button class="lb-button" type="submit"><TMPL_VAR ACTION.REVOKE_ALL></button></form>
+    </template>
   </section>
 
   <section id="diagnostics" class="mcp-card" aria-labelledby="diagnostics-title">
@@ -168,6 +174,9 @@
   const certificateOriginMatch = document.getElementById('certificate-origin-match');
   const certificateHostnameMatch = document.getElementById('certificate-hostname-match');
   const certificateWarning = document.getElementById('certificate-warning');
+  const sessionsSection = document.getElementById('sessions');
+  const sessionList = document.getElementById('session-list');
+  const sessionTableTemplate = document.getElementById('session-table-template');
   const syncTestEndpoint = () => { testEndpoint.value = miniserverEndpoint.value; };
   const syncMiniserverSelection = () => {
     const selectedEndpoint = miniserverSelect.value;
@@ -190,13 +199,20 @@
     const value = Number(raw);
     return Number.isSafeInteger(value) && value <= MAX_EXPIRY_EPOCH ? value : null;
   };
-  for (const element of document.querySelectorAll('time.mcp-expiry')) {
+  const updateExpiry = (element, raw) => {
+    element.dataset.expiresAt = String(raw ?? '');
     const expiresAt = parseExpiry(element.dataset.expiresAt);
     if (expiresAt !== null) {
       const date = new Date(expiresAt * 1000);
       element.dateTime = date.toISOString();
       element.textContent = expiryFormatter.format(date);
+    } else {
+      element.removeAttribute('datetime');
+      element.textContent = String(raw ?? '');
     }
+  };
+  for (const element of document.querySelectorAll('time.mcp-expiry')) {
+    updateExpiry(element, element.dataset.expiresAt);
   }
   const hideStatusTimers = new WeakMap();
   const hideSuccess = (element) => {
@@ -250,50 +266,103 @@
       certificateExpiry.textContent = expiryFormatter.format(date);
     }
   };
-  const pollCertificateRenewal = async (button, attempt = 0) => {
-    if (!certificateRenewalState || attempt >= 30) {
+  const postAjax = async (body, timeoutMs) => {
+    const controller = new AbortController();
+    const timeout = window.setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const response = await fetch('index.cgi', {
+        method: 'POST',
+        body,
+        signal: controller.signal,
+        headers: {'X-Requested-With': 'XMLHttpRequest'},
+      });
+      const result = await response.json();
+      if (!response.ok || !result.ok) throw new Error(result.error?.message || '<TMPL_VAR AJAX.ERROR ESCAPE=JS>');
+      return result;
+    } finally {
+      window.clearTimeout(timeout);
+    }
+  };
+  const pollCertificateRenewal = async (button) => {
+    const deadline = Date.now() + 75000;
+    try {
+      while (certificateRenewalState && Date.now() < deadline) {
+        await new Promise((resolve) => window.setTimeout(resolve, 2000));
+        try {
+          const body = new FormData();
+          body.set('action', 'certificate_status');
+          body.set('ajax', '1');
+          const result = await postAjax(body, 5000);
+          const state = result.data.certificate?.renewal?.state || 'error';
+          certificateRenewalState.textContent = certificateStateLabels[state] || certificateStateLabels.error;
+          if (state === 'success') updateCertificate(result.data.certificate);
+          if (state === 'success' || state === 'error' || state === 'idle') return;
+        } catch {
+          // Apache restarts while the LoxBerry Core installs the new certificate.
+        }
+      }
+      if (certificateRenewalState) certificateRenewalState.textContent = certificateStateLabels.error;
+    } finally {
       button.disabled = false;
       button.removeAttribute('aria-busy');
-      return;
     }
-    await new Promise((resolve) => window.setTimeout(resolve, 2000));
-    try {
-      const body = new FormData();
-      body.set('action', 'certificate_status');
-      body.set('ajax', '1');
-      const response = await fetch('index.cgi', {method: 'POST', body, headers: {'X-Requested-With': 'XMLHttpRequest'}});
-      const result = await response.json();
-      if (!response.ok || !result.ok) throw new Error('status');
-      const state = result.data.certificate?.renewal?.state || 'error';
-      certificateRenewalState.textContent = certificateStateLabels[state] || certificateStateLabels.error;
-      if (state === 'success') {
-        updateCertificate(result.data.certificate);
-        button.disabled = false;
-        button.removeAttribute('aria-busy');
-        return;
-      }
-      if (state === 'error' || state === 'idle') {
-        button.disabled = false;
-        button.removeAttribute('aria-busy');
-        return;
-      }
-    } catch {
-      // Apache restarts while the LoxBerry Core installs the new certificate.
-    }
-    pollCertificateRenewal(button, attempt + 1);
   };
   const updateSessions = (sessions) => {
-    const activeIds = new Set(sessions.map((session) => session.id));
-    const list = document.getElementById('session-list');
-    for (const row of list.querySelectorAll('tr[data-session-id]')) {
-      if (!activeIds.has(row.dataset.sessionId)) row.remove();
-    }
-    if (!list.querySelector('tr[data-session-id]')) {
+    if (!sessions.length) {
       const empty = document.createElement('p');
-      empty.textContent = document.getElementById('sessions').dataset.emptyLabel;
-      list.replaceChildren(empty);
+      empty.textContent = sessionsSection.dataset.emptyLabel;
+      sessionList.replaceChildren(empty);
+      return;
     }
+    const fragment = sessionTableTemplate.content.cloneNode(true);
+    const body = fragment.querySelector('tbody');
+    for (const session of sessions) {
+      const row = document.createElement('tr');
+      row.dataset.sessionId = String(session.id);
+      const values = [session.client_name || sessionsSection.dataset.unnamedLabel, session.client, session.identity, session.scopes];
+      values.forEach((value, index) => {
+        const cell = document.createElement('td');
+        const content = index === 0 ? document.createTextNode(String(value ?? '')) : document.createElement('code');
+        if (index !== 0) content.textContent = String(value ?? '');
+        cell.append(content);
+        row.append(cell);
+      });
+      const expiryCell = document.createElement('td');
+      const expiry = document.createElement('time');
+      expiry.className = 'mcp-expiry';
+      updateExpiry(expiry, session.expires_at);
+      expiryCell.append(expiry);
+      row.append(expiryCell);
+      const actionCell = document.createElement('td');
+      const revokeForm = document.createElement('form');
+      revokeForm.method = 'post';
+      revokeForm.action = 'index.cgi';
+      revokeForm.dataset.ajax = 'revoke_session';
+      const action = document.createElement('input');
+      action.type = 'hidden';
+      action.name = 'action';
+      action.value = 'revoke_session';
+      const id = document.createElement('input');
+      id.type = 'hidden';
+      id.name = 'id';
+      id.value = String(session.id);
+      const button = document.createElement('button');
+      button.className = 'lb-button';
+      button.type = 'submit';
+      button.textContent = '<TMPL_VAR ACTION.REVOKE ESCAPE=JS>';
+      revokeForm.append(action, id, button);
+      actionCell.append(revokeForm);
+      row.append(actionCell);
+      body.append(row);
+    }
+    sessionList.replaceChildren(fragment);
   };
+  const actionTimeout = (action) => ({
+    save_config: 90000,
+    revoke_session: 75000,
+    revoke_all: 75000,
+    renew_certificate: 30000,
+  })[action] || 15000;
   document.addEventListener('submit', async (event) => {
     const form = event.target.closest('form[data-ajax]');
     if (!form) return;
@@ -308,17 +377,14 @@
       status.textContent = '<TMPL_VAR AJAX.WORKING ESCAPE=JS>';
       const body = new FormData(form);
       body.set('ajax', '1');
-      const controller = new AbortController();
-      const timeout = window.setTimeout(() => controller.abort(), 15000);
       try {
-        const response = await fetch('index.cgi', {method: 'POST', body, signal: controller.signal, headers: {'X-Requested-With': 'XMLHttpRequest'}});
-        const result = await response.json();
-        if (!response.ok || !result.ok) throw new Error(result.error?.message || '<TMPL_VAR AJAX.ERROR ESCAPE=JS>');
+        const result = await postAjax(body, actionTimeout(form.dataset.ajax));
         status.dataset.kind = 'success';
         status.textContent = '<TMPL_VAR AJAX.SUCCESS ESCAPE=JS>';
         hideSuccess(status);
         if ('service_active' in result.data) document.getElementById('service-state').textContent = result.data.service_active ? '<TMPL_VAR STATUS.RUNNING ESCAPE=JS>' : '<TMPL_VAR STATUS.STOPPED ESCAPE=JS>';
         if (Array.isArray(result.data.sessions)) updateSessions(result.data.sessions);
+        if (result.data.certificate) updateCertificate(result.data.certificate);
         if (form.dataset.ajax === 'save_config') {
           const savedEndpoint = result.data.configuration.loxone.endpoint;
           miniserverEndpoint.value = savedEndpoint;
@@ -337,7 +403,6 @@
         else if (error instanceof TypeError) status.textContent = '<TMPL_VAR AJAX.NETWORK ESCAPE=JS>';
         else status.textContent = error instanceof Error ? error.message : '<TMPL_VAR AJAX.ERROR ESCAPE=JS>';
       } finally {
-        window.clearTimeout(timeout);
         if (!keepButtonDisabled) {
           button.disabled = false;
           button.removeAttribute('aria-busy');

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import subprocess
 from pathlib import Path
@@ -73,6 +74,25 @@ def test_page_state_aggregates_initial_admin_ui_data(monkeypatch: pytest.MonkeyP
         "service_active": True,
         "sessions": [{"id": "family"}],
         "certificate": {"available": True, "renewal_supported": False},
+    }
+
+
+def test_status_refresh_returns_all_dynamic_admin_ui_data(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sessions = [{"id": "family"}]
+    certificate = {"available": True, "renewal": {"state": "idle"}}
+    monkeypatch.setattr("mcpserver.admin._service_active", lambda: True)
+    monkeypatch.setattr("mcpserver.admin._sessions", lambda: sessions)
+    monkeypatch.setattr("mcpserver.admin._certificate_status", lambda: certificate)
+
+    result = dispatch({"action": "status"})
+
+    assert result == {
+        "version": result["version"],
+        "service_active": True,
+        "sessions": sessions,
+        "certificate": certificate,
     }
 
 
@@ -183,7 +203,7 @@ def test_disabling_control_revokes_control_sessions_after_successful_restart(
     next_document["tools"]["loxone_control_enabled"] = False
     next_document["loxone"]["endpoint"] = "http://192.168.10.30"
     events: list[str] = []
-    revocations: list[tuple[str, str | None, float | None]] = []
+    revocations: list[tuple[list[str], str | None, float | None]] = []
 
     class AuthStore:
         def snapshot(self) -> dict[str, object]:
@@ -201,19 +221,24 @@ def test_disabling_control_revokes_control_sessions_after_successful_restart(
     monkeypatch.setattr("mcpserver.admin._auth_store", lambda: AuthStore())
     monkeypatch.setattr("mcpserver.admin._restart_service", lambda: events.append("restart"))
 
-    def revoke(
-        family_id: str, *, endpoint: str | None = None, timeout_seconds: float | None = None
+    def revoke_many(
+        family_ids: list[str],
+        *,
+        endpoint: str | None = None,
+        timeout_seconds: float | None = None,
     ) -> int:
-        events.append(f"revoke:{family_id}")
-        revocations.append((family_id, endpoint, timeout_seconds))
-        return 1
+        events.append(f"revoke:{','.join(family_ids)}")
+        revocations.append((family_ids, endpoint, timeout_seconds))
+        return len(family_ids)
 
-    monkeypatch.setattr("mcpserver.admin._revoke", revoke)
+    monkeypatch.setattr("mcpserver.admin._revoke_many", revoke_many)
 
     _save(next_document)
 
     assert events == ["restart", "revoke:control-family"]
-    assert revocations == [("control-family", "http://192.168.10.20", previous.connection_timeout)]
+    assert revocations == [
+        (["control-family"], "http://192.168.10.20", previous.connection_timeout)
+    ]
 
 
 def test_session_list_excludes_revoked_families(
@@ -424,3 +449,67 @@ def test_revoke_deletes_local_token_after_remote_protocol_error(
     assert _revoke("family") == 1
     assert deleted == ["family"]
     assert store.snapshot()["families"]["family"]["revoked"] is True
+
+
+def test_revoke_kills_remote_tokens_concurrently(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    auth_path = (tmp_path / "data" / "auth" / "sessions.json").resolve()
+    store = AtomicJsonAuthStore(auth_path)
+
+    def add_families(document: dict[str, object]) -> None:
+        families = document["families"]
+        assert isinstance(families, dict)
+        for number in range(2):
+            families[f"family-{number}"] = {
+                "client_id": f"client-{number}",
+                "identity_id": f"identity-{number}",
+                "miniserver_id": "miniserver",
+                "revoked": False,
+            }
+
+    store.mutate(add_families)
+    active = 0
+    maximum_active = 0
+    deleted: list[str] = []
+
+    class TokenStore:
+        def get(self, family_id: str, miniserver_id: str, identity_id: str) -> LoxoneToken:
+            return LoxoneToken(family_id, identity_id, "key", "SHA256", 1)
+
+        def delete(self, family_id: str) -> None:
+            deleted.append(family_id)
+
+    class ConcurrentClient:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            pass
+
+        async def kill_token(self, token: LoxoneToken) -> None:
+            nonlocal active, maximum_active
+            active += 1
+            maximum_active = max(maximum_active, active)
+            await asyncio.sleep(0)
+            active -= 1
+
+    monkeypatch.setenv("MCPSERVER_AUTH_STORE", str(auth_path))
+    monkeypatch.setattr("mcpserver.admin._token_store", lambda: TokenStore())
+    monkeypatch.setattr("mcpserver.admin._loxone_client", ConcurrentClient)
+    monkeypatch.setattr(
+        "mcpserver.admin._config_store",
+        lambda: type(
+            "ConfigStore",
+            (),
+            {
+                "load": lambda self: PluginConfig.from_document(
+                    {
+                        "schema_version": 1,
+                        "loxone": {"endpoint": "http://192.168.10.20"},
+                    }
+                )
+            },
+        )(),
+    )
+
+    assert _revoke(None) == 2
+    assert maximum_active == 2
+    assert sorted(deleted) == ["family-0", "family-1"]

--- a/tests/test_admin_ui.py
+++ b/tests/test_admin_ui.py
@@ -27,6 +27,19 @@ def test_common_actions_update_the_page_without_a_reload() -> None:
     assert "window.setTimeout(() => { element.hidden = true; }, 4000)" in template
     assert "window.clearTimeout(hideStatusTimers.get(status))" in template
     assert "url.searchParams.delete('notice')" in template
+    assert "postAjax(body, actionTimeout(form.dataset.ajax))" in template
+    assert "save_config: 90000" in template
+    assert "revoke_all: 75000" in template
+    assert "postAjax(body, 5000)" in template
+    assert "if (result.data.certificate) updateCertificate" in template
+    assert 'id="session-table-template"' in template
+    assert "sessionList.replaceChildren(fragment)" in template
+
+
+def test_admin_cards_use_consistent_vertical_spacing() -> None:
+    template = (ROOT / "templates" / "index.html").read_text(encoding="utf-8")
+
+    assert ".mcp-page { display: grid; gap: 1rem;" in template
 
 
 def test_miniserver_access_mode_is_an_explicit_read_or_switch_selection() -> None:

--- a/tests/test_explorer_ui.py
+++ b/tests/test_explorer_ui.py
@@ -567,6 +567,36 @@ def test_explorer_generated_field_ids_are_unique_and_labelled() -> None:
     }
 
 
+def test_explorer_transcript_is_incremental_and_details_are_lazy() -> None:
+    source = SCRIPT.read_text(encoding="utf-8")
+
+    add_transcript = source[
+        source.index("function addTranscript") : source.index("function safeMcpResponse")
+    ]
+    transcript_entry = source[
+        source.index("function transcriptEntry") : source.index("function renderTranscript")
+    ]
+
+    assert "renderTranscript()" not in add_transcript
+    assert "elements.transcript.append(transcriptEntry(entry))" in add_transcript
+    assert "firstElementChild?.remove()" in add_transcript
+    assert "details.addEventListener('toggle'" in transcript_entry
+    assert "{once: true}" in transcript_entry
+
+
+def test_explorer_tabs_support_roving_focus_and_arrow_keys() -> None:
+    source = SCRIPT.read_text(encoding="utf-8")
+
+    assert "elements.formTab.tabIndex = jsonMode ? -1 : 0" in source
+    assert "elements.jsonTab.tabIndex = jsonMode ? 0 : -1" in source
+    assert "if (event.key === 'ArrowLeft')" in source
+    assert "if (event.key === 'ArrowRight')" in source
+    assert "if (event.key === 'Home')" in source
+    assert "if (event.key === 'End')" in source
+    assert "elements.formTab.addEventListener('keydown', handleTabKey)" in source
+    assert "elements.jsonTab.addEventListener('keydown', handleTabKey)" in source
+
+
 def test_explorer_control_option_requires_positive_discovery() -> None:
     expression = """(() => {
       const state={controlAvailable:false};
@@ -668,6 +698,15 @@ def test_explorer_ui_is_local_scoped_and_progressively_safe() -> None:
     assert "Cache_Control => 'no-store'" in callback
     assert "frame-ancestors 'none'" in callback
     assert "window.history.replaceState" in callback
+
+
+def test_explorer_uses_csp_compatible_panel_free_loxberry_header() -> None:
+    cgi = (ROOT / "webfrontend" / "htmlauth" / "explorer.cgi").read_text(encoding="utf-8")
+    template = (ROOT / "templates" / "explorer.html").read_text(encoding="utf-8")
+
+    assert "lbheader($L{'EXPLORER.TITLE'} . \" V$version\", 'nopanels'" in cgi
+    assert "'unsafe-eval'" not in cgi
+    assert '<a class="lb-button" href="index.cgi"><TMPL_VAR EXPLORER.BACK></a>' in template
 
 
 def test_explorer_transcript_never_records_authorization_headers() -> None:

--- a/webfrontend/htmlauth/explorer.cgi
+++ b/webfrontend/htmlauth/explorer.cgi
@@ -36,7 +36,7 @@ print "Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-in
 print "Referrer-Policy: no-referrer\n";
 print "X-Content-Type-Options: nosniff\n";
 print "X-Frame-Options: DENY\n";
-LoxBerry::Web::lbheader($L{'EXPLORER.TITLE'} . " V$version", '', '', 'nojqm');
+LoxBerry::Web::lbheader($L{'EXPLORER.TITLE'} . " V$version", 'nopanels', '', 'nojqm');
 print $template->output();
 LoxBerry::Web::lbfooter();
 exit;

--- a/webfrontend/htmlauth/explorer.js
+++ b/webfrontend/htmlauth/explorer.js
@@ -944,9 +944,13 @@
   }
 
   function addTranscript(method, request, response, status, duration) {
-    state.transcript.push({method, request, response, status, duration, at: new Date().toISOString()});
-    if (state.transcript.length > core.MAX_TRANSCRIPT) state.transcript.splice(0, state.transcript.length - core.MAX_TRANSCRIPT);
-    renderTranscript();
+    const entry = {method, request, response, status, duration, at: new Date().toISOString()};
+    state.transcript.push(entry);
+    if (state.transcript.length > core.MAX_TRANSCRIPT) {
+      state.transcript.splice(0, state.transcript.length - core.MAX_TRANSCRIPT);
+      elements.transcript.firstElementChild?.remove();
+    }
+    elements.transcript.append(transcriptEntry(entry));
   }
 
   function safeMcpResponse(response, tool) {
@@ -1268,18 +1272,24 @@
     elements.copy.disabled = false;
   }
 
-  function renderTranscript() {
-    elements.transcript.replaceChildren();
-    state.transcript.forEach((entry) => {
-      const details = element('details');
-      details.append(element('summary', {text: `${entry.method} — ${entry.status} — ${entry.duration} ms`}));
+  function transcriptEntry(entry) {
+    const details = element('details');
+    details.append(element('summary', {text: `${entry.method} — ${entry.status} — ${entry.duration} ms`}));
+    details.addEventListener('toggle', () => {
+      if (!details.open) return;
       details.append(element('p', {text: `${label('status')}: ${entry.status}; ${label('duration')}: ${entry.duration} ms`}));
       details.append(element('strong', {text: label('request')}));
       details.append(element('pre', {className: 'mcp-explorer-pre', text: JSON.stringify(entry.request, null, 2)}));
       details.append(element('strong', {text: label('response')}));
       details.append(element('pre', {className: 'mcp-explorer-pre', text: JSON.stringify(entry.response, null, 2)}));
-      elements.transcript.append(details);
-    });
+    }, {once: true});
+    return details;
+  }
+
+  function renderTranscript() {
+    const fragment = document.createDocumentFragment();
+    state.transcript.forEach((entry) => fragment.append(transcriptEntry(entry)));
+    elements.transcript.replaceChildren(fragment);
   }
 
   function renderHistory() {
@@ -1398,12 +1408,28 @@
     }
   }
 
-  function selectTab(jsonMode) {
+  function selectTab(jsonMode, focusPanel = true) {
     elements.formTab.setAttribute('aria-selected', String(!jsonMode));
     elements.jsonTab.setAttribute('aria-selected', String(jsonMode));
+    elements.formTab.tabIndex = jsonMode ? -1 : 0;
+    elements.jsonTab.tabIndex = jsonMode ? 0 : -1;
     elements.formPanel.hidden = jsonMode;
     elements.jsonPanel.hidden = !jsonMode;
-    (jsonMode ? elements.json : elements.form.querySelector('input,select,textarea'))?.focus();
+    if (focusPanel) (jsonMode ? elements.json : elements.form.querySelector('input,select,textarea'))?.focus();
+  }
+
+  function handleTabKey(event) {
+    const tabs = [elements.formTab, elements.jsonTab];
+    const current = tabs.indexOf(event.currentTarget);
+    let target = null;
+    if (event.key === 'ArrowLeft') target = tabs[(current - 1 + tabs.length) % tabs.length];
+    if (event.key === 'ArrowRight') target = tabs[(current + 1) % tabs.length];
+    if (event.key === 'Home') target = tabs[0];
+    if (event.key === 'End') target = tabs[tabs.length - 1];
+    if (!target) return;
+    event.preventDefault();
+    selectTab(target === elements.jsonTab, false);
+    target.focus();
   }
 
   elements.connect.addEventListener('click', async () => {
@@ -1436,6 +1462,8 @@
   elements.run.addEventListener('click', runSelectedTool);
   elements.formTab.addEventListener('click', () => selectTab(false));
   elements.jsonTab.addEventListener('click', () => selectTab(true));
+  elements.formTab.addEventListener('keydown', handleTabKey);
+  elements.jsonTab.addEventListener('keydown', handleTabKey);
   elements.json.addEventListener('change', () => { if (validateDraft(true)) renderSelectedTool(); });
   elements.copy.addEventListener('click', async () => {
     try { await navigator.clipboard.writeText(JSON.stringify(state.lastResult, null, 2)); setStatus(label('copied'), 'success'); }
@@ -1449,6 +1477,7 @@
   });
   elements.transfer.addEventListener('close', () => { if (elements.transfer.returnValue === 'apply') applyTransfer(); });
 
+  selectTab(false, false);
   renderAll();
   (async () => {
     let stored = null;


### PR DESCRIPTION
## Summary

- make admin status refresh update service, sessions, and certificate state without reloading the page
- align AJAX timeouts with bounded backend operations and make certificate polling fail safely
- render session changes completely, add consistent card spacing, and batch bounded remote token revocation
- make the Explorer transcript lazy and incremental, add complete keyboard tab behavior, and use a CSP-compatible panel-free LoxBerry header with an explicit back link

## Root cause

The admin page used one generic 15-second timeout even when server work could take longer, refreshed only part of the visible state, and removed session rows without being able to add or update them. The Explorer rebuilt the full retained transcript after every request, lacked the ARIA tab keyboard pattern, and its CSP conflicted with the Vue-based LoxBerry panels.

## Validation

- `python tools/test.py --profile changed`: 99 passed; Ruff and mypy clean
- focused file deployment to Loxberry-Test: backup, hashes, atomic replacement, service, and health checks passed
- browser acceptance at desktop and mobile sizes: no overflow or clipping, consistent 16 px card gaps, AJAX status refresh without navigation, Explorer keyboard tabs, and a clean console
- local Full profile is incomplete because Python 3.13 is unavailable; PR CI is required
- no Loxone control, configuration save, session revocation, or certificate renewal was performed

The focused deployment is hot-swap validation only; it is not Plugin Manager install or upgrade evidence.
