### PR TITLE
Fix LoxBerry home path resolution

### DIFF
--- a/bin/renew-web-certificate
+++ b/bin/renew-web-certificate
@@ -3,17 +3,19 @@
 
 use strict;
 use warnings;
+our $loxberry_home;
 BEGIN {
-    $ENV{LBHOMEDIR} = '/opt/loxberry';
-    $ENV{PERL5LIB} = '/opt/loxberry/libs/perllib';
+    $loxberry_home = '@LBHOMEDIR@';
+    $ENV{LBHOMEDIR} = $loxberry_home;
+    $ENV{PERL5LIB} = "$loxberry_home/libs/perllib";
+    unshift @INC, "$loxberry_home/libs/perllib";
 }
-use lib '/opt/loxberry/libs/perllib';
 use Fcntl qw(:DEFAULT :flock O_NOFOLLOW);
 use JSON::PP qw(encode_json);
 use Sys::Hostname qw(hostname);
 use LoxBerry::System;
 
-my $home = '/opt/loxberry';
+my $home = $loxberry_home;
 my $plugin = 'mcpserver';
 my $status_file = "$home/data/plugins/$plugin/certificate-renewal.json";
 my $lock_file = "/run/lock/loxberry-$plugin-certificate-renewal.lock";

--- a/postroot.sh
+++ b/postroot.sh
@@ -8,8 +8,23 @@ sudoers=/etc/sudoers.d/loxberry-mcpserver
 certificate_helper=/usr/local/sbin/loxberry-mcpserver-renew-web-certificate
 
 actual_folder=$3
-if [ -z "$actual_folder" ] || [ -z "${LBPBIN:-}" ] || [ -z "${LBPCONFIG:-}" ] || [ -z "${LBPDATA:-}" ] || [ -z "${LBPLOG:-}" ]; then
+if [ -z "$actual_folder" ] || [ -z "${LBHOMEDIR:-}" ] || [ -z "${LBPBIN:-}" ] || [ -z "${LBPCONFIG:-}" ] || [ -z "${LBPDATA:-}" ] || [ -z "${LBPLOG:-}" ]; then
     echo "<ERROR> LoxBerry plugin paths are unavailable."
