### PR TITLE
Bound and configure service logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ extracted from the matching version heading.
 
 ## Unreleased
 
+- Bound the service log to three 512 KiB files, default operational logging to
+  warnings, and add temporary 15- or 60-minute debug logging in the admin UI.
+- Avoid routine admin-page and HTTP access-log writes while retaining masked,
+  unsuppressible audit records for control attempts.
 - Build official packages only through the owner-triggered GitHub workflow, with
   canonical ZIP and wheel output, locked runtime-wheel hashes, exact manifests,
   verified draft uploads, and separate read/write job permissions.

--- a/config/default-config.json
+++ b/config/default-config.json
@@ -8,6 +8,10 @@
     "connection_timeout": 10,
     "endpoint": ""
   },
+  "logging": {
+    "debug_until": 0,
+    "level": "warning"
+  },
   "schema_version": 1,
   "server": {
     "enabled": false,

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -207,7 +207,16 @@ Der englische Healthcheck führt keine Reparatur aus:
 LBPCONFIG=/actual/config/path LBPDATA=/actual/data/path /actual/bin/healthcheck
 ```
 
-Logs erscheinen im LoxBerry-Logviewer. Der Diagnoseexport enthält nur Version,
+Das Dienstlog kann direkt aus der Statuskarte im LoxBerry-Logviewer geöffnet
+werden. Es ist auf die aktive Datei und zwei Rotationen mit jeweils 512 KiB,
+also insgesamt ungefähr 1,5 MB, begrenzt. Unter **Diagnose und Logs** ist
+**Warnungen** voreingestellt; **Fehler** und **Informationen** sind dauerhaft
+wählbar. **Debug** kann für 15 oder 60 Minuten aktiviert werden und fällt danach
+ohne weiteren Neustart automatisch auf den gewählten Log-Level zurück. Normale
+HTTP-Zugriffe und erfolgreiche lesende MCP-Aufrufe werden außerhalb von Debug
+nicht einzeln protokolliert.
+
+Der Diagnoseexport enthält nur Version,
 Dienststatus, Transportart und maskierte Zähler. Sitzungen können einzeln oder
 gemeinsam widerrufen werden; ein erreichbarer Miniserver erhält zusätzlich
 best effort `killtoken`.

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -193,8 +193,15 @@ The English healthcheck never repairs the system:
 LBPCONFIG=/actual/config/path LBPDATA=/actual/data/path /actual/bin/healthcheck
 ```
 
-Logs appear in the LoxBerry log viewer. Diagnostic export contains only the
-version, service state, transport kind and masked counts. Sessions can be
+The service log can be opened directly from the status card in the LoxBerry log
+viewer. It is bounded to the active file and two 512 KiB rotations, approximately
+1.5 MB in total. Under **Diagnostics and logs**, **Warnings** is the default;
+**Errors** and **Information** can be selected persistently. **Debug** can be
+enabled for 15 or 60 minutes and automatically returns to the selected log level
+without another restart. Normal HTTP access and successful read-only MCP calls
+are not recorded individually outside debug.
+
+Diagnostic export contains only the version, service state, transport kind and masked counts. Sessions can be
 revoked individually or together; an available Miniserver also receives a
 best-effort `killtoken`.
 

--- a/src/mcpserver/admin.py
+++ b/src/mcpserver/admin.py
@@ -9,7 +9,9 @@ import re
 import socket
 import subprocess
 import sys
+import time
 from contextlib import suppress
+from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Final
 from uuid import UUID
@@ -26,6 +28,7 @@ _MAX_REQUEST_BYTES: Final = 32 * 1024
 _SERVICE: Final = "loxberry-mcpserver.service"
 _SERVICE_ACTIONS: Final = frozenset({"start", "stop", "restart"})
 _CLIENT_UUID: Final = UUID("3f52f6fe-3af0-4d30-a8bb-f429b9da4465")
+_DEBUG_DURATIONS: Final = {"debug_15": 15 * 60, "debug_60": 60 * 60}
 
 
 class AdminError(RuntimeError):
@@ -249,6 +252,12 @@ def _save(payload: object) -> dict[str, Any]:
     config = PluginConfig.from_document(payload)
     store = _config_store()
     previous = store.load()
+    if "logging" not in payload:
+        config = replace(
+            config,
+            log_level=previous.log_level,
+            debug_until=previous.debug_until,
+        )
     control_families: list[str] = []
     if previous.loxone_control_enabled and not config.loxone_control_enabled:
         document = _auth_store().snapshot()
@@ -280,6 +289,40 @@ def _save(payload: object) -> dict[str, Any]:
         "configuration": config.to_document(),
         "applied": True,
         "sessions": _sessions(),
+    } | _service_response()
+
+
+def _set_logging(payload: object) -> dict[str, Any]:
+    from mcpserver.config import ConfigError
+
+    if not isinstance(payload, dict) or not isinstance(payload.get("mode"), str):
+        raise AdminError("logging mode is invalid")
+    mode = payload["mode"]
+    store = _config_store()
+    previous = store.load()
+    if mode in {"error", "warning", "info"}:
+        updated = replace(previous, log_level=mode)
+    elif mode in _DEBUG_DURATIONS:
+        updated = replace(previous, debug_until=int(time.time()) + _DEBUG_DURATIONS[mode])
+    elif mode == "stop_debug":
+        updated = replace(previous, debug_until=0)
+    else:
+        raise AdminError("logging mode is invalid")
+    store.save(updated)
+    try:
+        _restart_service()
+    except AdminError as apply_error:
+        try:
+            store.save(previous)
+            _restart_service()
+        except (AdminError, ConfigError) as rollback_error:
+            raise AdminError("logging apply and rollback failed") from rollback_error
+        raise AdminError(
+            "logging was not applied; previous configuration restored"
+        ) from apply_error
+    return {
+        "configuration": updated.to_document(),
+        "applied": True,
     } | _service_response()
 
 
@@ -458,6 +501,8 @@ def dispatch(request: object) -> dict[str, Any]:
         return {"configuration": _config_store().load().to_document()}
     if action == "save_config":
         return _save(payload)
