### PR TITLE
Add live service controls and collapsible admin sections

### DIFF
--- a/config/systemd/loxberry-mcpserver.service.in
+++ b/config/systemd/loxberry-mcpserver.service.in
@@ -16,11 +16,12 @@ Environment=MCPSERVER_CONFIG=@CONFIG@
 Environment=MCPSERVER_AUTH_STORE=@SESSIONS@
 Environment=MCPSERVER_LOXONE_TOKEN_STORE=@TOKENS@
 Environment=MCPSERVER_INSTALL_KEY=@KEY@
+Environment=MCPSERVER_LOG_FILE=@LOG_DIR@/service.log
 Environment=MCPSERVER_ALLOWED_HOSTS=127.0.0.1:8765,localhost:8765,@HOST@,@HOST@:*,@LOCAL_IP_HOST@,@LOCAL_IP_HOST@:*
 Environment=MCPSERVER_ALLOWED_ORIGINS=https://@HOST@,https://@LOCAL_IP_HOST@
 ExecStart=@VENV@/bin/mcpserver
-StandardOutput=append:@LOG_DIR@/service.log
-StandardError=append:@LOG_DIR@/service.log
+StandardOutput=journal
+StandardError=journal
 Restart=on-failure
 RestartSec=5s
 TimeoutStartSec=30s

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -212,13 +212,27 @@ Dienststatus, Transportart und maskierte Zähler. Sitzungen können einzeln oder
 gemeinsam widerrufen werden; ein erreichbarer Miniserver erhält zusätzlich
 best effort `killtoken`.
 
+Die Statuskarte der Adminseite aktualisiert Zustand und PID automatisch. Bei
+inaktivem Dienst steht **Starten** bereit; bei aktivem Dienst stehen **Stoppen**
+und **Neu starten** bereit. Stoppen und Neustarten müssen bestätigt werden und
+unterbrechen aktive MCP-Verbindungen. Diese Aktionen ändern weder die gespeicherte
+Plugin-Konfiguration noch den systemd-Autostart. Sie steuern ausschließlich die
+feste Unit `loxberry-mcpserver.service`.
+
+Die Dienststeuerung ist eine administrative LoxBerry-Funktion und verleiht weder
+Loxone- noch MCP-Berechtigungen. Die sudoers-Datei erlaubt dem Benutzer
+`loxberry` ausschließlich die vollständigen `systemctl start`, `systemctl stop`
+und `systemctl restart`-Befehle für diese feste Unit; freie Unterbefehle,
+Argumente oder andere Units sind nicht erlaubt. Aktion und Ergebnis werden ohne
+rohe `systemctl`-Ausgabe im Adminlog protokolliert.
+
 Jeder Schreibversuch erzeugt einen kompakten maskierten Eintrag im bestehenden
 Service-Log. Wiederholte identische Ablehnungen werden gedrosselt; eine separate
 Auditdatei wird nicht angelegt.
 
 ## Rücksetzen
 
-Deaktiviere zuerst den Dienst in der UI. Bei einer fehlerhaften Vorabversion
+Stoppe zuerst den Dienst in der UI. Bei einer fehlerhaften Vorabversion
 kann das vorherige Plugin-ZIP über den Plugin Manager erneut installiert
 werden. Konfiguration, Sitzungen, verschlüsselte Loxone-Tokens und der lokale
 Installationsschlüssel bleiben beim Upgrade gemeinsam erhalten, sodass eine

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -198,13 +198,27 @@ version, service state, transport kind and masked counts. Sessions can be
 revoked individually or together; an available Miniserver also receives a
 best-effort `killtoken`.
 
+The admin status card refreshes the service state and PID automatically. An
+inactive service offers **Start**; an active service offers **Stop** and
+**Restart**. Stop and restart require confirmation and interrupt active MCP
+connections. These actions change neither the stored plugin configuration nor
+systemd auto-start. They control only the fixed
+`loxberry-mcpserver.service` unit.
+
+Service control is an administrative LoxBerry function and grants no Loxone or
+MCP permissions. The sudoers file permits the `loxberry` user only the complete
+`systemctl start`, `systemctl stop`, and `systemctl restart` commands for that
+fixed unit; arbitrary subcommands, arguments, and other units are not allowed.
+The action and result are recorded in the admin log without raw `systemctl`
+output.
+
 Every control attempt creates one compact masked record in the existing service
 log. Repeated identical rejections are limited; no separate audit file is
 created.
 
 ## Rollback
 
-Disable the service in the UI first. If a prerelease is faulty, reinstall the
+Stop the service in the UI first. If a prerelease is faulty, reinstall the
 previous plugin ZIP through Plugin Manager. Configuration and sessions survive
 upgrades together with encrypted Loxone tokens and the local installation key,
 so a still-valid session can continue without another login. Uninstall removes

--- a/postroot.sh
+++ b/postroot.sh
@@ -45,17 +45,6 @@ fi
 chown root:loxberry "$key"
 chmod 640 "$key"
 
-if [ -L "$service_log" ] || { [ -e "$service_log" ] && [ ! -f "$service_log" ]; }; then
-    echo "<ERROR> Refusing unsafe service log path."
-    exit 2
-fi
-if [ ! -e "$service_log" ]; then
-    install -o loxberry -g loxberry -m 640 /dev/null "$service_log" || exit 2
-else
-    chown loxberry:loxberry "$service_log"
-    chmod 640 "$service_log"
-fi
-
 host=$(hostname -f 2>/dev/null || hostname)
 case "$host" in
     *[!A-Za-z0-9.-]*|'') echo "<ERROR> Invalid local hostname."; exit 2 ;;
@@ -103,6 +92,33 @@ visudo -cf "$sudoers" >/dev/null || { rm -f "$sudoers"; exit 2; }
 a2enmod proxy proxy_http >/dev/null || exit 2
 a2enconf loxberry-mcpserver >/dev/null || exit 2
 apache2ctl configtest >/dev/null || { a2disconf loxberry-mcpserver >/dev/null; exit 2; }
+
+if systemctl is-active --quiet loxberry-mcpserver.service; then
+    systemctl stop loxberry-mcpserver.service || exit 2
+fi
+python3 - "$service_log" <<'PY' || exit 2
+import grp
+import os
+import pwd
+import stat
+import sys
+
+path = sys.argv[1]
+flags = os.O_WRONLY | os.O_APPEND | os.O_CREAT | os.O_CLOEXEC | os.O_NOFOLLOW
+fd = os.open(path, flags, 0o640)
+try:
+    opened = os.fstat(fd)
+    if not stat.S_ISREG(opened.st_mode):
+        raise RuntimeError("service log is not a regular file")
+    os.fchown(fd, pwd.getpwnam("loxberry").pw_uid, grp.getgrnam("loxberry").gr_gid)
+    os.fchmod(fd, 0o640)
+    current = os.lstat(path)
+    if not stat.S_ISREG(current.st_mode) or (current.st_dev, current.st_ino) != (opened.st_dev, opened.st_ino):
+        raise RuntimeError("service log path changed during preparation")
+finally:
+    os.close(fd)
+PY
+
 systemctl daemon-reload
 systemctl enable loxberry-mcpserver.service >/dev/null
 systemctl restart loxberry-mcpserver.service || exit 2

--- a/postroot.sh
+++ b/postroot.sh
@@ -15,6 +15,7 @@ fi
 plugin_config="$LBPCONFIG/$actual_folder"
 plugin_data="$LBPDATA/$actual_folder"
 plugin_log="$LBPLOG/$actual_folder"
+service_log="$plugin_log/service.log"
 
 for target in "$unit" "$apache" "$sudoers" "$certificate_helper"; do
     if [ -e "$target" ] && ! grep -Fqx "$marker" "$target"; then
@@ -43,6 +44,17 @@ if [ ! -f "$key" ]; then
 fi
 chown root:loxberry "$key"
 chmod 640 "$key"
+
+if [ -L "$service_log" ] || { [ -e "$service_log" ] && [ ! -f "$service_log" ]; }; then
+    echo "<ERROR> Refusing unsafe service log path."
+    exit 2
+fi
+if [ ! -e "$service_log" ]; then
+    install -o loxberry -g loxberry -m 640 /dev/null "$service_log" || exit 2
+else
+    chown loxberry:loxberry "$service_log"
+    chmod 640 "$service_log"
+fi
 
 host=$(hostname -f 2>/dev/null || hostname)
 case "$host" in
