### PR TITLE
List service log rotations

### DIFF
--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -207,8 +207,10 @@ Der englische Healthcheck führt keine Reparatur aus:
 LBPCONFIG=/actual/config/path LBPDATA=/actual/data/path /actual/bin/healthcheck
 ```
 
-Das Dienstlog kann direkt aus der Statuskarte im LoxBerry-Logviewer geöffnet
-werden. Es ist auf die aktive Datei und zwei Rotationen mit jeweils 512 KiB,
+Das Dienstlog kann direkt aus der Statuskarte oder als Liste der aktiven Datei
+und vorhandenen Backups im Unterabschnitt **Dienst-Log (service.log)** im
+LoxBerry-Logviewer geöffnet werden. Es ist auf die aktive Datei und zwei
+Rotationen mit jeweils 512 KiB,
 also insgesamt ungefähr 1,5 MB, begrenzt. Einzelne Einträge sind auf 8 KiB
 begrenzt. Unter **Diagnose und Logs** kann der ausschließlich für `service.log`
 geltende Level dauerhaft auf **Aus**, **Fehler**, **Warnungen**,

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -193,8 +193,9 @@ The English healthcheck never repairs the system:
 LBPCONFIG=/actual/config/path LBPDATA=/actual/data/path /actual/bin/healthcheck
 ```
 
-The service log can be opened directly from the status card in the LoxBerry log
-viewer. It is bounded to the active file and two 512 KiB rotations, approximately
+The service log can be opened directly from the status card or as a list of the
+active file and available backups in the **Service log (service.log)** section of
+the LoxBerry log viewer. It is bounded to the active file and two 512 KiB rotations, approximately
 1.5 MB in total. Individual records are limited to 8 KiB. Under **Diagnostics
 and logs**, the level applying exclusively to `service.log` can be set
 persistently to **Off**, **Errors**, **Warnings**, **Information**, or **Debug**;