+    if action == "set_logging":
+        return _set_logging(payload)
     if action == "status":
         return {
             "version": __version__,

--- a/src/mcpserver/config.py
+++ b/src/mcpserver/config.py
@@ -22,6 +22,9 @@ DEFAULT_CONNECTION_TIMEOUT: Final = 10.0
 DEFAULT_REQUESTS_PER_MINUTE: Final = 60
 DEFAULT_MAX_PARALLEL_CALLS: Final = 4
 DEFAULT_CONTROL_REQUESTS_PER_MINUTE: Final = 10
+DEFAULT_LOG_LEVEL: Final = "warning"
+SUPPORTED_LOG_LEVELS: Final = frozenset({"error", "warning", "info"})
+MAX_DEBUG_UNTIL: Final = 4_102_444_799
 
 
 class ConfigError(ValueError):
@@ -55,6 +58,12 @@ def _integer(value: object, *, name: str, minimum: int, maximum: int) -> int:
     return value
 
 
+def _log_level(value: object) -> str:
+    if not isinstance(value, str) or value not in SUPPORTED_LOG_LEVELS:
+        raise ConfigError("logging.level is unsupported")
+    return value
+
+
 @dataclass(frozen=True, slots=True)
 class PluginConfig:
     """The small public Phase 1 configuration contract."""
@@ -68,6 +77,8 @@ class PluginConfig:
     requests_per_minute: int = DEFAULT_REQUESTS_PER_MINUTE
     control_requests_per_minute: int = DEFAULT_CONTROL_REQUESTS_PER_MINUTE
     max_parallel_calls: int = DEFAULT_MAX_PARALLEL_CALLS
+    log_level: str = DEFAULT_LOG_LEVEL
+    debug_until: int = 0
     _source: dict[str, Any] | None = None
 
     @classmethod
@@ -83,6 +94,7 @@ class PluginConfig:
         loxone = _mapping(root.get("loxone", {}), name="loxone")
         tools = _mapping(root.get("tools", {}), name="tools")
         limits = _mapping(root.get("limits", {}), name="limits")
+        logging_config = _mapping(root.get("logging", {}), name="logging")
 
         enabled = _boolean(server.get("enabled", False), name="server.enabled")
         public_origin_value = server.get("public_origin", "")
@@ -161,6 +173,13 @@ class PluginConfig:
             minimum=1,
             maximum=32,
         )
+        log_level = _log_level(logging_config.get("level", DEFAULT_LOG_LEVEL))
+        debug_until = _integer(
+            logging_config.get("debug_until", 0),
+            name="logging.debug_until",
+            minimum=0,
+            maximum=MAX_DEBUG_UNTIL,
+        )
         return cls(
             enabled=enabled,
             public_origin=public_origin,
@@ -171,13 +190,15 @@ class PluginConfig:
             requests_per_minute=requests,
             control_requests_per_minute=control_requests,
             max_parallel_calls=parallel,
+            log_level=log_level,
+            debug_until=debug_until,
             _source=copy.deepcopy(root),
         )
 
     def to_document(self) -> dict[str, Any]:
         document = copy.deepcopy(self._source) if self._source is not None else {}
         document["schema_version"] = SCHEMA_VERSION
-        for key in ("server", "loxone", "tools", "limits"):
+        for key in ("server", "loxone", "tools", "limits", "logging"):
             current = document.get(key)
             if not isinstance(current, dict):
                 document[key] = {}
@@ -190,6 +211,8 @@ class PluginConfig:
         document["limits"]["requests_per_minute"] = self.requests_per_minute
         document["limits"]["control_requests_per_minute"] = self.control_requests_per_minute
         document["limits"]["max_parallel_calls"] = self.max_parallel_calls
+        document["logging"]["level"] = self.log_level
+        document["logging"]["debug_until"] = self.debug_until
         return document
 
 

--- a/src/mcpserver/server.py
+++ b/src/mcpserver/server.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import logging
 import os
+import time
+from collections.abc import Callable
+from logging.handlers import RotatingFileHandler
 from typing import Final
 
 from mcp.server.auth.provider import AccessToken, TokenVerifier
@@ -23,18 +26,74 @@ from mcpserver.auth.loxone_store import EncryptedLoxoneTokenStore
 from mcpserver.auth.provider import CONTROL_SCOPE, READ_SCOPE, Phase0OAuthProvider
 from mcpserver.auth.store import AtomicJsonAuthStore
 from mcpserver.auth.web import Phase0OAuthWeb
+from mcpserver.config import DEFAULT_LOG_LEVEL
 from mcpserver.loxone.runtime import LoxoneRuntime
 from mcpserver.settings import ServerSettings
 from mcpserver.skill_delivery import SERVER_INSTRUCTIONS, register_skill_resource
 from mcpserver.tools import register_control_tool, register_read_tools, register_skill_tool
 
 SERVER_NAME: Final = "LoxBerry MCP Server"
+LOG_MAX_BYTES: Final = 512 * 1024
+LOG_BACKUP_COUNT: Final = 2
+_LOG_LEVELS: Final = {
+    "error": logging.ERROR,
+    "warning": logging.WARNING,
+    "info": logging.INFO,
+}
 _TRANSPORT_LOGGER_NAME: Final = "mcp.server.transport_security"
 _SENSITIVE_REJECTION_PREFIXES: Final = (
     "Invalid Host header:",
     "Invalid Origin header:",
     "Invalid Content-Type header:",
 )