+    exit 2
+fi
+case "$LBHOMEDIR" in
+    /*) ;;
+    *) echo "<ERROR> Invalid LoxBerry home directory."; exit 2 ;;
+esac
+case "$LBHOMEDIR" in
+    *[!A-Za-z0-9_./-]*) echo "<ERROR> Invalid LoxBerry home directory."; exit 2 ;;
+esac
+loxberry_home=$(realpath -e -- "$LBHOMEDIR") || { echo "<ERROR> Invalid LoxBerry home directory."; exit 2; }
+case "$loxberry_home" in
+    /|*[!A-Za-z0-9_./-]*) echo "<ERROR> Invalid LoxBerry home directory."; exit 2 ;;
+esac
+if [ ! -d "$loxberry_home/libs/perllib" ]; then
+    echo "<ERROR> LoxBerry Perl libraries are unavailable."
     exit 2
 fi
 plugin_config="$LBPCONFIG/$actual_folder"
@@ -49,7 +64,7 @@ host=$(hostname -f 2>/dev/null || hostname)
 case "$host" in
     *[!A-Za-z0-9.-]*|'') echo "<ERROR> Invalid local hostname."; exit 2 ;;
 esac
-local_ip=$(perl -I"${LBHOMEDIR:-/opt/loxberry}/libs/perllib" -MLoxBerry::System -e \
+local_ip=$(perl -I"$loxberry_home/libs/perllib" -MLoxBerry::System -e \
     'print LoxBerry::System::get_localip()' 2>/dev/null)
 case "$local_ip" in
     *[!0-9A-Fa-f:.]*|'') echo "<ERROR> Invalid local IP address."; exit 2 ;;
@@ -76,8 +91,15 @@ sed \
 cp "$plugin_config/apache/mcpserver.conf" "$apache" || exit 2
 chown root:root "$unit" "$apache"
 chmod 644 "$unit" "$apache"
-install -o root -g root -m 755 \
-    "$LBPBIN/$actual_folder/renew-web-certificate" "$certificate_helper" || exit 2
+certificate_helper_tmp=$(mktemp "${certificate_helper}.tmp.XXXXXX") || exit 2
+if ! sed "s|@LBHOMEDIR@|$loxberry_home|g" \
+    "$LBPBIN/$actual_folder/renew-web-certificate" > "$certificate_helper_tmp" \
+    || ! chown root:root "$certificate_helper_tmp" \
+    || ! chmod 755 "$certificate_helper_tmp" \
+    || ! mv -f "$certificate_helper_tmp" "$certificate_helper"; then
+    rm -f "$certificate_helper_tmp"
+    exit 2
+fi
 {
     echo "$marker"
     echo 'loxberry ALL=(root) NOPASSWD: /bin/systemctl start loxberry-mcpserver.service'

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -205,7 +205,10 @@ def test_postroot_keeps_installer_alive_during_apache_activation() -> None:
     assert 'if [ "$service_ready" -ne 1 ]' in hook
     assert '(umask 0137 && openssl rand 32 > "$key")' in hook
     assert 'chmod 644 "$unit" "$apache"' in hook
-    assert "install -o root -g root -m 755" in hook
+    assert 'loxberry_home=$(realpath -e -- "$LBHOMEDIR")' in hook
+    assert 'sed "s|@LBHOMEDIR@|$loxberry_home|g"' in hook
+    assert 'chmod 755 "$certificate_helper_tmp"' in hook
+    assert 'mv -f "$certificate_helper_tmp" "$certificate_helper"' in hook
     assert "/usr/local/sbin/loxberry-mcpserver-renew-web-certificate" in hook
     assert 'NOPASSWD: /usr/local/sbin/loxberry-mcpserver-renew-web-certificate ""' in hook
     assert "renew-web-certificate *" not in hook
@@ -306,7 +309,9 @@ def test_certificate_helper_keeps_pin_off_argv_and_uses_fixed_core_actions() -> 
     assert "check_securepin($securepin)" in helper
     assert "revokewwwcert.sh" in helper
     assert "makewwwcert.sh" in helper
-    assert "$ENV{PERL5LIB} = '/opt/loxberry/libs/perllib';" in helper
+    assert "@LBHOMEDIR@" in helper
+    assert '$ENV{PERL5LIB} = "$loxberry_home/libs/perllib";' in helper
+    assert "/opt/loxberry" not in helper
     assert "systemd-run" in helper
     assert "--unit=$unit" in helper
     assert "@ARGV == 1 && $ARGV[0] eq '--worker'" in helper


### PR DESCRIPTION
## Summary

- replace the packaged `/opt/loxberry` literals in the certificate renewal helper with an installation-time placeholder
- resolve and validate LoxBerry's `LBHOMEDIR` in `postroot.sh`
- render and atomically install the root-owned certificate helper
- add regression coverage for the portable path bootstrap

## Root cause

`bin/renew-web-certificate` hardcoded `/opt/loxberry` so it could load `LoxBerry::System` before the normal Perl path variables were available. LoxBerry's installer therefore reported a hardcoded-path warning while scanning the uploaded plugin.

## Impact

The packaged plugin no longer contains a hardcoded LoxBerry home path in executable runtime files. Installations use the path supplied by LoxBerry through `LBHOMEDIR`, while the privileged helper remains independent of caller-controlled runtime environment variables.

## Validation

- `python tools/test.py --profile changed`: passed (55 tests)
- `bash -n postroot.sh`: passed
- `perl -Itests/perl_stubs -c bin/renew-web-certificate`: passed
- `git diff --check`: passed

A native Plugin Manager installation or upgrade on `Loxberry-Test` has not been performed for this draft.