--- a/templates/index.html
+++ b/templates/index.html
@@ -22,6 +22,7 @@
   .mcp-help { margin: 0; color: #4b5563; }
   .mcp-log-section { display: grid; gap: .85rem; min-width: 0; padding: 1rem; border: 1px solid #d7dadd; border-radius: .4rem; }
   .mcp-log-section h3 { margin: 0; font-size: 1.1rem; }
+  .mcp-log-files { display: grid; gap: .35rem; margin: 0; padding-left: 1.25rem; }
   .mcp-actions { display: flex; flex-wrap: wrap; gap: .6rem; align-items: center; }
   .mcp-actions button { min-height: 2.75rem; max-width: 100%; }
   .mcp-copy-row { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: .5rem; align-items: end; }
@@ -205,6 +206,8 @@
     <form method="post" action="index.cgi"><input type="hidden" name="action" value="diagnostic"><button class="lb-button" type="submit"><TMPL_VAR ACTION.DIAGNOSTIC></button></form>
     <section class="mcp-log-section" aria-labelledby="service-log-heading">
     <h3 id="service-log-heading"><TMPL_VAR DIAGNOSTICS.SERVICE_SECTION></h3>
+    <p class="mcp-help"><TMPL_VAR DIAGNOSTICS.SERVICE_LOG_FILES></p>
+    <ul class="mcp-log-files"><TMPL_LOOP SERVICE_LOGS><li><a href="<TMPL_VAR url ESCAPE=HTML>" target="_blank" rel="noopener"><TMPL_VAR filename ESCAPE=HTML></a></li></TMPL_LOOP></ul>
     <div id="logging-controls" class="mcp-form"
       data-level-off="<TMPL_VAR DIAGNOSTICS.LEVEL_OFF ESCAPE=HTML>"
       data-level-error="<TMPL_VAR DIAGNOSTICS.LEVEL_ERROR ESCAPE=HTML>"

--- a/templates/lang/language_de.ini
+++ b/templates/lang/language_de.ini
@@ -69,6 +69,7 @@ TITLE=Diagnose und Logs
 TEXT=Das Dienstlog wird über den integrierten LoxBerry-Logviewer angezeigt. Der Diagnoseexport maskiert sensible Werte.
 CURRENT_LEVEL=Aktueller Log-Level
 SERVICE_SECTION=Dienst-Log (service.log)
+SERVICE_LOG_FILES=Aktive Datei und vorhandene Backups im LoxBerry-Logviewer:
 PLUGIN_SECTION=Plugin-Logs (LoxBerry LogManager)
 SERVICE_LEVEL=Log-Level für service.log
 LEVEL_OFF=Aus (außer Sicherheits-Audit)

--- a/templates/lang/language_en.ini
+++ b/templates/lang/language_en.ini
@@ -69,6 +69,7 @@ TITLE=Diagnostics and logs
 TEXT=The service log is shown through the integrated LoxBerry log viewer. The diagnostic export masks sensitive values.
 CURRENT_LEVEL=Current log level
 SERVICE_SECTION=Service log (service.log)
+SERVICE_LOG_FILES=Active file and available backups in the LoxBerry log viewer:
 PLUGIN_SECTION=Plugin logs (LoxBerry Log Manager)
 SERVICE_LEVEL=Log level for service.log
 LEVEL_OFF=Off (except security audit)

--- a/tests/test_admin_ui.py
+++ b/tests/test_admin_ui.py
@@ -121,6 +121,15 @@ def test_diagnostics_offer_dedicated_persistent_service_logging_controls() -> No
     assert "DIAGNOSTICS.PLUGIN_SECTION" in template
     assert template.count('class="mcp-log-section"') == 2
     assert template.index('id="service-log-heading"') < template.index('id="plugin-log-heading"')
+    service_log_section = template[
+        template.index('id="service-log-heading"') : template.index('id="plugin-log-heading"')
+    ]
+    assert 'class="mcp-log-files"' in service_log_section
+    assert "TMPL_LOOP SERVICE_LOGS" in service_log_section
+    assert 'href="<TMPL_VAR url ESCAPE=HTML>"' in service_log_section
+    assert "DIAGNOSTICS.SERVICE_LOG_FILES" in service_log_section
+    assert "SERVICE_LOGS => \\@service_logs" in cgi
+    assert "for my $suffix ('', '.1', '.2')" in cgi
     assert "set_logging: 75000" in template
     assert "renderLogging(result.data.configuration)" in template
     assert "window.location.reload" not in template

--- a/webfrontend/htmlauth/index.cgi
+++ b/webfrontend/htmlauth/index.cgi
@@ -490,6 +490,15 @@ my $notice_text = $notice_value eq 'success' ? $L{'AJAX.SUCCESS'}
     : $notice_value ne '' ? $L{'AJAX.ERROR'} : '';
 my $notice_kind = $notice_value eq 'success' || $notice_value eq 'certificate_scheduled'
     ? 'success' : 'error';
+my @service_logs;
+for my $suffix ('', '.1', '.2') {
+    my $filename = "service.log$suffix";
+    next if $suffix ne '' && !-f "$lbplogdir/$filename";
+    push @service_logs, {
+        filename => $filename,
+        url => "/admin/system/tools/logfile.cgi?logfile=plugins/$lbpplugindir/$filename&header=html&format=template",
+    };
+}
 $template->param(
     VERSION => $version,
     ENABLED => $config->{server}{enabled} ? 1 : 0,
@@ -520,6 +529,7 @@ $template->param(
     SERVICE_PID => $service->{pid} // '-',
     SERVICE_NAME => $service->{name} // 'loxberry-mcpserver.service',
     SERVICE_LOG_URL => "/admin/system/tools/logfile.cgi?logfile=plugins/$lbpplugindir/service.log&header=html&format=template",
+    SERVICE_LOGS => \@service_logs,
     CERTIFICATE_AVAILABLE => $certificate->{available} ? 1 : 0,
     CERTIFICATE_SOURCE_LOXBERRY => ($certificate->{source} // '') eq 'loxberry_ca' ? 1 : 0,
     CERTIFICATE_EXPIRES_AT => $certificate->{expires_at} // '',


### PR DESCRIPTION
## What changed

- list the active `service.log` and existing `.1` / `.2` rotations in the Service log section
- open every listed file through the native LoxBerry log viewer
- retain the status-card shortcut and keep German and English guides synchronized

## Why

The service log is independently rotated, so the diagnostics UI should expose the current file and retained backups without conflating them with LogManager-managed plugin logs.

## Validation

- Changed profile: 122 passed
- focused LoxBerry file deployment: passed, backup retained
- browser acceptance: German and English; 1280x800 and 390x844; no horizontal overflow