+
+
+class TimedLevelFilter(logging.Filter):
+    """Keep audits while lowering operational verbosity after debug expires."""
+
+    def __init__(
+        self,
+        level: str = DEFAULT_LOG_LEVEL,
+        *,
+        debug_until: int = 0,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        super().__init__()
+        self._level = _LOG_LEVELS[level]
+        self._debug_until = debug_until
+        self._clock = clock
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if getattr(record, "mcp_audit", False):
+            return True
+        threshold = logging.DEBUG if self._clock() < self._debug_until else self._level
+        return record.levelno >= threshold
+
+
+def configure_service_logging(
+    *,
+    level: str,
+    debug_until: int,
+    log_file: str | None,
+) -> logging.Handler:
+    """Configure one bounded handler and return it for deterministic verification."""
+    if log_file:
+        handler: logging.Handler = RotatingFileHandler(
+            log_file,
+            maxBytes=LOG_MAX_BYTES,
+            backupCount=LOG_BACKUP_COUNT,
+            encoding="utf-8",
+        )
+    else:
+        handler = logging.StreamHandler()
+    handler.addFilter(TimedLevelFilter(level, debug_until=debug_until))
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format="%(asctime)s component=%(name)s severity=%(levelname)s %(message)s",
+        handlers=[handler],
+        force=True,
+    )
+    return handler
 
 
 class _RedactRejectedTransportHeader(logging.Filter):
@@ -110,6 +169,20 @@ class _DisabledServiceMiddleware(BaseHTTPMiddleware):
 
 class _ForwardedHostFastMCP(FastMCP):
     """FastMCP application that also validates Apache's original Host header."""
+
+    async def run_streamable_http_async(self) -> None:  # pragma: no cover - process boundary
+        """Run Uvicorn through the bounded root logger without request access logs."""
+        import uvicorn
+
+        config = uvicorn.Config(
+            self.streamable_http_app(),
+            host=self.settings.host,
+            port=self.settings.port,
+            log_config=None,
+            log_level="debug",
+            access_log=False,
+        )
+        await uvicorn.Server(config).serve()
 
     forwarded_allowed_hosts: tuple[str, ...] = ()
     transport_guard: TransportSecurityMiddleware | None = None
@@ -274,18 +347,12 @@ def create_server(settings: ServerSettings) -> FastMCP:
 
 def main() -> None:
     """Run Streamable HTTP on the configured loopback port."""
-    log_file = os.environ.get("MCPSERVER_LOG_FILE")
-    log_format = "%(asctime)s component=%(name)s severity=%(levelname)s %(message)s"
-    if log_file:
-        logging.basicConfig(
-            level=logging.INFO,
-            format=log_format,
-            filename=log_file,
-            encoding="utf-8",
-        )
-    else:
-        logging.basicConfig(level=logging.INFO, format=log_format)
     settings = ServerSettings.from_environment()
+    configure_service_logging(
+        level=settings.log_level,
+        debug_until=settings.debug_until,
+        log_file=os.environ.get("MCPSERVER_LOG_FILE"),
+    )
     create_server(settings).run(transport="streamable-http")
 
 

--- a/src/mcpserver/settings.py
+++ b/src/mcpserver/settings.py
@@ -11,7 +11,7 @@ from urllib.parse import urlsplit
 
 import idna
 
-from mcpserver.config import AtomicConfigStore, PluginConfig
+from mcpserver.config import DEFAULT_LOG_LEVEL, AtomicConfigStore, PluginConfig
 from mcpserver.loxone.client import MiniserverEndpoint
 
 SERVER_PORT: Final = 8765
@@ -210,20 +210,15 @@ def _phase0_auth_from_environment() -> Phase0AuthSettings | None:
 
 def _phase1_auth_from_environment(
     base: Phase0AuthSettings | None,
+    config: PluginConfig | None,
 ) -> tuple[Phase0AuthSettings | None, bool]:
-    config_value = os.getenv("MCPSERVER_CONFIG", "").strip()
     token_value = os.getenv("MCPSERVER_LOXONE_TOKEN_STORE", "").strip()
     key_value = os.getenv("MCPSERVER_INSTALL_KEY", "").strip()
     if bool(token_value) != bool(key_value):
         raise ValueError(
             "MCPSERVER_LOXONE_TOKEN_STORE and MCPSERVER_INSTALL_KEY are required together"
         )
-    config: PluginConfig | None = None
-    if config_value:
-        config_path = Path(config_value)
-        if not config_path.is_absolute():
-            raise ValueError("MCPSERVER_CONFIG must be an absolute path")
-        config = AtomicConfigStore(config_path).load()
+    if config is not None:
         if not config.enabled:
             return None, False
         if base is None:
@@ -269,6 +264,8 @@ class ServerSettings:
     allowed_origins: tuple[str, ...]
     phase0_auth: Phase0AuthSettings | None = None
     service_enabled: bool = True
+    log_level: str = DEFAULT_LOG_LEVEL
+    debug_until: int = 0
 
     @classmethod
     def from_environment(cls) -> ServerSettings:
@@ -293,8 +290,15 @@ class ServerSettings:
                 setting="MCPSERVER_ALLOWED_ORIGINS",
             )
         )
+        config_value = os.getenv("MCPSERVER_CONFIG", "").strip()
+        plugin_config: PluginConfig | None = None
+        if config_value:
+            config_path = Path(config_value)
+            if not config_path.is_absolute():
+                raise ValueError("MCPSERVER_CONFIG must be an absolute path")
+            plugin_config = AtomicConfigStore(config_path).load()
         phase_auth, service_enabled = _phase1_auth_from_environment(
-            None if os.getenv("MCPSERVER_CONFIG", "").strip() else _phase0_auth_from_environment()
+            None if config_value else _phase0_auth_from_environment(), plugin_config
         )
         if phase_auth is not None and phase_auth.plugin_config is not None:
             public = urlsplit(phase_auth.public_origin)
@@ -314,4 +318,6 @@ class ServerSettings:
             allowed_origins=allowed_origins,
             phase0_auth=phase_auth,
             service_enabled=service_enabled,
+            log_level=plugin_config.log_level if plugin_config is not None else DEFAULT_LOG_LEVEL,
+            debug_until=plugin_config.debug_until if plugin_config is not None else 0,
         )