@@ -79,6 +91,8 @@ install -o root -g root -m 755 \
     "$LBPBIN/$actual_folder/renew-web-certificate" "$certificate_helper" || exit 2
 {
     echo "$marker"
+    echo 'loxberry ALL=(root) NOPASSWD: /bin/systemctl start loxberry-mcpserver.service'
+    echo 'loxberry ALL=(root) NOPASSWD: /bin/systemctl stop loxberry-mcpserver.service'
     echo 'loxberry ALL=(root) NOPASSWD: /bin/systemctl restart loxberry-mcpserver.service'
     echo 'loxberry ALL=(root) NOPASSWD: /bin/systemctl is-active --quiet loxberry-mcpserver.service'
     echo 'loxberry ALL=(root) NOPASSWD: /usr/local/sbin/loxberry-mcpserver-renew-web-certificate ""'
@@ -91,7 +105,19 @@ a2enconf loxberry-mcpserver >/dev/null || exit 2
 apache2ctl configtest >/dev/null || { a2disconf loxberry-mcpserver >/dev/null; exit 2; }
 systemctl daemon-reload
 systemctl enable loxberry-mcpserver.service >/dev/null
-systemctl restart loxberry-mcpserver.service
+systemctl restart loxberry-mcpserver.service || exit 2
+service_ready=0
+for _ in {1..30}; do
+    if curl --fail --silent --max-time 2 http://127.0.0.1:8765/healthz >/dev/null; then
+        service_ready=1
+        break
+    fi
+    sleep 1
+done
+if [ "$service_ready" -ne 1 ]; then
+    echo "<ERROR> Service did not become healthy after installation."
+    exit 2
+fi
 systemctl reload apache2
 echo "<OK> Service and Apache proxy installed."
 exit 0

--- a/src/mcpserver/admin.py
+++ b/src/mcpserver/admin.py
@@ -135,7 +135,7 @@ def _run_service_command(command: str) -> None:
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
-            timeout=25,
+            timeout=65,
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
         raise AdminError("the service action failed", code="service_action_failed") from exc

--- a/src/mcpserver/admin.py
+++ b/src/mcpserver/admin.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 
 _MAX_REQUEST_BYTES: Final = 32 * 1024
 _SERVICE: Final = "loxberry-mcpserver.service"
+_SERVICE_ACTIONS: Final = frozenset({"start", "stop", "restart"})
 _CLIENT_UUID: Final = UUID("3f52f6fe-3af0-4d30-a8bb-f429b9da4465")
 
 
@@ -72,32 +73,94 @@ def _loxone_client(
     return LoxoneClient(endpoint, client_uuid=client_uuid, timeout_seconds=timeout_seconds)
 
 
-def _service_active() -> bool:
-    result = subprocess.run(
-        ["sudo", "-n", "/bin/systemctl", "is-active", "--quiet", _SERVICE],
-        check=False,
-        stdin=subprocess.DEVNULL,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        timeout=5,
-    )
-    return result.returncode == 0
-
-
-def _restart_service() -> None:
+def _service_status() -> dict[str, Any]:
+    status: dict[str, Any] = {
+        "name": _SERVICE,
+        "installed": False,
+        "active_state": "unknown",
+        "sub_state": "unknown",
+        "pid": None,
+        "active": False,
+    }
     try:
         result = subprocess.run(
-            ["sudo", "-n", "/bin/systemctl", "restart", _SERVICE],
+            [
+                "/bin/systemctl",
+                "show",
+                "--property=LoadState",
+                "--property=ActiveState",
+                "--property=SubState",
+                "--property=MainPID",
+                "--no-pager",
+                _SERVICE,
+            ],
+            check=False,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return status
+    if result.returncode != 0:
+        return status
+    properties = dict(line.split("=", 1) for line in result.stdout.splitlines() if "=" in line)
+    load_state = properties.get("LoadState", "unknown")
+    active_state = properties.get("ActiveState", "unknown")
+    sub_state = properties.get("SubState", "unknown")
+    raw_pid = properties.get("MainPID", "")
+    pid = int(raw_pid) if raw_pid.isdecimal() and int(raw_pid) > 0 else None
+    status.update(
+        installed=load_state not in {"not-found", "unknown", ""},
+        active_state=active_state or "unknown",
+        sub_state=sub_state or "unknown",
+        pid=pid,
+        active=active_state == "active",
+    )
+    return status
+
+
+def _service_active() -> bool:
+    return bool(_service_status()["active"])
+
+
+def _run_service_command(command: str) -> None:
+    if command not in _SERVICE_ACTIONS:
+        raise AdminError("service action is invalid")
+    try:
+        result = subprocess.run(
+            ["sudo", "-n", "/bin/systemctl", command, _SERVICE],
             check=False,
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
-            timeout=15,
+            timeout=25,
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
-        raise AdminError("the service could not be restarted") from exc
+        raise AdminError("the service action failed", code="service_action_failed") from exc
     if result.returncode != 0:
-        raise AdminError("the service could not be restarted")
+        raise AdminError("the service action failed", code="service_action_failed")
+
+
+def _service_response() -> dict[str, Any]:
+    service = _service_status()
+    return {"service_active": service["active"], "service": service}
+
+
+def _service_action(payload: object) -> dict[str, Any]:
+    command = payload.get("command") if isinstance(payload, dict) else None
+    if not isinstance(command, str) or command not in _SERVICE_ACTIONS:
+        raise AdminError("service action is invalid")
+    _run_service_command(command)
+    return _service_response()
+
+
+def _restart_service() -> None:
+    try:
+        _run_service_command("restart")
+    except AdminError as exc:
+        raise AdminError("the service could not be restarted") from exc
 
 
 def _optional_path(name: str) -> Path | None:
@@ -216,9 +279,8 @@ def _save(payload: object) -> dict[str, Any]:
     return {
         "configuration": config.to_document(),
         "applied": True,
-        "service_active": _service_active(),
         "sessions": _sessions(),
-    }
+    } | _service_response()
 
 
 async def _test_connection(payload: object) -> dict[str, Any]:
@@ -389,10 +451,9 @@ def dispatch(request: object) -> dict[str, Any]:
         return {
             "configuration": _config_store().load().to_document(),
             "version": __version__,
-            "service_active": _service_active(),
             "sessions": _sessions(),
             "certificate": _certificate_status(),
-        }
+        } | _service_response()
     if action == "get_config":
         return {"configuration": _config_store().load().to_document()}
     if action == "save_config":
@@ -400,10 +461,13 @@ def dispatch(request: object) -> dict[str, Any]:
     if action == "status":
         return {
             "version": __version__,
-            "service_active": _service_active(),
             "sessions": _sessions(),
             "certificate": _certificate_status(),
-        }
+        } | _service_response()
+    if action == "service_status":
+        return _service_response()
+    if action == "service_action":
+        return _service_action(payload)
     if action == "test_connection":
         return asyncio.run(_test_connection(payload))
     if action == "list_sessions":

--- a/src/mcpserver/server.py
+++ b/src/mcpserver/server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from typing import Final
 
 from mcp.server.auth.provider import AccessToken, TokenVerifier
@@ -273,10 +274,17 @@ def create_server(settings: ServerSettings) -> FastMCP:
 
 def main() -> None:
     """Run Streamable HTTP on the configured loopback port."""
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s component=%(name)s severity=%(levelname)s %(message)s",
-    )
+    log_file = os.environ.get("MCPSERVER_LOG_FILE")
+    log_format = "%(asctime)s component=%(name)s severity=%(levelname)s %(message)s"
+    if log_file:
+        logging.basicConfig(
+            level=logging.INFO,
+            format=log_format,
+            filename=log_file,
+            encoding="utf-8",
+        )
+    else:
+        logging.basicConfig(level=logging.INFO, format=log_format)
     settings = ServerSettings.from_environment()
     create_server(settings).run(transport="streamable-http")
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -611,7 +611,7 @@
     revoke_session: 75000,
     revoke_all: 75000,
     renew_certificate: 30000,
