### PR TITLE
Handle draft release lookup

### DIFF
--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -863,7 +863,7 @@ def test_release_workflow_is_manual_owner_only_and_separates_permissions() -> No
     assert "actual_body=" in publisher
     assert "title or notes do not match" in publisher
     assert 'gh release view "$TAG" --repo "$REPOSITORY"' in publisher
-    assert 'releases/tags/$TAG' not in publisher
+    assert "releases/tags/$TAG" not in publisher
 
 
 def test_package_contract_excludes_update_and_development_files() -> None:

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -864,6 +864,8 @@ def test_release_workflow_is_manual_owner_only_and_separates_permissions() -> No
     assert "title or notes do not match" in publisher
     assert 'gh release view "$TAG" --repo "$REPOSITORY"' in publisher
     assert "releases/tags/$TAG" not in publisher
+    assert "draft: .isDraft" in publisher
+    assert 'apiUrl | split("/") | last' in publisher
 
 
 def test_package_contract_excludes_update_and_development_files() -> None:

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -862,6 +862,8 @@ def test_release_workflow_is_manual_owner_only_and_separates_permissions() -> No
     assert "actual_title=" in publisher
     assert "actual_body=" in publisher
     assert "title or notes do not match" in publisher
+    assert 'gh release view "$TAG" --repo "$REPOSITORY"' in publisher
+    assert 'releases/tags/$TAG' not in publisher
 
 
 def test_package_contract_excludes_update_and_development_files() -> None:

--- a/tools/publish_github_release.sh
+++ b/tools/publish_github_release.sh
@@ -28,7 +28,11 @@ release_json="$(mktemp)"
 load_release() {
   gh release view "$TAG" --repo "$REPOSITORY" \
     --json databaseId,name,body,isDraft,assets |
-    jq '. + {id: .databaseId}'
+    jq '. + {
+      id: .databaseId,
+      draft: .isDraft,
+      assets: [.assets[] | . + {id: (.apiUrl | split("/") | last)}]
+    }'
 }
 
 if load_release >"$release_json" 2>/dev/null; then

--- a/tools/publish_github_release.sh
+++ b/tools/publish_github_release.sh
@@ -25,7 +25,13 @@ else
 fi
 
 release_json="$(mktemp)"
-if gh api "repos/$REPOSITORY/releases/tags/$TAG" >"$release_json" 2>/dev/null; then
+load_release() {
+  gh release view "$TAG" --repo "$REPOSITORY" \
+    --json databaseId,name,body,isDraft,assets |
+    jq '. + {id: .databaseId}'
+}
+
+if load_release >"$release_json" 2>/dev/null; then
   if [[ "$(jq -r .draft "$release_json")" != "true" ]]; then
     echo "Published release $TAG already exists and will not be modified." >&2
     exit 1
@@ -33,7 +39,7 @@ if gh api "repos/$REPOSITORY/releases/tags/$TAG" >"$release_json" 2>/dev/null; t
 else
   gh release create "$TAG" --draft --verify-tag \
     --title "LoxBerry MCP Server $VERSION" --notes-file "$NOTES"
-  gh api "repos/$REPOSITORY/releases/tags/$TAG" >"$release_json"
+  load_release >"$release_json"
 fi
 
 expected_title="LoxBerry MCP Server $VERSION"
@@ -69,7 +75,7 @@ for asset in "$ARCHIVE" "$SIDECAR"; do
   fi
 done
 
-gh api "repos/$REPOSITORY/releases/tags/$TAG" >"$release_json"
+load_release >"$release_json"
 for asset in "$ARCHIVE" "$SIDECAR"; do
   name="$(basename "$asset")"
   asset_id="$(jq -r --arg name "$name" '.assets[] | select(.name == $name) | .id' "$release_json")"


### PR DESCRIPTION
Fix the official release workflow to load GitHub draft releases through the CLI, because the releases-by-tag API returns 404 for drafts.\n\nValidation: package workflow regression tests and Bash syntax check.