--- a/src/mcpserver/tools.py
+++ b/src/mcpserver/tools.py
@@ -42,6 +42,8 @@ _LOGGER = logging.getLogger("mcpserver.tools")
 _AUDIT_SUPPRESSION_SECONDS: Final = 60.0
 _MAX_AUDIT_SUPPRESSION_KEYS: Final = 512
 _AUDIT_LAST: OrderedDict[tuple[str, str], float] = OrderedDict()
+_ERROR_SUPPRESSION_SECONDS: Final = 60.0
+_ERROR_LAST: dict[str, float] = {}
 
 CursorArgument = Annotated[
     str | None,
@@ -198,7 +200,7 @@ def _result[EnvelopeT: ToolEnvelope](
     warnings: list[str] | None = None,
 ) -> EnvelopeT:
     trace_id = str(uuid4())
-    _LOGGER.info("component=tools severity=INFO trace_id=%s outcome=ok", trace_id)
+    _LOGGER.debug("component=tools severity=DEBUG trace_id=%s outcome=ok", trace_id)
     return envelope_type(
         ok=True,
         data=data,
@@ -213,11 +215,22 @@ def _error[EnvelopeT: ToolEnvelope](
     envelope_type: type[EnvelopeT], code: str, message: str
 ) -> EnvelopeT:
     trace_id = str(uuid4())
-    _LOGGER.warning(
-        "component=tools severity=WARNING trace_id=%s outcome=error code=%s",
-        trace_id,
-        code,
-    )
+    if code == "temporarily_unavailable":
+        now = time.monotonic()
+        previous = _ERROR_LAST.get(code)
+        if previous is None or previous <= now - _ERROR_SUPPRESSION_SECONDS:
+            _ERROR_LAST[code] = now
+            _LOGGER.warning(
+                "component=tools severity=WARNING trace_id=%s outcome=error code=%s",
+                trace_id,
+                code,
+            )
+    else:
+        _LOGGER.debug(
+            "component=tools severity=DEBUG trace_id=%s outcome=error code=%s",
+            trace_id,
+            code,
+        )
     return envelope_type(
         ok=False,
         data={"error": code, "message": message},
@@ -270,6 +283,7 @@ def _control_envelope(
             json.dumps(control_uuid[:128]),
             action[:64] if action else "invalid",
             outcome,
+            extra={"mcp_audit": True},
         )
     data = (
         ControlOperationData.model_validate(result)

--- a/templates/index.html
+++ b/templates/index.html
@@ -200,6 +200,24 @@
     <summary><TMPL_VAR DIAGNOSTICS.TITLE></summary>
     <div class="mcp-collapsible-content">
     <p><TMPL_VAR DIAGNOSTICS.TEXT></p>
+    <div id="logging-controls" class="mcp-form"
+      data-level-error="<TMPL_VAR DIAGNOSTICS.LEVEL_ERROR ESCAPE=HTML>"
+      data-level-warning="<TMPL_VAR DIAGNOSTICS.LEVEL_WARNING ESCAPE=HTML>"
+      data-level-info="<TMPL_VAR DIAGNOSTICS.LEVEL_INFO ESCAPE=HTML>"
+      data-level-debug="<TMPL_VAR DIAGNOSTICS.LEVEL_DEBUG ESCAPE=HTML>">
+      <p><TMPL_VAR DIAGNOSTICS.CURRENT_LEVEL>: <strong id="logging-current"><TMPL_IF DEBUG_ACTIVE><TMPL_VAR DIAGNOSTICS.LEVEL_DEBUG> <TMPL_VAR DEBUG_UNTIL_DISPLAY ESCAPE=HTML><TMPL_ELSE><TMPL_IF LOG_LEVEL_ERROR><TMPL_VAR DIAGNOSTICS.LEVEL_ERROR><TMPL_ELSE><TMPL_IF LOG_LEVEL_INFO><TMPL_VAR DIAGNOSTICS.LEVEL_INFO><TMPL_ELSE><TMPL_VAR DIAGNOSTICS.LEVEL_WARNING></TMPL_IF></TMPL_IF></TMPL_IF></strong></p>
+      <form method="post" action="index.cgi" data-ajax="set_logging" class="mcp-form">
+        <input type="hidden" name="action" value="set_logging">
+        <label class="mcp-field"><span><TMPL_VAR DIAGNOSTICS.BASE_LEVEL></span><select id="logging-level" name="mode"><option value="error" <TMPL_IF LOG_LEVEL_ERROR>selected</TMPL_IF>><TMPL_VAR DIAGNOSTICS.LEVEL_ERROR></option><option value="warning" <TMPL_IF LOG_LEVEL_WARNING>selected</TMPL_IF>><TMPL_VAR DIAGNOSTICS.LEVEL_WARNING></option><option value="info" <TMPL_IF LOG_LEVEL_INFO>selected</TMPL_IF>><TMPL_VAR DIAGNOSTICS.LEVEL_INFO></option></select></label>
+        <button class="lb-button" type="submit"><TMPL_VAR ACTION.SAVE_LOG_LEVEL></button>
+      </form>
+      <div class="mcp-actions">
+        <form method="post" action="index.cgi" data-ajax="set_logging"><input type="hidden" name="action" value="set_logging"><input type="hidden" name="mode" value="debug_15"><button class="lb-button" type="submit"><TMPL_VAR ACTION.DEBUG_15></button></form>
+        <form method="post" action="index.cgi" data-ajax="set_logging"><input type="hidden" name="action" value="set_logging"><input type="hidden" name="mode" value="debug_60"><button class="lb-button" type="submit"><TMPL_VAR ACTION.DEBUG_60></button></form>
+        <form id="stop-debug-form" method="post" action="index.cgi" data-ajax="set_logging" <TMPL_UNLESS DEBUG_ACTIVE>hidden</TMPL_UNLESS>><input type="hidden" name="action" value="set_logging"><input type="hidden" name="mode" value="stop_debug"><button class="lb-button" type="submit"><TMPL_VAR ACTION.DEBUG_STOP></button></form>
+      </div>
+      <p class="mcp-help"><TMPL_VAR DIAGNOSTICS.LOGGING_HELP></p>
+    </div>
     <form method="post" action="index.cgi"><input type="hidden" name="action" value="diagnostic"><button class="lb-button" type="submit"><TMPL_VAR ACTION.DIAGNOSTIC></button></form>
     <TMPL_VAR LOGLIST>
     </div>
@@ -272,6 +290,10 @@
   const serviceInstalled = document.getElementById('service-installed');
   const serviceConfirm = document.getElementById('service-confirm');
   const serviceConfirmMessage = document.getElementById('service-confirm-message');
+  const loggingControls = document.getElementById('logging-controls');
+  const loggingCurrent = document.getElementById('logging-current');
+  const loggingLevel = document.getElementById('logging-level');
+  const stopDebugForm = document.getElementById('stop-debug-form');
   let pendingServiceForm = null;
   let serviceActionRunning = false;
   let servicePollInFlight = false;
@@ -280,6 +302,17 @@
   let sessionPollInFlight = false;
   let sessionPollTimer = null;
   let lastService = null;
+  const renderLogging = (configuration) => {
+    const configured = configuration && configuration.logging ? configuration.logging : {};
+    const level = ['error', 'warning', 'info'].includes(configured.level) ? configured.level : 'warning';
+    const debugUntil = Number(configured.debug_until) || 0;
+    const debugActive = debugUntil > Date.now() / 1000;
+    loggingLevel.value = level;
+    loggingCurrent.textContent = debugActive
+      ? `${loggingControls.dataset.levelDebug} ${new Date(debugUntil * 1000).toLocaleString()}`
+      : loggingControls.dataset[`level${level[0].toUpperCase()}${level.slice(1)}`];
+    stopDebugForm.hidden = !debugActive;
+  };
   const syncTestEndpoint = () => { testEndpoint.value = miniserverEndpoint.value; };
   const syncMiniserverSelection = () => {
     const selectedEndpoint = miniserverSelect.value;
@@ -608,6 +641,7 @@
   scheduleSessionPoll();
   const actionTimeout = (action) => ({
     save_config: 90000,
+    set_logging: 75000,
     revoke_session: 75000,
     revoke_all: 75000,
     renew_certificate: 30000,
@@ -666,6 +700,7 @@
           explorerLink.href = `${window.location.origin}${explorerPath}`;
           syncTestEndpoint();
         }
+        if (form.dataset.ajax === 'set_logging') renderLogging(result.data.configuration);
         if (form.dataset.ajax === 'renew_certificate') {
           keepButtonDisabled = true;
           form.querySelector('input[name="securepin"]').value = '';

--- a/templates/lang/language_de.ini
+++ b/templates/lang/language_de.ini
@@ -67,6 +67,13 @@ EMPTY=Keine Sitzungen vorhanden.
 [DIAGNOSTICS]
 TITLE=Diagnose und Logs
 TEXT=Das Dienstlog wird über den integrierten LoxBerry-Logviewer angezeigt. Der Diagnoseexport maskiert sensible Werte.
+CURRENT_LEVEL=Aktueller Log-Level
+BASE_LEVEL=Log-Level nach Ablauf von Debug
+LEVEL_ERROR=Fehler
+LEVEL_WARNING=Warnungen
+LEVEL_INFO=Informationen
+LEVEL_DEBUG=Debug bis
+LOGGING_HELP=Debug protokolliert vorübergehend zusätzliche Details und fällt danach automatisch auf den gewählten Log-Level zurück. Das Dienstlog ist auf drei Dateien mit insgesamt höchstens etwa 1,5 MB begrenzt.
 
 [HELP]
 TITLE=Hilfe
@@ -121,6 +128,10 @@ RESTART=Neu starten
 REVOKE=Widerrufen
 REVOKE_ALL=Alle widerrufen
 DIAGNOSTIC=Maskierte Diagnose exportieren
+SAVE_LOG_LEVEL=Log-Level speichern
+DEBUG_15=Debug für 15 Minuten
+DEBUG_60=Debug für 60 Minuten
+DEBUG_STOP=Debug beenden
 EXPLORER=MCP Tool Explorer öffnen
 COPY=Kopieren
 COPIED=Kopiert

--- a/templates/lang/language_en.ini
+++ b/templates/lang/language_en.ini
@@ -67,6 +67,13 @@ EMPTY=No sessions exist.
 [DIAGNOSTICS]
 TITLE=Diagnostics and logs
 TEXT=The service log is shown through the integrated LoxBerry log viewer. The diagnostic export masks sensitive values.
+CURRENT_LEVEL=Current log level
+BASE_LEVEL=Log level after debug expires
+LEVEL_ERROR=Errors
+LEVEL_WARNING=Warnings
+LEVEL_INFO=Information
+LEVEL_DEBUG=Debug until
+LOGGING_HELP=Debug temporarily records additional details and then automatically returns to the selected log level. The service log is limited to three files totalling approximately 1.5 MB.
 
 [HELP]
 TITLE=Help
@@ -121,6 +128,10 @@ RESTART=Restart
 REVOKE=Revoke
 REVOKE_ALL=Revoke all
 DIAGNOSTIC=Export masked diagnostics
+SAVE_LOG_LEVEL=Save log level
+DEBUG_15=Debug for 15 minutes
+DEBUG_60=Debug for 60 minutes
+DEBUG_STOP=Stop debug
 EXPLORER=Open MCP Tool Explorer
 COPY=Copy
 COPIED=Copied

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -13,6 +13,7 @@ from mcpserver.admin import (
     _revoke,
     _save,
     _service_status,
+    _set_logging,
     dispatch,
 )
 from mcpserver.auth.loxone_store import LoxoneTokenStoreError
@@ -341,6 +342,89 @@ def test_failed_config_apply_restores_previous_configuration(
 
     assert restarts == 2
     assert store.load().to_document() == previous.to_document()
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected_level", "expected_until"),
+    [
+        ("error", "error", 0),
+        ("warning", "warning", 0),
+        ("info", "info", 0),
+        ("debug_15", "warning", 1_900),
+        ("debug_60", "warning", 4_600),
+        ("stop_debug", "warning", 0),
+    ],
+)
+def test_logging_mode_is_validated_persisted_and_applied(
+    mode: str,
+    expected_level: str,
+    expected_until: int,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = AtomicConfigStore((tmp_path / "config" / "mcpserver.json").resolve())
+    store.save(PluginConfig.defaults())
+    restarts: list[str] = []
+    monkeypatch.setattr("mcpserver.admin._config_store", lambda: store)
+    monkeypatch.setattr("mcpserver.admin._restart_service", lambda: restarts.append("restart"))
+    monkeypatch.setattr("mcpserver.admin.time.time", lambda: 1_000)
+
+    result = _set_logging({"mode": mode})
+
+    assert store.load().log_level == expected_level
+    assert store.load().debug_until == expected_until
+    assert result["configuration"]["logging"] == {
+        "level": expected_level,
+        "debug_until": expected_until,
+    }
+    assert restarts == ["restart"]
+
+
+def test_invalid_logging_mode_is_rejected_before_writing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = AtomicConfigStore((tmp_path / "config" / "mcpserver.json").resolve())
+    store.save(PluginConfig.defaults())
+    monkeypatch.setattr("mcpserver.admin._config_store", lambda: store)
+
+    with pytest.raises(AdminError, match="logging mode is invalid"):
+        _set_logging({"mode": "unlimited_debug"})
+
+    assert store.load().to_document() == PluginConfig.defaults().to_document()
+
+
+def test_base_level_change_keeps_an_active_debug_window(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = AtomicConfigStore((tmp_path / "config" / "mcpserver.json").resolve())
+    store.save(PluginConfig(log_level="warning", debug_until=2_000, _source={}))
+    monkeypatch.setattr("mcpserver.admin._config_store", lambda: store)
+    monkeypatch.setattr("mcpserver.admin._restart_service", lambda: None)
+
+    _set_logging({"mode": "info"})
+
+    assert store.load().log_level == "info"
+    assert store.load().debug_until == 2_000
+
+
+def test_main_config_save_preserves_separately_managed_logging(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = AtomicConfigStore((tmp_path / "config" / "mcpserver.json").resolve())
+    previous = PluginConfig(log_level="info", debug_until=1234, _source={})
+    store.save(previous)
+    monkeypatch.setattr("mcpserver.admin._config_store", lambda: store)
+    monkeypatch.setattr("mcpserver.admin._restart_service", lambda: None)
+    monkeypatch.setattr("mcpserver.admin._sessions", lambda: [])
+    monkeypatch.setattr(
+        "mcpserver.admin._service_response",
+        lambda: {"service_active": True, "service": {"active": True}},
+    )
+
+    _save({"schema_version": 1, "server": {"enabled": False}})
+
+    assert store.load().log_level == "info"
+    assert store.load().debug_until == 1234
 
 
 def test_disabling_control_revokes_control_sessions_after_successful_restart(

--- a/tests/test_admin_ui.py
+++ b/tests/test_admin_ui.py
@@ -89,6 +89,23 @@ def test_read_only_ajax_polling_does_not_create_admin_log_files() -> None:
     assert "loglevel => 7" in cgi
     assert 'admin_logger()->INF("service-action=$command result=completed")' in cgi
     assert 'admin_logger()->ERR("service-action=$command result=failed")' in cgi
+    assert "LOGSTART('index.cgi called')" not in cgi
+    assert 'admin_logger()->ERR("admin helper failed")' in cgi
+    assert "admin_logger()->WARN('Stored Miniserver configuration is invalid')" in cgi
+
+
+def test_diagnostics_offer_bounded_temporary_logging_controls() -> None:
+    cgi = (ROOT / "webfrontend/htmlauth/index.cgi").read_text(encoding="utf-8")
+    template = (ROOT / "templates/index.html").read_text(encoding="utf-8")
+
+    assert "admin_call('set_logging', {mode => ($q->{mode} // '')})" in cgi
+    assert 'data-ajax="set_logging"' in template
+    assert 'value="debug_15"' in template
+    assert 'value="debug_60"' in template
+    assert 'value="stop_debug"' in template
+    assert "set_logging: 75000" in template
+    assert "renderLogging(result.data.configuration)" in template
+    assert "window.location.reload" not in template
 
 
 def test_service_actions_use_an_accessible_confirmation_and_dynamic_controls() -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,6 +19,8 @@ def test_defaults_are_disabled_and_bounded() -> None:
     assert config.requests_per_minute == 60
     assert config.control_requests_per_minute == 10
     assert config.max_parallel_calls == 4
+    assert config.log_level == "warning"
+    assert config.debug_until == 0
 
 
 def test_configuration_round_trip_preserves_unknown_keys(tmp_path: Path) -> None:
@@ -56,6 +58,8 @@ def test_configuration_round_trip_preserves_unknown_keys(tmp_path: Path) -> None
             "server": {"enabled": False},
             "loxone": {"endpoint": "http://public.example"},
         },
+        {"schema_version": 1, "logging": {"level": "debug"}},
+        {"schema_version": 1, "logging": {"debug_until": -1}},
     ],
 )
 def test_invalid_configuration_is_rejected(document: object) -> None:

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+import pytest
+
+from mcpserver.server import (
+    LOG_BACKUP_COUNT,
+    LOG_MAX_BYTES,
+    TimedLevelFilter,
+    configure_service_logging,
+)
+
+
+def _record(level: int, *, audit: bool = False) -> logging.LogRecord:
+    record = logging.LogRecord("test", level, __file__, 1, "message", (), None)
+    if audit:
+        record.mcp_audit = True  # type: ignore[attr-defined]
+    return record
+
+
+def test_debug_window_expires_to_the_configured_level() -> None:
+    now = [100.0]
+    filter_ = TimedLevelFilter("warning", debug_until=200, clock=lambda: now[0])
+
+    assert filter_.filter(_record(logging.DEBUG)) is True
+    now[0] = 201.0
+    assert filter_.filter(_record(logging.INFO)) is False
+    assert filter_.filter(_record(logging.WARNING)) is True
+    assert filter_.filter(_record(logging.DEBUG, audit=True)) is True
+
+
+def test_service_file_handler_is_size_bounded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    options: dict[str, object] = {}
+    monkeypatch.setattr(logging, "basicConfig", lambda **kwargs: options.update(kwargs))
+
+    handler = configure_service_logging(
+        level="warning",
+        debug_until=0,
+        log_file=str(tmp_path / "service.log"),
+    )
+    try:
+        assert isinstance(handler, RotatingFileHandler)
+        assert handler.maxBytes == LOG_MAX_BYTES == 512 * 1024
+        assert handler.backupCount == LOG_BACKUP_COUNT == 2
+        assert options["level"] == logging.DEBUG
+        assert options["handlers"] == [handler]
+        assert options["force"] is True
+    finally:
+        handler.close()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -35,16 +35,50 @@ def test_main_opens_the_configured_log_as_the_service_user(
 
     monkeypatch.setenv("MCPSERVER_LOG_FILE", str(log_file))
     monkeypatch.setattr(
-        "mcpserver.server.logging.basicConfig", lambda **kwargs: logging_options.update(kwargs)
+        "mcpserver.server.configure_service_logging",
+        lambda **kwargs: logging_options.update(kwargs),
     )
     monkeypatch.setattr(ServerSettings, "from_environment", staticmethod(_settings))
     monkeypatch.setattr("mcpserver.server.create_server", lambda settings: Server())
 
     main()
 
-    assert logging_options["filename"] == str(log_file)
-    assert logging_options["encoding"] == "utf-8"
+    assert logging_options == {
+        "level": "warning",
+        "debug_until": 0,
+        "log_file": str(log_file),
+    }
     assert run_options == {"transport": "streamable-http"}
+
+
+@pytest.mark.asyncio
+async def test_http_runtime_uses_root_logging_without_access_log(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server = create_server(_settings())
+    options: dict[str, object] = {}
+    served: list[object] = []
+
+    def config(app: object, **kwargs: object) -> object:
+        options.update(kwargs)
+        return app
+
+    class UvicornServer:
+        def __init__(self, config: object) -> None:
+            self.config = config
+
+        async def serve(self) -> None:
+            served.append(self.config)
+
+    monkeypatch.setattr("uvicorn.Config", config)
+    monkeypatch.setattr("uvicorn.Server", UvicornServer)
+
+    await server.run_streamable_http_async()
+
+    assert options["log_config"] is None
+    assert options["log_level"] == "debug"
+    assert options["access_log"] is False
+    assert len(served) == 1
 
 
 def test_health_is_small_and_contains_no_configuration() -> None:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -36,19 +36,27 @@ def test_secure_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     assert settings.allowed_origins == ()
     assert settings.phase0_auth is None
     assert settings.service_enabled is True
+    assert settings.log_level == "warning"
+    assert settings.debug_until == 0
 
 
 def test_disabled_phase1_configuration_fails_closed(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     config = tmp_path / "mcpserver.json"
-    config.write_text('{"schema_version":1,"server":{"enabled":false}}', encoding="utf-8")
+    config.write_text(
+        '{"schema_version":1,"server":{"enabled":false},'
+        '"logging":{"level":"info","debug_until":1234}}',
+        encoding="utf-8",
+    )
     monkeypatch.setenv("MCPSERVER_CONFIG", str(config))
 
     settings = ServerSettings.from_environment()
 
     assert settings.phase0_auth is None
     assert settings.service_enabled is False
+    assert settings.log_level == "info"
+    assert settings.debug_until == 1234
 
 
 def test_enabled_phase1_configuration_supplies_endpoint_and_public_origin(

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 import pytest
 from mcp.server.fastmcp import FastMCP
 
@@ -9,12 +11,47 @@ from mcpserver.loxone.models import Control, LoxoneIdentity, LoxoneStructure
 from mcpserver.loxone.runtime import RuntimeSnapshot
 from mcpserver.skill_delivery import read_skill_markdown
 from mcpserver.tools import (
+    SystemStatusEnvelope,
     _CursorCodec,
+    _error,
     _page,
+    _result,
     register_control_tool,
     register_read_tools,
     register_skill_tool,
 )
+
+
+def test_read_results_and_expected_errors_are_debug_only(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.DEBUG, logger="mcpserver.tools")
+
+    _result(
+        SystemStatusEnvelope,
+        {
+            "reachable": True,
+            "miniserver_serial": "masked",
+            "structure_last_modified": "",
+            "cache_freshness": "current",
+        },
+    )
+    _error(SystemStatusEnvelope, "invalid_input", "invalid")
+
+    assert [record.levelno for record in caplog.records] == [logging.DEBUG, logging.DEBUG]
+
+
+def test_repeated_runtime_warning_is_suppressed(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    tools_module._ERROR_LAST.clear()
+    monkeypatch.setattr(tools_module.time, "monotonic", lambda: 100.0)
+    caplog.set_level(logging.WARNING, logger="mcpserver.tools")
+
+    _error(SystemStatusEnvelope, "temporarily_unavailable", "unavailable")
+    _error(SystemStatusEnvelope, "temporarily_unavailable", "unavailable")
+
+    assert len(caplog.records) == 1
 
 
 def test_opaque_cursor_paginates_without_exposing_offset() -> None:

--- a/webfrontend/htmlauth/index.cgi
+++ b/webfrontend/htmlauth/index.cgi
@@ -60,12 +60,12 @@ sub admin_call {
     my $stderr = <$child_err> // '';
     waitpid($pid, 0);
     if ($? != 0 || $stdout eq '') {
-        LOGERR("admin helper failed");
+        admin_logger()->ERR("admin helper failed");
         return {ok => JSON::PP::false, error => {code => 'internal_error', message => 'Administrative action failed'}};
     }
     my $result = eval { decode_json($stdout) };
     if (!$result || ref($result) ne 'HASH') {
-        LOGERR("admin helper returned invalid JSON");
+        admin_logger()->ERR("admin helper returned invalid JSON");
         return {ok => JSON::PP::false, error => {code => 'internal_error', message => 'Administrative action failed'}};
     }
     return $result;
@@ -146,12 +146,12 @@ sub stored_general_config {
     $general_config_loaded = 1;
     my $path = "$lbhomedir/config/system/general.json";
     if (!-f $path || !-r $path) {
-        LOGWARN('Could not read stored LoxBerry configuration');
+        admin_logger()->WARN('Could not read stored LoxBerry configuration');
         $general_config_cache = {};
         return $general_config_cache;
     }
     open my $handle, '<:raw', $path or do {
-        LOGWARN('Could not open stored LoxBerry configuration');
+        admin_logger()->WARN('Could not open stored LoxBerry configuration');
         $general_config_cache = {};
         return $general_config_cache;
     };
@@ -159,13 +159,13 @@ sub stored_general_config {
     my $raw = <$handle> // '';
     close $handle;
     if (length($raw) > 1024 * 1024) {
-        LOGWARN('Stored LoxBerry configuration is unexpectedly large');
+        admin_logger()->WARN('Stored LoxBerry configuration is unexpectedly large');
         $general_config_cache = {};
         return $general_config_cache;
     }
     my $document = eval { decode_json($raw) };
     if ($@ || ref($document) ne 'HASH') {
-        LOGWARN('Stored LoxBerry configuration is invalid');
+        admin_logger()->WARN('Stored LoxBerry configuration is invalid');
         $general_config_cache = {};
         return $general_config_cache;
     }
@@ -176,7 +176,7 @@ sub stored_general_config {
 sub stored_miniservers {
     my $document = stored_general_config();
     if (ref($document->{Miniserver}) ne 'HASH') {
-        LOGWARN('Stored Miniserver configuration is invalid');
+        admin_logger()->WARN('Stored Miniserver configuration is invalid');
         return {};
     }
 
@@ -311,6 +311,8 @@ if ($action ne '') {
             },
         };
         $result = admin_call('save_config', $document);
+    } elsif ($action eq 'set_logging') {
+        $result = admin_call('set_logging', {mode => ($q->{mode} // '')});
     } elsif ($action eq 'test_connection') {
         $result = admin_call('test_connection', {endpoint => requested_endpoint($q)});
     } elsif ($action eq 'revoke_session') {
@@ -393,6 +395,7 @@ $config->{server} = {} if ref($config->{server}) ne 'HASH';
 $config->{loxone} = {} if ref($config->{loxone}) ne 'HASH';
 $config->{tools} = {} if ref($config->{tools}) ne 'HASH';
 $config->{limits} = {} if ref($config->{limits}) ne 'HASH';
+$config->{logging} = {} if ref($config->{logging}) ne 'HASH';
 my $miniservers = configured_miniservers($config->{loxone}{endpoint});
 my $has_selected_miniserver = grep { $_->{selected} } @$miniservers;
 my ($selected_miniserver) = grep { $_->{selected} } @$miniservers;
@@ -418,6 +421,8 @@ my %renewal_labels = (
     error => $L{'CERTIFICATE.STATE_ERROR'},
 );
 my $renewal_state = $renewal->{state} // 'idle';
+my $debug_until = $config->{logging}{debug_until} // 0;
+my $debug_active = $debug_until =~ /\A(?:0|[1-9][0-9]*)\z/ && $debug_until > time ? 1 : 0;
 my $notice_value = $q->{notice} // '';
 my $notice_text = $notice_value eq 'success' ? $L{'AJAX.SUCCESS'}
     : $notice_value eq 'certificate_scheduled' ? $L{'CERTIFICATE.STATE_SCHEDULED'}
@@ -439,6 +444,13 @@ $template->param(
     REQUESTS_PER_MINUTE => $config->{limits}{requests_per_minute} // 60,
     CONTROL_REQUESTS_PER_MINUTE => $config->{limits}{control_requests_per_minute} // 10,
     MAX_PARALLEL_CALLS => $config->{limits}{max_parallel_calls} // 4,
+    LOG_LEVEL => $config->{logging}{level} // 'warning',
+    LOG_LEVEL_ERROR => ($config->{logging}{level} // 'warning') eq 'error' ? 1 : 0,
+    LOG_LEVEL_WARNING => ($config->{logging}{level} // 'warning') eq 'warning' ? 1 : 0,
+    LOG_LEVEL_INFO => ($config->{logging}{level} // 'warning') eq 'info' ? 1 : 0,
+    DEBUG_ACTIVE => $debug_active,
+    DEBUG_UNTIL => $debug_until,
+    DEBUG_UNTIL_DISPLAY => $debug_active ? format_expiry($debug_until) : '',
     SERVICE_ACTIVE => $page_state->{service_active} ? 1 : 0,
     SERVICE_INSTALLED => $service->{installed} ? 1 : 0,
     SERVICE_FAILED => ($service->{active_state} // '') eq 'failed' ? 1 : 0,


### PR DESCRIPTION
## Summary

- expose persistent Error/Warning/Information levels and temporary 15/60-minute Debug modes in Diagnose und Logs
- bound service.log with rotation (512 KiB, two backups) and suppress routine HTTP/read-success noise
- preserve audit records independently of the selected service log level
- document the behavior in German and English and cover configuration, runtime, admin, tool, and UI paths

## Why

The service log should remain useful without causing avoidable SD-card writes. Debug output is now deliberately temporary, while normal operation defaults to warnings and bounded storage.

## Verification

- Local Full profile: formatting, Ruff, MyPy, and 349 tests passed
- Focused plugin-owned file deployment to the authorized Loxberry-Test system passed; backup retained
- Desktop and 390 px mobile UI checked in Chrome
- Debug activation, expiry display, stop action, persistent Information setting, and restoration to Warning verified
- Five health checks produced no service.log size or timestamp change
- Service remained active; final target configuration is Warning with no active Debug window

This was a focused hot-swap acceptance, not a native Plugin Manager upgrade lifecycle test.