-    service_action: 35000,
+    service_action: 75000,
     service_status: 7000,
   })[action] || 15000;
   document.addEventListener('submit', async (event) => {

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,8 +2,20 @@
   .mcp-page { display: grid; gap: 1rem; max-width: 76rem; margin: 0 auto; padding: .5rem; overflow-wrap: anywhere; }
   .mcp-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 20rem), 1fr)); gap: 1rem; }
   .mcp-card { min-width: 0; padding: 1rem; border: 1px solid #c9cdd2; border-radius: .4rem; background: #fff; }
+  details.mcp-card { padding: 0; }
+  details.mcp-card > summary { padding: 1rem; cursor: pointer; font-size: 1.25rem; font-weight: 600; }
+  details.mcp-card[open] > summary { border-bottom: 1px solid #d7dadd; }
+  .mcp-collapsible-content { min-width: 0; padding: 1rem; }
+  .mcp-service-summary { display: inline-flex; flex-wrap: wrap; gap: .75rem; align-items: center; }
+  .mcp-service-badge { display: inline-block; padding: .2rem .55rem; border-radius: 999px; background: #6b7280; color: #fff; font-size: .9rem; }
+  .mcp-service-badge[data-kind="success"] { background: #198754; }
+  .mcp-service-badge[data-kind="error"] { background: #b91c1c; }
+  .mcp-service-badge[data-kind="inactive"] { background: #6b7280; }
+  .mcp-service-details { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 12rem), 1fr)); gap: .5rem 1rem; }
+  .mcp-service-details p { margin: 0; }
   .mcp-form { display: grid; gap: .85rem; }
   .mcp-field { display: grid; gap: .3rem; min-width: 0; }
+  .mcp-field-stack { display: grid; gap: .85rem; }
   .mcp-field input,
   .mcp-field select { box-sizing: border-box; width: 100%; max-width: 100%; min-height: 2.75rem; }
   .mcp-manual-endpoint[hidden] { display: none; }
@@ -21,8 +33,11 @@
   .mcp-table { width: 100%; border-collapse: collapse; }
   .mcp-table th, .mcp-table td { padding: .5rem; text-align: left; border-bottom: 1px solid #ddd; }
   .mcp-page :focus-visible { outline: 3px solid #1261a0; outline-offset: 2px; }
+  .mcp-dialog { width: min(32rem, calc(100% - 2rem)); border: 0; border-radius: .5rem; padding: 1rem; }
+  .mcp-dialog::backdrop { background: rgb(0 0 0 / 55%); }
   @media (max-width: 30rem) {
-    .mcp-card { padding: .75rem; }
+    .mcp-card:not(details) { padding: .75rem; }
+    details.mcp-card > summary, .mcp-collapsible-content { padding: .75rem; }
     .mcp-actions > * { width: 100%; }
     .mcp-copy-row { grid-template-columns: minmax(0, 1fr); }
     .mcp-copy-row button { width: 100%; }
@@ -42,8 +57,41 @@
   <TMPL_IF NOTICE><div id="page-notice" class="mcp-status" role="status" data-kind="<TMPL_VAR NOTICE_KIND ESCAPE=HTML>"><TMPL_VAR NOTICE ESCAPE=HTML></div></TMPL_IF>
   <div id="ajax-status" class="mcp-status" role="status" aria-live="polite" hidden></div>
 
-  <section id="setup" class="mcp-card" aria-labelledby="setup-title">
-    <h2 id="setup-title"><TMPL_VAR SETUP.TITLE></h2>
+  <details id="status" class="mcp-card" data-persist-collapse open
+    data-state-active="<TMPL_VAR STATUS.ACTIVE ESCAPE=HTML>"
+    data-state-inactive="<TMPL_VAR STATUS.INACTIVE ESCAPE=HTML>"
+    data-state-failed="<TMPL_VAR STATUS.FAILED ESCAPE=HTML>"
+    data-state-unknown="<TMPL_VAR STATUS.UNKNOWN ESCAPE=HTML>"
+    data-yes="<TMPL_VAR STATUS.YES ESCAPE=HTML>"
+    data-no="<TMPL_VAR STATUS.NO ESCAPE=HTML>"
+    data-service-installed="<TMPL_IF SERVICE_INSTALLED>1<TMPL_ELSE>0</TMPL_IF>"
+    data-service-active="<TMPL_IF SERVICE_ACTIVE>1<TMPL_ELSE>0</TMPL_IF>"
+    data-service-active-state="<TMPL_VAR SERVICE_ACTIVE_STATE ESCAPE=HTML>"
+    data-service-sub-state="<TMPL_VAR SERVICE_SUB_STATE ESCAPE=HTML>"
+    data-service-pid="<TMPL_VAR SERVICE_PID ESCAPE=HTML>"
+    data-service-name="<TMPL_VAR SERVICE_NAME ESCAPE=HTML>">
+    <summary><span class="mcp-service-summary"><span><TMPL_VAR STATUS.TITLE></span><span id="service-state" class="mcp-service-badge" data-kind="<TMPL_IF SERVICE_ACTIVE>success<TMPL_ELSE><TMPL_IF SERVICE_FAILED>error<TMPL_ELSE>inactive</TMPL_IF></TMPL_IF>"><TMPL_IF SERVICE_ACTIVE><TMPL_VAR STATUS.ACTIVE><TMPL_ELSE><TMPL_IF SERVICE_FAILED><TMPL_VAR STATUS.FAILED><TMPL_ELSE><TMPL_IF SERVICE_KNOWN><TMPL_VAR STATUS.INACTIVE><TMPL_ELSE><TMPL_VAR STATUS.UNKNOWN></TMPL_IF></TMPL_IF></TMPL_IF></span></span></summary>
+    <div class="mcp-collapsible-content mcp-form">
+      <div class="mcp-service-details">
+        <p><TMPL_VAR STATUS.VERSION>: <code><TMPL_VAR VERSION ESCAPE=HTML></code></p>
+        <p><TMPL_VAR STATUS.SYSTEMD_STATE>: <strong id="service-active-state"><TMPL_VAR SERVICE_ACTIVE_STATE ESCAPE=HTML></strong></p>
+        <p><TMPL_VAR STATUS.SUB_STATE>: <strong id="service-sub-state"><TMPL_VAR SERVICE_SUB_STATE ESCAPE=HTML></strong></p>
+        <p><TMPL_VAR STATUS.PID>: <code id="service-pid"><TMPL_VAR SERVICE_PID ESCAPE=HTML></code></p>
+        <p><TMPL_VAR STATUS.UNIT>: <code id="service-name"><TMPL_VAR SERVICE_NAME ESCAPE=HTML></code></p>
+        <p><TMPL_VAR STATUS.INSTALLED>: <strong id="service-installed"><TMPL_IF SERVICE_INSTALLED><TMPL_VAR STATUS.YES><TMPL_ELSE><TMPL_VAR STATUS.NO></TMPL_IF></strong></p>
+      </div>
+      <div class="mcp-actions" id="service-actions">
+        <form method="post" action="index.cgi" data-ajax="service_action" data-service-command="start" <TMPL_IF SERVICE_ACTIVE>hidden</TMPL_IF>><input type="hidden" name="action" value="service_action"><input type="hidden" name="command" value="start"><button class="lb-button" type="submit"><TMPL_VAR ACTION.START></button></form>
+        <form method="post" action="index.cgi" data-ajax="service_action" data-service-command="stop" <TMPL_UNLESS SERVICE_ACTIVE>hidden</TMPL_UNLESS>><input type="hidden" name="action" value="service_action"><input type="hidden" name="command" value="stop"><button class="lb-button" type="submit"><TMPL_VAR ACTION.STOP></button></form>
+        <form method="post" action="index.cgi" data-ajax="service_action" data-service-command="restart" <TMPL_UNLESS SERVICE_ACTIVE>hidden</TMPL_UNLESS>><input type="hidden" name="action" value="service_action"><input type="hidden" name="command" value="restart"><button class="lb-button" type="submit"><TMPL_VAR ACTION.RESTART></button></form>
+        <a class="lb-button" href="<TMPL_VAR SERVICE_LOG_URL ESCAPE=HTML>" target="_blank" rel="noopener"><TMPL_VAR STATUS.SHOW_LOG></a>
+      </div>
+    </div>
+  </details>
+
+  <details id="setup" class="mcp-card" data-persist-collapse open>
+    <summary><TMPL_VAR SETUP.TITLE></summary>
+    <div class="mcp-collapsible-content">
     <form class="mcp-form" method="post" action="index.cgi" data-ajax="save_config">
       <input type="hidden" name="action" value="save_config">
       <label class="mcp-field"><span><TMPL_VAR SETUP.PUBLIC_ORIGIN></span><input name="public_origin" type="url" value="<TMPL_VAR PUBLIC_ORIGIN ESCAPE=HTML>" placeholder="https://loxberry.local" required></label>
@@ -76,28 +124,24 @@
       <input type="hidden" name="endpoint" value="<TMPL_VAR ENDPOINT ESCAPE=HTML>">
       <button class="lb-button" type="submit"><TMPL_VAR ACTION.TEST></button>
     </form>
-  </section>
+    </div>
+  </details>
 
-  <div class="mcp-grid">
-    <section id="status" class="mcp-card" aria-labelledby="status-title">
-      <h2 id="status-title"><TMPL_VAR STATUS.TITLE></h2>
-      <p><TMPL_VAR STATUS.VERSION>: <code><TMPL_VAR VERSION ESCAPE=HTML></code></p>
-      <p><TMPL_VAR STATUS.SERVICE>: <strong id="service-state"><TMPL_IF SERVICE_ACTIVE><TMPL_VAR STATUS.RUNNING><TMPL_ELSE><TMPL_VAR STATUS.STOPPED></TMPL_IF></strong></p>
-      <form method="post" action="index.cgi" data-ajax="status"><input type="hidden" name="action" value="status"><button class="lb-button" type="submit"><TMPL_VAR ACTION.REFRESH></button></form>
-    </section>
-
-    <section id="help" class="mcp-card" aria-labelledby="help-title">
-      <h2 id="help-title"><TMPL_VAR HELP.TITLE></h2>
+  <details id="help" class="mcp-card" data-persist-collapse>
+    <summary><TMPL_VAR HELP.TITLE></summary>
+    <div class="mcp-collapsible-content">
       <p><TMPL_VAR HELP.TOOL_ACCESS></p>
-      <label class="mcp-field"><span><TMPL_VAR HELP.MCP_HOSTNAME></span><span class="mcp-copy-row"><input id="mcp-url-hostname" type="text" readonly value="<TMPL_VAR HOSTNAME_MCP_URL ESCAPE=HTML>"><button class="lb-button" type="button" data-copy-target="mcp-url-hostname"><TMPL_VAR ACTION.COPY></button></span></label>
-      <label class="mcp-field"><span><TMPL_VAR HELP.MCP_IP></span><span class="mcp-copy-row"><input id="mcp-url-ip" type="text" readonly value="<TMPL_VAR IP_MCP_URL ESCAPE=HTML>"><button class="lb-button" type="button" data-copy-target="mcp-url-ip"><TMPL_VAR ACTION.COPY></button></span></label>
+      <div class="mcp-field-stack">
+        <label class="mcp-field"><span><TMPL_VAR HELP.MCP_HOSTNAME></span><span class="mcp-copy-row"><input id="mcp-url-hostname" type="text" readonly value="<TMPL_VAR HOSTNAME_MCP_URL ESCAPE=HTML>"><button class="lb-button" type="button" data-copy-target="mcp-url-hostname"><TMPL_VAR ACTION.COPY></button></span></label>
+        <label class="mcp-field"><span><TMPL_VAR HELP.MCP_IP></span><span class="mcp-copy-row"><input id="mcp-url-ip" type="text" readonly value="<TMPL_VAR IP_MCP_URL ESCAPE=HTML>"><button class="lb-button" type="button" data-copy-target="mcp-url-ip"><TMPL_VAR ACTION.COPY></button></span></label>
+      </div>
       <p class="mcp-help"><TMPL_VAR HELP.MCP_CERTIFICATE_HINT></p>
       <p><a id="explorer-link" class="lb-button" href="<TMPL_VAR EXPLORER_URL ESCAPE=HTML>" target="_blank" rel="noopener"><TMPL_VAR ACTION.EXPLORER></a></p>
       <p><a href="https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server" target="_blank" rel="noopener"><TMPL_VAR HELP.PROJECT></a></p>
-    </section>
-  </div>
+    </div>
+  </details>
 
-  <section id="certificate" class="mcp-card" aria-labelledby="certificate-title"
+  <details id="certificate" class="mcp-card" data-persist-collapse
     data-state-scheduled="<TMPL_VAR CERTIFICATE.STATE_SCHEDULED ESCAPE=HTML>"
     data-state-running="<TMPL_VAR CERTIFICATE.STATE_RUNNING ESCAPE=HTML>"
     data-state-success="<TMPL_VAR CERTIFICATE.STATE_SUCCESS ESCAPE=HTML>"
@@ -105,7 +149,8 @@
     data-yes="<TMPL_VAR CERTIFICATE.YES ESCAPE=HTML>"
     data-no="<TMPL_VAR CERTIFICATE.NO ESCAPE=HTML>"
     data-not-configured="<TMPL_VAR CERTIFICATE.NOT_CONFIGURED ESCAPE=HTML>">
-    <h2 id="certificate-title"><TMPL_VAR CERTIFICATE.TITLE></h2>
+    <summary><TMPL_VAR CERTIFICATE.TITLE></summary>
+    <div class="mcp-collapsible-content">
     <p><TMPL_VAR CERTIFICATE.TEXT></p>
     <TMPL_IF CERTIFICATE_AVAILABLE>
       <div class="mcp-grid">
@@ -128,12 +173,14 @@
         </form>
       <TMPL_ELSE><p class="mcp-help"><TMPL_VAR CERTIFICATE.UNSUPPORTED></p></TMPL_IF>
     <TMPL_ELSE><p class="mcp-status" data-kind="error"><TMPL_VAR CERTIFICATE.UNAVAILABLE></p></TMPL_IF>
-  </section>
+    </div>
+  </details>
 
-  <section id="sessions" class="mcp-card" aria-labelledby="sessions-title"
+  <details id="sessions" class="mcp-card" data-persist-collapse
     data-empty-label="<TMPL_VAR SESSIONS.EMPTY ESCAPE=HTML>"
     data-unnamed-label="<TMPL_VAR SESSIONS.UNNAMED ESCAPE=HTML>">
-    <h2 id="sessions-title"><TMPL_VAR SESSIONS.TITLE></h2>
+    <summary><TMPL_VAR SESSIONS.TITLE></summary>
+    <div class="mcp-collapsible-content">
     <div id="session-list">
     <TMPL_IF HAS_SESSIONS>
       <div class="mcp-table-wrap"><table class="mcp-table"><thead><tr><th><TMPL_VAR SESSIONS.CLIENT></th><th><TMPL_VAR SESSIONS.INSTANCE></th><th><TMPL_VAR SESSIONS.IDENTITY></th><th><TMPL_VAR SESSIONS.SCOPES></th><th><TMPL_VAR SESSIONS.EXPIRES></th><th><TMPL_VAR SESSIONS.ACTION></th></tr></thead><tbody>
@@ -146,19 +193,58 @@
       <div class="mcp-table-wrap"><table class="mcp-table"><thead><tr><th><TMPL_VAR SESSIONS.CLIENT></th><th><TMPL_VAR SESSIONS.INSTANCE></th><th><TMPL_VAR SESSIONS.IDENTITY></th><th><TMPL_VAR SESSIONS.SCOPES></th><th><TMPL_VAR SESSIONS.EXPIRES></th><th><TMPL_VAR SESSIONS.ACTION></th></tr></thead><tbody></tbody></table></div>
       <form method="post" action="index.cgi" data-ajax="revoke_all"><input type="hidden" name="action" value="revoke_all"><button class="lb-button" type="submit"><TMPL_VAR ACTION.REVOKE_ALL></button></form>
     </template>
-  </section>
+    </div>
+  </details>
 
-  <section id="diagnostics" class="mcp-card" aria-labelledby="diagnostics-title">
-    <h2 id="diagnostics-title"><TMPL_VAR DIAGNOSTICS.TITLE></h2>
+  <details id="diagnostics" class="mcp-card" data-persist-collapse>
+    <summary><TMPL_VAR DIAGNOSTICS.TITLE></summary>
+    <div class="mcp-collapsible-content">
     <p><TMPL_VAR DIAGNOSTICS.TEXT></p>
     <form method="post" action="index.cgi"><input type="hidden" name="action" value="diagnostic"><button class="lb-button" type="submit"><TMPL_VAR ACTION.DIAGNOSTIC></button></form>
     <TMPL_VAR LOGLIST>
-  </section>
+    </div>
+  </details>
 </main>
+
+<dialog id="service-confirm" class="mcp-dialog" aria-labelledby="service-confirm-title">
+  <form method="dialog" class="mcp-form">
+    <h2 id="service-confirm-title"><TMPL_VAR STATUS.CONFIRM_TITLE></h2>
+    <p id="service-confirm-message"></p>
+    <div class="mcp-actions">
+      <button class="lb-button" type="submit" value="cancel"><TMPL_VAR STATUS.CANCEL></button>
+      <button id="service-confirm-submit" class="lb-button" type="submit" value="confirm"><TMPL_VAR STATUS.CONFIRM_ACTION></button>
+    </div>
+  </form>
+</dialog>
 
 <script>
 (() => {
   const status = document.getElementById('ajax-status');
+  const collapseStorageKey = 'mcpserver.admin.sections.v1';
+  const collapsibles = [...document.querySelectorAll('details[data-persist-collapse]')];
+  let storedCollapseState = {};
+  try {
+    storedCollapseState = JSON.parse(window.localStorage.getItem(collapseStorageKey) || '{}');
+  } catch {
+    storedCollapseState = {};
+  }
+  const persistCollapsibles = () => {
+    const state = Object.fromEntries(collapsibles.map((element) => [element.id, element.open]));
+    try { window.localStorage.setItem(collapseStorageKey, JSON.stringify(state)); } catch { /* Defaults remain usable. */ }
+  };
+  for (const element of collapsibles) {
+    if (typeof storedCollapseState[element.id] === 'boolean') element.open = storedCollapseState[element.id];
+    element.addEventListener('toggle', persistCollapsibles);
+  }
+  const openHashSection = () => {
+    const target = document.getElementById(window.location.hash.slice(1));
+    if (target instanceof HTMLDetailsElement && !target.open) {
+      target.open = true;
+      persistCollapsibles();
+    }
+  };
+  window.addEventListener('hashchange', openHashSection);
+  openHashSection();
   const miniserverSelect = document.getElementById('miniserver-select');
   const manualEndpointFields = document.getElementById('manual-endpoint-fields');
   const miniserverEndpoint = document.getElementById('miniserver-endpoint');
@@ -177,6 +263,23 @@
   const sessionsSection = document.getElementById('sessions');
   const sessionList = document.getElementById('session-list');
   const sessionTableTemplate = document.getElementById('session-table-template');
+  const serviceSection = document.getElementById('status');
+  const serviceState = document.getElementById('service-state');
+  const serviceActiveState = document.getElementById('service-active-state');
+  const serviceSubState = document.getElementById('service-sub-state');
+  const servicePid = document.getElementById('service-pid');
+  const serviceName = document.getElementById('service-name');
+  const serviceInstalled = document.getElementById('service-installed');
+  const serviceConfirm = document.getElementById('service-confirm');
+  const serviceConfirmMessage = document.getElementById('service-confirm-message');
+  let pendingServiceForm = null;
+  let serviceActionRunning = false;
+  let servicePollInFlight = false;
+  let servicePollTimer = null;
+  let sessionActionRunning = false;
+  let sessionPollInFlight = false;
+  let sessionPollTimer = null;
+  let lastService = null;
   const syncTestEndpoint = () => { testEndpoint.value = miniserverEndpoint.value; };
   const syncMiniserverSelection = () => {
     const selectedEndpoint = miniserverSelect.value;
@@ -283,6 +386,102 @@
       window.clearTimeout(timeout);
     }
   };
+  const renderService = (service) => {
+    if (!service || typeof service !== 'object') return;
+    lastService = service;
+    const installed = Boolean(service.installed);
+    const active = Boolean(service.active);
+    const activeState = String(service.active_state || 'unknown');
+    const subState = String(service.sub_state || 'unknown');
+    const pid = Number.isInteger(service.pid) && service.pid > 0 ? String(service.pid) : '-';
+    let label = serviceSection.dataset.stateUnknown;
+    let kind = '';
+    if (installed && active) {
+      label = serviceSection.dataset.stateActive;
+      kind = 'success';
+    } else if (installed && activeState === 'failed') {
+      label = serviceSection.dataset.stateFailed;
+      kind = 'error';
+    } else if (installed && ['inactive', 'activating', 'deactivating'].includes(activeState)) {
+      label = serviceSection.dataset.stateInactive;
+      kind = 'inactive';
+    }
+    serviceState.textContent = label;
+    serviceState.dataset.kind = kind;
+    serviceActiveState.textContent = activeState;
+    serviceSubState.textContent = subState;
+    servicePid.textContent = pid;
+    serviceName.textContent = String(service.name || 'loxberry-mcpserver.service');
+    serviceInstalled.textContent = installed ? serviceSection.dataset.yes : serviceSection.dataset.no;
+    for (const form of document.querySelectorAll('form[data-service-command]')) {
+      const command = form.dataset.serviceCommand;
+      const available = command === 'start'
+        ? installed && !active && ['inactive', 'failed'].includes(activeState)
+        : installed && active;
+      form.hidden = !available;
+      const button = form.querySelector('button[type="submit"]');
+      button.disabled = serviceActionRunning || !available;
+      if (serviceActionRunning) button.setAttribute('aria-busy', 'true');
+      else button.removeAttribute('aria-busy');
+    }
+  };
+  renderService({
+    installed: serviceSection.dataset.serviceInstalled === '1',
+    active: serviceSection.dataset.serviceActive === '1',
+    active_state: serviceSection.dataset.serviceActiveState,
+    sub_state: serviceSection.dataset.serviceSubState,
+    pid: Number(serviceSection.dataset.servicePid),
+    name: serviceSection.dataset.serviceName,
+  });
+  const serviceConfirmMessages = {
+    stop: '<TMPL_VAR STATUS.CONFIRM_STOP ESCAPE=JS>',
+    restart: '<TMPL_VAR STATUS.CONFIRM_RESTART ESCAPE=JS>',
+  };
+  serviceConfirm.addEventListener('close', () => {
+    const form = pendingServiceForm;
+    pendingServiceForm = null;
+    if (serviceConfirm.returnValue !== 'confirm' || !form) return;
+    form.dataset.confirmed = 'true';
+    form.requestSubmit();
+  });
+  const scheduleServicePoll = (delay = 10000) => {
+    window.clearTimeout(servicePollTimer);
+    servicePollTimer = null;
+    if (!document.hidden && !serviceActionRunning) {
+      servicePollTimer = window.setTimeout(pollServiceStatus, delay);
+    }
+  };
+  const pollServiceStatus = async () => {
+    if (document.hidden || serviceActionRunning || servicePollInFlight) {
+      scheduleServicePoll();
+      return;
+    }
+    servicePollInFlight = true;
+    try {
+      const body = new FormData();
+      body.set('action', 'service_status');
+      body.set('ajax', '1');
+      const result = await postAjax(body, 7000);
+      renderService(result.data.service);
+    } catch {
+      // Keep the last known state; the next visible-page poll retries.
+    } finally {
+      servicePollInFlight = false;
+      scheduleServicePoll();
+    }
+  };
+  document.addEventListener('visibilitychange', () => {
+    if (document.hidden) {
+      window.clearTimeout(servicePollTimer);
+      servicePollTimer = null;
+      window.clearTimeout(sessionPollTimer);
+      sessionPollTimer = null;
+    } else {
+      scheduleServicePoll(0);
+      scheduleSessionPoll(0);
+    }
+  });
+  scheduleServicePoll();
   const pollCertificateRenewal = async (button) => {
     const deadline = Date.now() + 75000;
     try {
@@ -307,6 +506,50 @@
       button.removeAttribute('aria-busy');
     }
   };
+  const sessionFingerprint = (session) => JSON.stringify([
+    session.client_name || '', session.client || '', session.identity || '',
+    session.scopes || '', String(session.expires_at ?? ''),
+  ]);
+  const createSessionRow = (session) => {
+    const row = document.createElement('tr');
+    row.dataset.sessionId = String(session.id);
+    row.dataset.fingerprint = sessionFingerprint(session);
+    const values = [session.client_name || sessionsSection.dataset.unnamedLabel, session.client, session.identity, session.scopes];
+    values.forEach((value, index) => {
+      const cell = document.createElement('td');
+      const content = index === 0 ? document.createTextNode(String(value ?? '')) : document.createElement('code');
+      if (index !== 0) content.textContent = String(value ?? '');
+      cell.append(content);
+      row.append(cell);
+    });
+    const expiryCell = document.createElement('td');
+    const expiry = document.createElement('time');
+    expiry.className = 'mcp-expiry';
+    updateExpiry(expiry, session.expires_at);
+    expiryCell.append(expiry);
+    row.append(expiryCell);
+    const actionCell = document.createElement('td');
+    const revokeForm = document.createElement('form');
+    revokeForm.method = 'post';
+    revokeForm.action = 'index.cgi';
+    revokeForm.dataset.ajax = 'revoke_session';
+    const action = document.createElement('input');
+    action.type = 'hidden';
+    action.name = 'action';
+    action.value = 'revoke_session';
+    const id = document.createElement('input');
+    id.type = 'hidden';
+    id.name = 'id';
+    id.value = String(session.id);
+    const button = document.createElement('button');
+    button.className = 'lb-button';
+    button.type = 'submit';
+    button.textContent = '<TMPL_VAR ACTION.REVOKE ESCAPE=JS>';
+    revokeForm.append(action, id, button);
+    actionCell.append(revokeForm);
+    row.append(actionCell);
+    return row;
+  };
   const updateSessions = (sessions) => {
     if (!sessions.length) {
       const empty = document.createElement('p');
@@ -314,67 +557,99 @@
       sessionList.replaceChildren(empty);
       return;
     }
-    const fragment = sessionTableTemplate.content.cloneNode(true);
-    const body = fragment.querySelector('tbody');
-    for (const session of sessions) {
-      const row = document.createElement('tr');
-      row.dataset.sessionId = String(session.id);
-      const values = [session.client_name || sessionsSection.dataset.unnamedLabel, session.client, session.identity, session.scopes];
-      values.forEach((value, index) => {
-        const cell = document.createElement('td');
-        const content = index === 0 ? document.createTextNode(String(value ?? '')) : document.createElement('code');
-        if (index !== 0) content.textContent = String(value ?? '');
-        cell.append(content);
-        row.append(cell);
-      });
-      const expiryCell = document.createElement('td');
-      const expiry = document.createElement('time');
-      expiry.className = 'mcp-expiry';
-      updateExpiry(expiry, session.expires_at);
-      expiryCell.append(expiry);
-      row.append(expiryCell);
-      const actionCell = document.createElement('td');
-      const revokeForm = document.createElement('form');
-      revokeForm.method = 'post';
-      revokeForm.action = 'index.cgi';
-      revokeForm.dataset.ajax = 'revoke_session';
-      const action = document.createElement('input');
-      action.type = 'hidden';
-      action.name = 'action';
-      action.value = 'revoke_session';
-      const id = document.createElement('input');
-      id.type = 'hidden';
-      id.name = 'id';
-      id.value = String(session.id);
-      const button = document.createElement('button');
-      button.className = 'lb-button';
-      button.type = 'submit';
-      button.textContent = '<TMPL_VAR ACTION.REVOKE ESCAPE=JS>';
-      revokeForm.append(action, id, button);
-      actionCell.append(revokeForm);
-      row.append(actionCell);
-      body.append(row);
+    let body = sessionList.querySelector('tbody');
+    if (!body) {
+      const fragment = sessionTableTemplate.content.cloneNode(true);
+      sessionList.replaceChildren(fragment);
+      body = sessionList.querySelector('tbody');
     }
-    sessionList.replaceChildren(fragment);
+    const existing = new Map([...body.querySelectorAll('tr[data-session-id]')]
+      .map((row) => [row.dataset.sessionId, row]));
+    for (const session of sessions) {
+      const key = String(session.id);
+      let row = existing.get(key);
+      if (!row || row.dataset.fingerprint !== sessionFingerprint(session)) {
+        const replacement = createSessionRow(session);
+        if (row) row.replaceWith(replacement);
+        row = replacement;
+      }
+      body.append(row);
+      existing.delete(key);
+    }
+    for (const row of existing.values()) row.remove();
   };
+  const scheduleSessionPoll = (delay = 10000) => {
+    window.clearTimeout(sessionPollTimer);
+    sessionPollTimer = null;
+    if (!document.hidden && sessionsSection.open && !sessionActionRunning) {
+      sessionPollTimer = window.setTimeout(pollSessions, delay);
+    }
+  };
+  const pollSessions = async () => {
+    if (document.hidden || !sessionsSection.open || sessionActionRunning || sessionPollInFlight) {
+      scheduleSessionPoll();
+      return;
+    }
+    sessionPollInFlight = true;
+    try {
+      const body = new FormData();
+      body.set('action', 'list_sessions');
+      body.set('ajax', '1');
+      const result = await postAjax(body, 7000);
+      if (Array.isArray(result.data.sessions)) updateSessions(result.data.sessions);
+    } catch {
+      // Keep the last known table; the next visible and open-section poll retries.
+    } finally {
+      sessionPollInFlight = false;
+      scheduleSessionPoll();
+    }
+  };
+  sessionsSection.addEventListener('toggle', () => scheduleSessionPoll(sessionsSection.open ? 0 : 10000));
+  scheduleSessionPoll();
   const actionTimeout = (action) => ({
     save_config: 90000,
     revoke_session: 75000,
     revoke_all: 75000,
     renew_certificate: 30000,
+    service_action: 35000,
+    service_status: 7000,
   })[action] || 15000;
   document.addEventListener('submit', async (event) => {
     const form = event.target.closest('form[data-ajax]');
     if (!form) return;
       event.preventDefault();
+      const serviceCommand = form.dataset.serviceCommand;
+      if (form.dataset.ajax === 'service_action'
+          && serviceConfirmMessages[serviceCommand]
+          && form.dataset.confirmed !== 'true') {
+        pendingServiceForm = form;
+        serviceConfirmMessage.textContent = serviceConfirmMessages[serviceCommand];
+        serviceConfirm.returnValue = '';
+        serviceConfirm.showModal();
+        return;
+      }
+      delete form.dataset.confirmed;
       const button = form.querySelector('button[type="submit"]');
       let keepButtonDisabled = false;
+      if (form.dataset.ajax === 'service_action') {
+        serviceActionRunning = true;
+        window.clearTimeout(servicePollTimer);
+        servicePollTimer = null;
+        renderService(lastService);
+      }
+      if (form.dataset.ajax === 'revoke_session' || form.dataset.ajax === 'revoke_all') {
+        sessionActionRunning = true;
+        window.clearTimeout(sessionPollTimer);
+        sessionPollTimer = null;
+      }
       button.disabled = true;
       button.setAttribute('aria-busy', 'true');
       window.clearTimeout(hideStatusTimers.get(status));
       status.hidden = false;
       status.dataset.kind = '';
-      status.textContent = '<TMPL_VAR AJAX.WORKING ESCAPE=JS>';
+      status.textContent = form.dataset.ajax === 'service_action'
+        ? '<TMPL_VAR STATUS.ACTION_RUNNING ESCAPE=JS>'
+        : '<TMPL_VAR AJAX.WORKING ESCAPE=JS>';
       const body = new FormData(form);
       body.set('ajax', '1');
       try {
@@ -382,7 +657,7 @@
         status.dataset.kind = 'success';
         status.textContent = '<TMPL_VAR AJAX.SUCCESS ESCAPE=JS>';
         hideSuccess(status);
-        if ('service_active' in result.data) document.getElementById('service-state').textContent = result.data.service_active ? '<TMPL_VAR STATUS.RUNNING ESCAPE=JS>' : '<TMPL_VAR STATUS.STOPPED ESCAPE=JS>';
+        if (result.data.service) renderService(result.data.service);
         if (Array.isArray(result.data.sessions)) updateSessions(result.data.sessions);
         if (result.data.certificate) updateCertificate(result.data.certificate);
         if (form.dataset.ajax === 'save_config') {
@@ -403,6 +678,15 @@
         else if (error instanceof TypeError) status.textContent = '<TMPL_VAR AJAX.NETWORK ESCAPE=JS>';
         else status.textContent = error instanceof Error ? error.message : '<TMPL_VAR AJAX.ERROR ESCAPE=JS>';
       } finally {
+        if (form.dataset.ajax === 'service_action') {
+          serviceActionRunning = false;
+          renderService(lastService);
+          scheduleServicePoll(0);
+        }
+        if (form.dataset.ajax === 'revoke_session' || form.dataset.ajax === 'revoke_all') {
+          sessionActionRunning = false;
+          scheduleSessionPoll();
+        }
         if (!keepButtonDisabled) {
           button.disabled = false;
           button.removeAttribute('aria-busy');

--- a/templates/lang/language_de.ini
+++ b/templates/lang/language_de.ini
@@ -32,6 +32,26 @@ VERSION=Version
 SERVICE=Dienst
 RUNNING=läuft
 STOPPED=gestoppt
+ACTIVE=Aktiv
+INACTIVE=Inaktiv
+FAILED=Fehlgeschlagen
+UNKNOWN=Unbekannt
+DETAILS=Dienstdetails
+SYSTEMD_STATE=systemd-Status
+SUB_STATE=Unterstatus
+PID=PID
+UNIT=Unit
+INSTALLED=Installiert
+YES=Ja
+NO=Nein
+SHOW_LOG=Log anzeigen
+CONFIRM_TITLE=Dienstaktion bestätigen
+CONFIRM_STOP=Der MCP-Dienst wird gestoppt. Aktive MCP-Verbindungen werden unterbrochen.
+CONFIRM_RESTART=Der MCP-Dienst wird neu gestartet. Aktive MCP-Verbindungen werden kurz unterbrochen.
+CONFIRM_ACTION=Aktion ausführen
+CANCEL=Abbrechen
+ACTION_RUNNING=Dienstaktion läuft …
+ERROR_ACTION=Die Dienstaktion konnte nicht ausgeführt werden.
 
 [SESSIONS]
 TITLE=Clients und Sitzungen
@@ -46,7 +66,7 @@ EMPTY=Keine Sitzungen vorhanden.
 
 [DIAGNOSTICS]
 TITLE=Diagnose und Logs
-TEXT=Logs werden maskiert über den integrierten LoxBerry-Logviewer angezeigt.
+TEXT=Das Dienstlog wird über den integrierten LoxBerry-Logviewer angezeigt. Der Diagnoseexport maskiert sensible Werte.
 
 [HELP]
 TITLE=Hilfe
@@ -95,6 +115,9 @@ ERROR_FAILED=Die Zertifikatsneuausstellung konnte nicht gestartet werden.
 SAVE=Speichern und anwenden
 TEST=Verbindung testen
 REFRESH=Status aktualisieren
+START=Starten
+STOP=Stoppen
+RESTART=Neu starten
 REVOKE=Widerrufen
 REVOKE_ALL=Alle widerrufen
 DIAGNOSTIC=Maskierte Diagnose exportieren

--- a/templates/lang/language_en.ini
+++ b/templates/lang/language_en.ini
@@ -32,6 +32,26 @@ VERSION=Version
 SERVICE=Service
 RUNNING=running
 STOPPED=stopped
+ACTIVE=Active
+INACTIVE=Inactive
+FAILED=Failed
+UNKNOWN=Unknown
+DETAILS=Service details
+SYSTEMD_STATE=systemd state
+SUB_STATE=Substate
+PID=PID
+UNIT=Unit
+INSTALLED=Installed
+YES=Yes
+NO=No
+SHOW_LOG=Show log
+CONFIRM_TITLE=Confirm service action
+CONFIRM_STOP=The MCP service will be stopped. Active MCP connections will be interrupted.
+CONFIRM_RESTART=The MCP service will be restarted. Active MCP connections will be interrupted briefly.
+CONFIRM_ACTION=Run action
+CANCEL=Cancel
+ACTION_RUNNING=Service action in progress …
+ERROR_ACTION=The service action could not be completed.
 
 [SESSIONS]
 TITLE=Clients and sessions
@@ -46,7 +66,7 @@ EMPTY=No sessions exist.
 
 [DIAGNOSTICS]
 TITLE=Diagnostics and logs
-TEXT=Masked logs are shown through the integrated LoxBerry log viewer.
+TEXT=The service log is shown through the integrated LoxBerry log viewer. The diagnostic export masks sensitive values.
 
 [HELP]
 TITLE=Help
@@ -95,6 +115,9 @@ ERROR_FAILED=The certificate reissue could not be started.
 SAVE=Save and apply
 TEST=Test connection
 REFRESH=Refresh status
+START=Start
+STOP=Stop
+RESTART=Restart
 REVOKE=Revoke
 REVOKE_ALL=Revoke all
 DIAGNOSTIC=Export masked diagnostics

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -195,7 +195,7 @@ def test_service_status_fails_closed_when_systemctl_times_out(
 def test_service_action_uses_only_the_fixed_unit(
     command: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    captured: list[list[str]] = []
+    captured: list[tuple[list[str], dict[str, object]]] = []
     service = {
         "name": "loxberry-mcpserver.service",
         "installed": True,
@@ -206,7 +206,7 @@ def test_service_action_uses_only_the_fixed_unit(
     }
 
     def run(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[bytes]:
-        captured.append(argv)
+        captured.append((argv, kwargs))
         return subprocess.CompletedProcess(argv, 0, b"", b"")
 
     monkeypatch.setattr("mcpserver.admin.subprocess.run", run)
@@ -214,7 +214,10 @@ def test_service_action_uses_only_the_fixed_unit(
 
     result = dispatch({"action": "service_action", "payload": {"command": command}})
 
-    assert captured == [["sudo", "-n", "/bin/systemctl", command, "loxberry-mcpserver.service"]]
+    assert len(captured) == 1
+    argv, kwargs = captured[0]
+    assert argv == ["sudo", "-n", "/bin/systemctl", command, "loxberry-mcpserver.service"]
+    assert kwargs["timeout"] == 65
     assert result == {"service_active": True, "service": service}
 
 
@@ -237,7 +240,7 @@ def test_service_action_maps_timeout_to_sanitized_error(
 ) -> None:
     monkeypatch.setattr(
         "mcpserver.admin.subprocess.run",
-        lambda *args, **kwargs: (_ for _ in ()).throw(subprocess.TimeoutExpired(args[0], 25)),
+        lambda *args, **kwargs: (_ for _ in ()).throw(subprocess.TimeoutExpired(args[0], 65)),
     )
 
     with pytest.raises(AdminError) as failure:

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -7,7 +7,14 @@ from pathlib import Path
 
 import pytest
 
-from mcpserver.admin import AdminError, _renew_certificate, _revoke, _save, dispatch
+from mcpserver.admin import (
+    AdminError,
+    _renew_certificate,
+    _revoke,
+    _save,
+    _service_status,
+    dispatch,
+)
 from mcpserver.auth.loxone_store import LoxoneTokenStoreError
 from mcpserver.auth.store import AtomicJsonAuthStore
 from mcpserver.config import AtomicConfigStore, PluginConfig
@@ -59,7 +66,15 @@ def test_page_state_aggregates_initial_admin_ui_data(monkeypatch: pytest.MonkeyP
             return config
 
     monkeypatch.setattr("mcpserver.admin._config_store", lambda: ConfigStore())
-    monkeypatch.setattr("mcpserver.admin._service_active", lambda: True)
+    service = {
+        "name": "loxberry-mcpserver.service",
+        "installed": True,
+        "active_state": "active",
+        "sub_state": "running",
+        "pid": 123,
+        "active": True,
+    }
+    monkeypatch.setattr("mcpserver.admin._service_status", lambda: service)
     monkeypatch.setattr("mcpserver.admin._sessions", lambda: [{"id": "family"}])
     monkeypatch.setattr(
         "mcpserver.admin._certificate_status",
@@ -72,6 +87,7 @@ def test_page_state_aggregates_initial_admin_ui_data(monkeypatch: pytest.MonkeyP
         "configuration": config.to_document(),
         "version": result["version"],
         "service_active": True,
+        "service": service,
         "sessions": [{"id": "family"}],
         "certificate": {"available": True, "renewal_supported": False},
     }
@@ -82,7 +98,15 @@ def test_status_refresh_returns_all_dynamic_admin_ui_data(
 ) -> None:
     sessions = [{"id": "family"}]
     certificate = {"available": True, "renewal": {"state": "idle"}}
-    monkeypatch.setattr("mcpserver.admin._service_active", lambda: True)
+    service = {
+        "name": "loxberry-mcpserver.service",
+        "installed": True,
+        "active_state": "active",
+        "sub_state": "running",
+        "pid": 456,
+        "active": True,
+    }
+    monkeypatch.setattr("mcpserver.admin._service_status", lambda: service)
     monkeypatch.setattr("mcpserver.admin._sessions", lambda: sessions)
     monkeypatch.setattr("mcpserver.admin._certificate_status", lambda: certificate)
 
@@ -91,9 +115,135 @@ def test_status_refresh_returns_all_dynamic_admin_ui_data(
     assert result == {
         "version": result["version"],
         "service_active": True,
+        "service": service,
         "sessions": sessions,
         "certificate": certificate,
     }
+
+
+@pytest.mark.parametrize(
+    ("active_state", "sub_state", "raw_pid", "expected_pid", "active"),
+    [
+        ("active", "running", "1234", 1234, True),
+        ("inactive", "dead", "0", None, False),
+        ("failed", "failed", "", None, False),
+    ],
+)
+def test_service_status_reads_bounded_systemd_properties(
+    active_state: str,
+    sub_state: str,
+    raw_pid: str,
+    expected_pid: int | None,
+    active: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[str] = []
+
+    def run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        captured.extend(command)
+        output = (
+            "LoadState=loaded\n"
+            f"ActiveState={active_state}\n"
+            f"SubState={sub_state}\n"
+            f"MainPID={raw_pid}\n"
+        )
+        return subprocess.CompletedProcess(command, 0, output, "")
+
+    monkeypatch.setattr("mcpserver.admin.subprocess.run", run)
+
+    result = _service_status()
+
+    assert captured == [
+        "/bin/systemctl",
+        "show",
+        "--property=LoadState",
+        "--property=ActiveState",
+        "--property=SubState",
+        "--property=MainPID",
+        "--no-pager",
+        "loxberry-mcpserver.service",
+    ]
+    assert result == {
+        "name": "loxberry-mcpserver.service",
+        "installed": True,
+        "active_state": active_state,
+        "sub_state": sub_state,
+        "pid": expected_pid,
+        "active": active,
+    }
+
+
+def test_service_status_fails_closed_when_systemctl_times_out(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "mcpserver.admin.subprocess.run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(subprocess.TimeoutExpired(args[0], 5)),
+    )
+
+    assert _service_status() == {
+        "name": "loxberry-mcpserver.service",
+        "installed": False,
+        "active_state": "unknown",
+        "sub_state": "unknown",
+        "pid": None,
+        "active": False,
+    }
+
+
+@pytest.mark.parametrize("command", ["start", "stop", "restart"])
+def test_service_action_uses_only_the_fixed_unit(
+    command: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: list[list[str]] = []
+    service = {
+        "name": "loxberry-mcpserver.service",
+        "installed": True,
+        "active_state": "active",
+        "sub_state": "running",
+        "pid": 987,
+        "active": True,
+    }
+
+    def run(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        captured.append(argv)
+        return subprocess.CompletedProcess(argv, 0, b"", b"")
+
+    monkeypatch.setattr("mcpserver.admin.subprocess.run", run)
+    monkeypatch.setattr("mcpserver.admin._service_status", lambda: service)
+
+    result = dispatch({"action": "service_action", "payload": {"command": command}})
+
+    assert captured == [["sudo", "-n", "/bin/systemctl", command, "loxberry-mcpserver.service"]]
+    assert result == {"service_active": True, "service": service}
+
+
+def test_service_action_rejects_arbitrary_commands(monkeypatch: pytest.MonkeyPatch) -> None:
+    called = False
+
+    def run(*args: object, **kwargs: object) -> None:
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr("mcpserver.admin.subprocess.run", run)
+
+    with pytest.raises(AdminError, match="invalid"):
+        dispatch({"action": "service_action", "payload": {"command": "disable"}})
+    assert called is False
+
+
+def test_service_action_maps_timeout_to_sanitized_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "mcpserver.admin.subprocess.run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(subprocess.TimeoutExpired(args[0], 25)),
+    )
+
+    with pytest.raises(AdminError) as failure:
+        dispatch({"action": "service_action", "payload": {"command": "start"}})
+    assert failure.value.code == "service_action_failed"
+    assert str(failure.value) == "the service action failed"
 
 
 def test_certificate_reissue_passes_securepin_only_over_stdin(

--- a/tests/test_admin_ui.py
+++ b/tests/test_admin_ui.py
@@ -103,7 +103,7 @@ def test_service_actions_use_an_accessible_confirmation_and_dynamic_controls() -
     assert "installed && active" in template
     assert "serviceState.dataset.kind = kind" in template
     assert "serviceActionRunning = true" in template
-    assert "service_action: 35000" in template
+    assert "service_action: 75000" in template
 
 
 def test_admin_sections_are_native_persistent_collapsibles() -> None:

--- a/tests/test_admin_ui.py
+++ b/tests/test_admin_ui.py
@@ -33,13 +33,92 @@ def test_common_actions_update_the_page_without_a_reload() -> None:
     assert "postAjax(body, 5000)" in template
     assert "if (result.data.certificate) updateCertificate" in template
     assert 'id="session-table-template"' in template
-    assert "sessionList.replaceChildren(fragment)" in template
+    assert "row.dataset.fingerprint !== sessionFingerprint(session)" in template
+    assert "for (const row of existing.values()) row.remove()" in template
 
 
 def test_admin_cards_use_consistent_vertical_spacing() -> None:
     template = (ROOT / "templates" / "index.html").read_text(encoding="utf-8")
 
     assert ".mcp-page { display: grid; gap: 1rem;" in template
+    assert ".mcp-field-stack { display: grid; gap: .85rem; }" in template
+    assert '<div class="mcp-field-stack">' in template
+
+
+def test_service_status_is_first_and_uses_a_lightweight_ajax_contract() -> None:
+    cgi = (ROOT / "webfrontend/htmlauth/index.cgi").read_text(encoding="utf-8")
+    template = (ROOT / "templates/index.html").read_text(encoding="utf-8")
+
+    assert template.index('id="status"') < template.index('id="setup"')
+    assert 'data-ajax="service_status"' not in template
+    assert 'data-service-command="start"' in template
+    assert 'data-service-command="stop"' in template
+    assert 'data-service-command="restart"' in template
+    assert "body.set('action', 'service_status')" in template
+    assert "window.setTimeout(pollServiceStatus, delay)" in template
+    assert "document.hidden || serviceActionRunning || servicePollInFlight" in template
+    assert "document.addEventListener('visibilitychange'" in template
+    assert "admin_call('service_status', {})" in cgi
+    assert "admin_call('service_action', {command => $command})" in cgi
+    assert "$command =~ /\\A(?:start|stop|restart)\\z/" in cgi
+    assert "service.log&header=html&format=template" in cgi
+
+
+def test_sessions_poll_only_while_visible_and_open_and_patch_changed_rows() -> None:
+    cgi = (ROOT / "webfrontend/htmlauth/index.cgi").read_text(encoding="utf-8")
+    template = (ROOT / "templates/index.html").read_text(encoding="utf-8")
+
+    assert "admin_call('list_sessions', {})" in cgi
+    assert "body.set('action', 'list_sessions')" in template
+    assert "window.setTimeout(pollSessions, delay)" in template
+    assert (
+        "document.hidden || !sessionsSection.open || sessionActionRunning || sessionPollInFlight"
+        in template
+    )
+    assert "sessionsSection.addEventListener('toggle'" in template
+    assert "row.dataset.fingerprint !== sessionFingerprint(session)" in template
+    assert "sessionList.replaceChildren(fragment)" in template
+
+
+def test_read_only_ajax_polling_does_not_create_admin_log_files() -> None:
+    cgi = (ROOT / "webfrontend/htmlauth/index.cgi").read_text(encoding="utf-8")
+
+    assert "sub admin_logger" in cgi
+    assert cgi.index("sub admin_logger") < cgi.index("LoxBerry::Log->new")
+    assert "LOGSTART('index.cgi called')" not in cgi
+    assert "loglevel => 7" in cgi
+    assert 'admin_logger()->INF("service-action=$command result=completed")' in cgi
+    assert 'admin_logger()->ERR("service-action=$command result=failed")' in cgi
+
+
+def test_service_actions_use_an_accessible_confirmation_and_dynamic_controls() -> None:
+    template = (ROOT / "templates/index.html").read_text(encoding="utf-8")
+
+    assert '<dialog id="service-confirm"' in template
+    assert 'aria-labelledby="service-confirm-title"' in template
+    assert "serviceConfirmMessages[serviceCommand]" in template
+    assert "form.dataset.confirmed = 'true'" in template
+    assert "form.requestSubmit()" in template
+    assert "command === 'start'" in template
+    assert "installed && active" in template
+    assert "serviceState.dataset.kind = kind" in template
+    assert "serviceActionRunning = true" in template
+    assert "service_action: 35000" in template
+
+
+def test_admin_sections_are_native_persistent_collapsibles() -> None:
+    template = (ROOT / "templates/index.html").read_text(encoding="utf-8")
+
+    for section in ("status", "setup", "help", "certificate", "sessions", "diagnostics"):
+        assert f'<details id="{section}" class="mcp-card" data-persist-collapse' in template
+    assert '<details id="status" class="mcp-card" data-persist-collapse open' in template
+    assert '<details id="setup" class="mcp-card" data-persist-collapse open' in template
+    assert "mcpserver.admin.sections.v1" in template
+    assert "window.localStorage.getItem(collapseStorageKey)" in template
+    assert "window.localStorage.setItem(collapseStorageKey" in template
+    assert "element.addEventListener('toggle', persistCollapsibles)" in template
+    assert "window.addEventListener('hashchange', openHashSection)" in template
+    assert "target instanceof HTMLDetailsElement" in template
 
 
 def test_miniserver_access_mode_is_an_explicit_read_or_switch_selection() -> None:

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -198,12 +198,27 @@ def test_postroot_keeps_installer_alive_during_apache_activation() -> None:
     assert hook.index("systemctl restart loxberry-mcpserver.service") < hook.index(
         "systemctl reload apache2"
     )
+    assert "systemctl restart loxberry-mcpserver.service || exit 2" in hook
+    assert "for _ in {1..30}" in hook
+    assert "curl --fail --silent --max-time 2 http://127.0.0.1:8765/healthz" in hook
+    assert 'if [ "$service_ready" -ne 1 ]' in hook
     assert '(umask 0137 && openssl rand 32 > "$key")' in hook
     assert 'chmod 644 "$unit" "$apache"' in hook
     assert "install -o root -g root -m 755" in hook
     assert "/usr/local/sbin/loxberry-mcpserver-renew-web-certificate" in hook
     assert 'NOPASSWD: /usr/local/sbin/loxberry-mcpserver-renew-web-certificate ""' in hook
     assert "renew-web-certificate *" not in hook
+    for action in ("start", "stop", "restart"):
+        assert f"NOPASSWD: /bin/systemctl {action} loxberry-mcpserver.service" in hook
+    assert "NOPASSWD: /bin/systemctl * loxberry-mcpserver.service" not in hook
+    assert "NOPASSWD: /bin/systemctl start *" not in hook
+    assert "NOPASSWD: /bin/systemctl stop *" not in hook
+    assert 'service_log="$plugin_log/service.log"' in hook
+    assert '[ -L "$service_log" ]' in hook
+    assert 'install -o loxberry -g loxberry -m 640 /dev/null "$service_log"' in hook
+    assert 'chown loxberry:loxberry "$service_log"' in hook
+    assert 'chmod 640 "$service_log"' in hook
+    assert 'install -m 640 "$service_log"' not in hook
     assert "LoxBerry::System::get_localip()" in hook
     unit = (ROOT / "config/systemd/loxberry-mcpserver.service.in").read_text(encoding="utf-8")
     assert "@LOCAL_IP_HOST@" in unit

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -214,15 +214,38 @@ def test_postroot_keeps_installer_alive_during_apache_activation() -> None:
     assert "NOPASSWD: /bin/systemctl start *" not in hook
     assert "NOPASSWD: /bin/systemctl stop *" not in hook
     assert 'service_log="$plugin_log/service.log"' in hook
-    assert '[ -L "$service_log" ]' in hook
-    assert 'install -o loxberry -g loxberry -m 640 /dev/null "$service_log"' in hook
-    assert 'chown loxberry:loxberry "$service_log"' in hook
-    assert 'chmod 640 "$service_log"' in hook
-    assert 'install -m 640 "$service_log"' not in hook
+    assert "systemctl stop loxberry-mcpserver.service || exit 2" in hook
+    assert hook.index("systemctl stop loxberry-mcpserver.service || exit 2") < hook.index(
+        'python3 - "$service_log"'
+    )
+    assert "os.O_NOFOLLOW" in hook
+    assert "os.fchown(fd" in hook
+    assert "os.fchmod(fd, 0o640)" in hook
+    assert "os.lstat(path)" in hook
+    assert 'chown loxberry:loxberry "$service_log"' not in hook
+    assert 'chmod 640 "$service_log"' not in hook
     assert "LoxBerry::System::get_localip()" in hook
     unit = (ROOT / "config/systemd/loxberry-mcpserver.service.in").read_text(encoding="utf-8")
     assert "@LOCAL_IP_HOST@" in unit
     assert "https://@LOCAL_IP_HOST@" in unit
+    assert "Environment=MCPSERVER_LOG_FILE=@LOG_DIR@/service.log" in unit
+    assert "StandardOutput=journal" in unit
+    assert "StandardError=journal" in unit
+    assert "StandardOutput=append:@LOG_DIR@/service.log" not in unit
+
+
+def test_user_guides_document_the_fixed_privileged_service_controls() -> None:
+    german = (ROOT / "docs/user-guide.de.md").read_text(encoding="utf-8")
+    english = (ROOT / "docs/user-guide.en.md").read_text(encoding="utf-8")
+
+    for guide in (german, english):
+        assert "loxberry-mcpserver.service" in guide
+        assert "systemctl start" in guide
+        assert "systemctl stop" in guide
+        assert "systemctl restart" in guide
+        assert "sudoers" in guide
+    assert "aktive MCP-Verbindungen" in " ".join(german.split())
+    assert "active MCP connections" in " ".join(english.split())
 
 
 def test_postinstall_rewrites_moved_venv_entrypoints() -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -9,7 +9,7 @@ from starlette.testclient import TestClient
 from mcpserver.auth.provider import CONTROL_SCOPE, READ_SCOPE
 from mcpserver.config import PluginConfig
 from mcpserver.loxone.client import MiniserverEndpoint
-from mcpserver.server import create_server
+from mcpserver.server import create_server, main
 from mcpserver.settings import Phase0AuthSettings, ServerSettings
 
 
@@ -20,6 +20,31 @@ def _settings() -> ServerSettings:
         allowed_hosts=("testserver",),
         allowed_origins=("https://client.example",),
     )
+
+
+def test_main_opens_the_configured_log_as_the_service_user(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    log_file = tmp_path / "service.log"
+    logging_options: dict[str, object] = {}
+    run_options: dict[str, object] = {}
+
+    class Server:
+        def run(self, **kwargs: object) -> None:
+            run_options.update(kwargs)
+
+    monkeypatch.setenv("MCPSERVER_LOG_FILE", str(log_file))
+    monkeypatch.setattr(
+        "mcpserver.server.logging.basicConfig", lambda **kwargs: logging_options.update(kwargs)
+    )
+    monkeypatch.setattr(ServerSettings, "from_environment", staticmethod(_settings))
+    monkeypatch.setattr("mcpserver.server.create_server", lambda settings: Server())
+
+    main()
+
+    assert logging_options["filename"] == str(log_file)
+    assert logging_options["encoding"] == "utf-8"
+    assert run_options == {"transport": "streamable-http"}
 
 
 def test_health_is_small_and_contains_no_configuration() -> None:

--- a/webfrontend/htmlauth/index.cgi
+++ b/webfrontend/htmlauth/index.cgi
@@ -23,8 +23,20 @@ if (($q->{lang} // '') =~ /\A(?:de|en)\z/) {
     $LoxBerry::Web::lang = $q->{lang};
 }
 my $version = LoxBerry::System::pluginversion();
-my $log = LoxBerry::Log->new(name => 'admin-ui', package => $lbpplugindir, addtime => 1);
-$log->LOGSTART('index.cgi called');
+my $admin_log;
+
+sub admin_logger {
+    return $admin_log if $admin_log;
+    $admin_log = LoxBerry::Log->new(
+        name => 'admin-ui', package => $lbpplugindir, addtime => 1, loglevel => 7,
+    );
+    $admin_log->LOGSTART('Administrative action');
+    return $admin_log;
+}
+
+END {
+    $admin_log->LOGEND('Administrative action finished') if $admin_log;
+}
 
 $ENV{LBPDATA} = $lbpdatadir;
 $ENV{MCPSERVER_CONFIG} = "$lbpconfigdir/mcpserver.json";
@@ -260,6 +272,7 @@ sub localize_admin_error {
         certificate_busy => $L{'CERTIFICATE.ERROR_BUSY'},
         certificate_unsupported => $L{'CERTIFICATE.ERROR_UNSUPPORTED'},
         certificate_failed => $L{'CERTIFICATE.ERROR_FAILED'},
+        service_action_failed => $L{'STATUS.ERROR_ACTION'},
     );
     my $code = $result->{error}{code} // '';
     $result->{error}{message} = $messages{$code} if exists $messages{$code};
@@ -302,10 +315,26 @@ if ($action ne '') {
         $result = admin_call('test_connection', {endpoint => requested_endpoint($q)});
     } elsif ($action eq 'revoke_session') {
         $result = admin_call('revoke_session', {id => ($q->{id} // '')});
+    } elsif ($action eq 'list_sessions') {
+        $result = admin_call('list_sessions', {});
     } elsif ($action eq 'revoke_all') {
         $result = admin_call('revoke_all', {});
     } elsif ($action eq 'status') {
         $result = admin_call('status', {});
+    } elsif ($action eq 'service_status') {
+        $result = admin_call('service_status', {});
+    } elsif ($action eq 'service_action') {
+        my $command = $q->{command} // '';
+        if ($command =~ /\A(?:start|stop|restart)\z/) {
+            $result = admin_call('service_action', {command => $command});
+            if ($result->{ok}) {
+                admin_logger()->INF("service-action=$command result=completed");
+            } else {
+                admin_logger()->ERR("service-action=$command result=failed");
+            }
+        } else {
+            $result = {ok => JSON::PP::false, error => {code => 'invalid_request', message => 'Unsupported service action'}};
+        }
     } elsif ($action eq 'diagnostic') {
         $result = admin_call('diagnostic', {});
     } elsif ($action eq 'certificate_status') {
@@ -316,7 +345,7 @@ if ($action ne '') {
             confirmation => ($q->{renew_confirmation} // ''),
         });
         $q->{securepin} = '';
-        LOGINF('Web certificate renewal scheduled') if $result->{ok};
+        admin_logger()->INF('certificate-renewal result=scheduled') if $result->{ok};
     } else {
         $result = {ok => JSON::PP::false, error => {code => 'invalid_request', message => 'Unsupported action'}};
     }
@@ -373,6 +402,8 @@ $display_endpoint = $selected_miniserver->{endpoint}
 my $public_origin = $config->{server}{public_origin} // '';
 my $certificate = ref($page_state->{certificate}) eq 'HASH'
     ? $page_state->{certificate} : {};
+my $service = ref($page_state->{service}) eq 'HASH'
+    ? $page_state->{service} : {};
 my $renewal = ref($certificate->{renewal}) eq 'HASH' ? $certificate->{renewal} : {};
 my $general_config = stored_general_config();
 my $sslport = ref($general_config->{Webserver}) eq 'HASH'
@@ -409,6 +440,14 @@ $template->param(
     CONTROL_REQUESTS_PER_MINUTE => $config->{limits}{control_requests_per_minute} // 10,
     MAX_PARALLEL_CALLS => $config->{limits}{max_parallel_calls} // 4,
     SERVICE_ACTIVE => $page_state->{service_active} ? 1 : 0,
+    SERVICE_INSTALLED => $service->{installed} ? 1 : 0,
+    SERVICE_FAILED => ($service->{active_state} // '') eq 'failed' ? 1 : 0,
+    SERVICE_KNOWN => ($service->{active_state} // 'unknown') ne 'unknown' ? 1 : 0,
+    SERVICE_ACTIVE_STATE => $service->{active_state} // 'unknown',
+    SERVICE_SUB_STATE => $service->{sub_state} // 'unknown',
+    SERVICE_PID => $service->{pid} // '-',
+    SERVICE_NAME => $service->{name} // 'loxberry-mcpserver.service',
+    SERVICE_LOG_URL => "/admin/system/tools/logfile.cgi?logfile=plugins/$lbpplugindir/service.log&header=html&format=template",
     CERTIFICATE_AVAILABLE => $certificate->{available} ? 1 : 0,
     CERTIFICATE_SOURCE_LOXBERRY => ($certificate->{source} // '') eq 'loxberry_ca' ? 1 : 0,
     CERTIFICATE_EXPIRES_AT => $certificate->{expires_at} // '',
@@ -431,10 +470,10 @@ $template->param(
 );
 
 our %navbar;
-$navbar{10}{Name} = $L{'NAV.SETUP'};
-$navbar{10}{URL} = '#setup';
-$navbar{20}{Name} = $L{'NAV.STATUS'};
-$navbar{20}{URL} = '#status';
+$navbar{10}{Name} = $L{'NAV.STATUS'};
+$navbar{10}{URL} = '#status';
+$navbar{20}{Name} = $L{'NAV.SETUP'};
+$navbar{20}{URL} = '#setup';
 $navbar{30}{Name} = $L{'NAV.SESSIONS'};
 $navbar{30}{URL} = '#sessions';
 $navbar{40}{Name} = $L{'NAV.DIAGNOSTICS'};


### PR DESCRIPTION
## Summary

- add a top service-status card with state, PID, fixed-unit start/stop/restart controls, confirmation dialog, and LoxBerry logviewer link
- poll service status in the background and refresh the sessions table only while its section is open and the page is visible
- make all main admin sections native persistent collapsibles and improve responsive spacing
- harden service actions, sudoers rules, service-log permissions, lazy audit logging, and post-install health readiness

## Review follow-up

- eliminate privileged service-log symlink following by stopping the unit, using an O_NOFOLLOW file descriptor for migration, and moving runtime file logging into the unprivileged service process
- raise the backend service-command timeout to 65 seconds and the AJAX timeout to 75 seconds
- document service controls, interruption behavior, authorization boundaries, and exact sudo permissions in synchronized German and English guides

## Why

The admin UI did not expose enough lifecycle information or controls, and its status/session data required manual interaction or full-page work. The existing systemd log was not readable through the LoxBerry logviewer because systemd initially created it as root with mode 0600. Polling also revealed that eager CGI logging would create one admin log file per read-only request.

## Validation

- Python 3.13 full gate: 329 passed; Ruff formatting/lint and mypy clean
- reproducible ARM64 release-candidate ZIP verified
- native Plugin Manager upgrade on Loxberry-Test: installer status 0 and health passed
- service log owner/mode verified as loxberry:loxberry 0640; it updates after restart while systemd stdout/stderr use the journal
- browser matrix: 1280x800, 900x768, 390x844, 360x800, 320x568; no page/control overflow or UI console errors
- German and English labels, hash navigation, persisted collapsibles, service/session polling, confirmation dialog, and logviewer validated
- stop/start/restart exercised through the browser; health failed while stopped and recovered after start/restart; original active state restored