### PR TITLE
Harden release test temp handling

### DIFF
--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -619,9 +620,13 @@ def test_release_candidate_builds_plugin_archive_once(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     build_calls: list[tuple[str, ...]] = []
+    test_environments: list[dict[str, str]] = []
 
     def run(*arguments: str, root: Path, environment: dict[str, str] | None = None) -> None:
-        del root, environment
+        del root
+        if "tools/test.py" in arguments:
+            assert environment is not None
+            test_environments.append(environment)
         if "tools/build_plugin.py" in arguments:
             build_calls.append(arguments)
             output = Path(arguments[arguments.index("--output") + 1])
@@ -633,9 +638,17 @@ def test_release_candidate_builds_plugin_archive_once(
         "argv",
         ["build_release_candidate.py", "--output-dir", str(tmp_path)],
     )
+    monkeypatch.setenv("PYTEST_ADDOPTS", "--maxfail=1")
 
     assert build_release_candidate() == 0
     assert len(build_calls) == 1
+    assert len(test_environments) == 1
+    pytest_options = test_environments[0]["PYTEST_ADDOPTS"]
+    parsed_options = shlex.split(pytest_options)
+    assert parsed_options[-2:] == ["-p", "no:cacheprovider"]
+    basetemp = Path(parsed_options[0].removeprefix("--basetemp="))
+    assert basetemp.is_absolute()
+    assert not basetemp.exists()
 
 
 def test_prepare_runtime_wheelhouse_skips_project_wheel(

--- a/tools/build_release_candidate.py
+++ b/tools/build_release_candidate.py
@@ -6,6 +6,7 @@ import argparse
 import configparser
 import hashlib
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -160,7 +161,14 @@ def main() -> int:
     }
 
     if not args.skip_tests:
-        _run(sys.executable, "tools/test.py", root=root, environment=environment)
+        with tempfile.TemporaryDirectory(prefix="mcpserver-tests-", dir=output_dir) as test_temp:
+            test_environment = {
+                **environment,
+                "PYTEST_ADDOPTS": shlex.join(
+                    [f"--basetemp={Path(test_temp).as_posix()}", "-p", "no:cacheprovider"]
+                ),
+            }
+            _run(sys.executable, "tools/test.py", root=root, environment=test_environment)
     with tempfile.TemporaryDirectory(prefix="mcpserver-release-", dir=output_dir) as temporary:
         work = Path(temporary)
         wheelhouse = work / "wheelhouse"


### PR DESCRIPTION
## What changed

- run the release-candidate Full gate with an automatically managed pytest base temp directory
- disable pytest cache writes for that gate
- override ambient `PYTEST_ADDOPTS` deterministically and cover cleanup in regression tests

## Why

On Windows, pytest temp/cache residue could make the documented package build require manual retries or environment setup. The builder now owns this temporary state and removes it after the gate.

## Validation

- focused release-candidate and test-runner regression tests: 11 passed
- changed profile: 43 passed
- real release-candidate build without manual `PYTEST_ADDOPTS`: Full profile 363 passed; Ruff, MyPy, and diff checks passed; ZIP verified