### PR TITLE
Limit Jalousie slat actions by animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable user-visible changes are recorded here. GitHub release notes are
 extracted from the matching version heading.
 
+## Unreleased
+
+- Restrict Jalousie slat actions to the documented blind animation mode and
+  fail closed for shutters, curtains, unsupported, malformed, or absent modes.
+
 ## 0.4.0-alpha.2 - 2026-08-12
 
 - Canonicalize signed-zero control values, preserve fractional statistic interval

--- a/docs/development/adr/0005-bounded-loxone-controls.md
+++ b/docs/development/adr/0005-bounded-loxone-controls.md
@@ -26,7 +26,9 @@ design comparison and do not override the official contract.
 The normalized operation target comes only from `uuidAction`. A missing target
 or a read-only internal or external restriction makes the control non-operable.
 `details.isAutomatic` is retained only as a boolean capability flag for a
-`Jalousie`; all other details remain excluded from the normalized model.
+`Jalousie`. The documented integer `details.animation` is normalized only when
+it is in the official range 0 through 5; malformed or unknown values are
+discarded. All other details remain excluded from the normalized model.
 
 The existing controls remain unchanged: the tool is disabled by default,
 requires `loxone:read` plus `loxone:control`, resolves an exact UUID in a freshly
@@ -45,7 +47,8 @@ control type and identity:
 | `Dimmer` | `on`, `off`, `set_level` | `on`, `off`, `{position}` |
 | `LightController` | `on`, `off`, `set_mood` | `on`, `off`, `{sceneNumber}` |
 | `LightControllerV2` | `off`, `set_mood` | `changeTo/0`, `changeTo/{moodId}` |
-| `Jalousie` | `open`, `close`, `shade`, `stop`, position actions | `FullUp`, `FullDown`, `shade`, `stop`, `manualPosition`, `manualLamelle`, `manualPosBlind` |
+| `Jalousie` | `open`, `close`, `shade`, `stop`, `set_position` | `FullUp`, `FullDown`, `shade`, `stop`, `manualPosition` |
+| Jalousie with `details.animation = 0` only | plus `set_slat_position`, `set_position_and_slats` | `manualLamelle`, `manualPosBlind` |
 | automatic `Jalousie` | plus `enable_auto`, `disable_auto` | `auto`, `NoAuto` |
 
 Percentages are finite values from 0 through 100. Legacy scenes are decimal
@@ -57,6 +60,11 @@ Parameters must match the selected action exactly; extra and missing parameters
 are rejected. Relative-motion pairs, scene/mood mutation, naming, presence,
 end-position adjustment, expert operations, arbitrary paths, name targets, and
 bulk operations remain unavailable.
+
+Animation 0 is the documented blind mode. A shutter, curtain, unsupported, or
+unknown animation mode never advertises or accepts slat actions. This is a
+fail-closed capability boundary; it does not expose the raw animation value to
+the MCP client.
 
 Command confirmation uses a newer matching official state when a deterministic
 target state exists. Actions without a deterministic documented result can be

--- a/docs/development/phase-4-acceptance.md
+++ b/docs/development/phase-4-acceptance.md
@@ -103,17 +103,25 @@ and confirmed through the visible color state; the original color state was
 then accepted and confirmed as restored. This is fixture-specific acceptance
 evidence and does not make unassigned controls generally eligible for writes.
 
-The dedicated `Jalousie` fixture advertised all documented bounded actions.
-`open`, `set_position`, `set_slat_position`, `set_position_and_slats`, and
-`enable_auto` were accepted and confirmed through their advertised feedback.
-`close`, `shade`, `stop`, and the first `disable_auto` were accepted but their
-immediate feedback did not confirm an effect. A final explicit `disable_auto`
-was accepted and confirmed, restoring the initial automatic-mode state.
+The dedicated `Jalousie` fixture is configured for shutter animation. `open`,
+`set_position`, and `enable_auto` were accepted and confirmed through their
+advertised feedback. `close`, `shade`, `stop`, and the first `disable_auto` were
+accepted but their immediate feedback did not confirm an effect. A final
+explicit `disable_auto` was accepted and confirmed, restoring the initial
+automatic-mode state.
 
-The final position-and-slats restoration command was accepted twice but not
-confirmed; a read-only check still showed the earlier test target. No further
-write was sent automatically. Therefore this record does not claim that the
-initial Jalousie position was restored or that the unconfirmed commands had a
-physical effect.
+The earlier Lamelle and combined-position commands were accepted before the
+fixture's shutter animation was classified. They are not acceptance evidence
+for a shutter configuration and are no longer advertised for this mode. The
+final combined restoration command was not confirmed; no further write was
+sent automatically. Therefore this record does not claim that the initial
+Jalousie position was restored or that the unconfirmed commands had a physical
+effect.
+
+After the focused runtime deployment on 2026-08-12, a read-only description of
+the same fixture advertised `open`, `close`, `shade`, `stop`, `set_position`,
+`enable_auto`, and `disable_auto`, but no Lamelle or combined-position action.
+This confirms the fail-closed capability boundary on the target; no additional
+Jalousie command was dispatched for this check.
 
 Legacy XML/FTP compatibility remains out of scope and disabled.

--- a/docs/development/phase-4-acceptance.md
+++ b/docs/development/phase-4-acceptance.md
@@ -91,10 +91,29 @@ following actions were sent once through the deployed MCP service:
 
 `CentralJalousie`, `ClimateControllerUS`, `Ventilation`, `IRoomControllerV2`,
 the visible sliders/status controls and the `ColorPickerV2` were read on the
-same fixture. The picker advertised `set_color_hsv`, but it has no direct room
-or category assignment; its write path was intentionally not exercised under
-the narrow authorization boundary. V1 variants and every other untested action
-remain unverified. No UUID, control name, state value, address or credential is
-recorded here.
+same fixture. V1 variants and every other untested action remain unverified. No
+UUID, control name, state value, address or credential is recorded here.
+
+### Supplemental controlled-fixture evidence
+
+On 2026-08-12, a visible `ColorPickerV2` subcontrol with no direct room or
+category assignment was operated through its parent `LightControllerV2`, which
+was assigned to both dedicated MCP test groups. `set_color_hsv` was accepted
+and confirmed through the visible color state; the original color state was
+then accepted and confirmed as restored. This is fixture-specific acceptance
+evidence and does not make unassigned controls generally eligible for writes.
+
+The dedicated `Jalousie` fixture advertised all documented bounded actions.
+`open`, `set_position`, `set_slat_position`, `set_position_and_slats`, and
+`enable_auto` were accepted and confirmed through their advertised feedback.
+`close`, `shade`, `stop`, and the first `disable_auto` were accepted but their
+immediate feedback did not confirm an effect. A final explicit `disable_auto`
+was accepted and confirmed, restoring the initial automatic-mode state.
+
+The final position-and-slats restoration command was accepted twice but not
+confirmed; a read-only check still showed the earlier test target. No further
+write was sent automatically. Therefore this record does not claim that the
+initial Jalousie position was restored or that the unconfirmed commands had a
+physical effect.
 
 Legacy XML/FTP compatibility remains out of scope and disabled.

--- a/docs/development/support-matrix.md
+++ b/docs/development/support-matrix.md
@@ -110,9 +110,11 @@ Der vollständige maskierte Nachweis steht im
 - `Jalousie`-`open`, `set_position` und `enable_auto` sind auf der ausdrücklich
   freigegebenen Rolladen-Fixture über ihre sichtbaren Rückmeldungen bestätigt.
   `close`, `shade`, `stop` und der erste `disable_auto`-Aufruf wurden nur
-  akzeptiert. Lamellen- und Kombinationsaktionen werden für diesen Modus nicht
-  angeboten. Die frühere kombinierte Positionsrückführung blieb unbestätigt;
-  es wurde kein weiterer Befehl automatisch wiederholt.
+  akzeptiert; ein abschließendes `disable_auto` wurde bestätigt und stellte den
+  ursprünglichen Automatikzustand wieder her. Lamellen- und Kombinationsaktionen
+  werden für diesen Modus nicht angeboten. Die frühere kombinierte
+  Positionsrückführung blieb unbestätigt; es wurde kein weiterer Befehl
+  automatisch wiederholt.
   `LightsceneRGB` (`on`, `off`), `Radio` (`reset`) und `Pushbutton` (`pulse`)
   bleiben lediglich akzeptiert. Alle übrigen Aktionen bleiben entsprechend der
   User-Doku unverified.

--- a/docs/development/support-matrix.md
+++ b/docs/development/support-matrix.md
@@ -107,20 +107,24 @@ Der vollständige maskierte Nachweis steht im
 - `Dimmer` (`set_level`, `off`), `LightControllerV2` (`set_mood`) und
   `TimedSwitch` (`on`, `off`) sind an ausdrücklich freigegebenen, harmlosen
   Fixtures real bestätigt und jeweils in den Ausgangszustand zurückgeführt.
-- `Jalousie` (`stop`), `LightsceneRGB` (`on`, `off`), `Radio` (`reset`) und
-  `Pushbutton` (`pulse`) wurden real akzeptiert, ohne dass die jeweils sichtbare
-  Rückmeldung eine Wirkung bestätigen konnte. Alle übrigen Aktionen bleiben
-  entsprechend der User-Doku unverified.
+- `Jalousie`-`open`, Positions-, Lamellen- und Kombinationsaktionen sowie
+  `enable_auto` sind auf der ausdrücklich freigegebenen Fixture über ihre
+  sichtbaren Rückmeldungen bestätigt. `close`, `shade`, `stop` und der erste
+  `disable_auto`-Aufruf wurden nur akzeptiert. Die abschließende
+  Positionsrückführung blieb nach zwei akzeptierten, aber unbestätigten
+  Befehlen offen; es wurde kein weiterer Befehl automatisch wiederholt.
+  `LightsceneRGB` (`on`, `off`), `Radio` (`reset`) und `Pushbutton` (`pulse`)
+  bleiben lediglich akzeptiert. Alle übrigen Aktionen bleiben entsprechend der
+  User-Doku unverified.
 - Die klassische Binärstatistik (`statistic.outputs`, Rohabruf), eine
   `StatisticV2`-Serie und die Control-Historie sind an sichtbaren Controls real
   lesend bestätigt. Die lokal freigegebene, ausschließlich plugin-eigene
-  Cache-Leerung ist ebenfalls bestätigt. `ColorPickerV2` ist auf derselben
-  Fixture lesend bestätigt und bot `set_color_hsv`; mangels eigener
-  Raum-/Kategoriezuordnung wurde sein Write-Pfad nicht getestet. `ColorPicker`
-  (V1), nicht ausgeführte Aktionen und Control-Hinweise bleiben unverified. Für
-  Hinweise wurde in dieser Installation noch kein Control mit dem
-  Verfügbarkeitsmerkmal gefunden. Legacy-XML und
-  FTP-Statistik sind nicht aktiv.
+  Cache-Leerung ist ebenfalls bestätigt. Ein `ColorPickerV2`-Subcontrol ohne
+  eigene Raum-/Kategoriezuordnung ist über seinen beidseitig zugeordneten
+  `LightControllerV2`-Parent real mit `set_color_hsv` bestätigt und in den
+  Ausgangszustand zurückgeführt. `ColorPicker` (V1) und nicht ausgeführte
+  Aktionen bleiben unverified. Control-Hinweise sind durch einen begrenzten
+  realen Abruf bestätigt. Legacy-XML und FTP-Statistik sind nicht aktiv.
 - Die lokale Python-3.13-Full-Prüfung mit 466 Tests und das finale PR-CI-Gate
   sind bestanden. Die Clients-/Sitzungen-Bindungstabellen wurden mit einer
   authentifizierten Admin-Sitzung bei allen dokumentierten fünf Viewports ohne

--- a/docs/development/support-matrix.md
+++ b/docs/development/support-matrix.md
@@ -107,12 +107,12 @@ Der vollständige maskierte Nachweis steht im
 - `Dimmer` (`set_level`, `off`), `LightControllerV2` (`set_mood`) und
   `TimedSwitch` (`on`, `off`) sind an ausdrücklich freigegebenen, harmlosen
   Fixtures real bestätigt und jeweils in den Ausgangszustand zurückgeführt.
-- `Jalousie`-`open`, Positions-, Lamellen- und Kombinationsaktionen sowie
-  `enable_auto` sind auf der ausdrücklich freigegebenen Fixture über ihre
-  sichtbaren Rückmeldungen bestätigt. `close`, `shade`, `stop` und der erste
-  `disable_auto`-Aufruf wurden nur akzeptiert. Die abschließende
-  Positionsrückführung blieb nach zwei akzeptierten, aber unbestätigten
-  Befehlen offen; es wurde kein weiterer Befehl automatisch wiederholt.
+- `Jalousie`-`open`, `set_position` und `enable_auto` sind auf der ausdrücklich
+  freigegebenen Rolladen-Fixture über ihre sichtbaren Rückmeldungen bestätigt.
+  `close`, `shade`, `stop` und der erste `disable_auto`-Aufruf wurden nur
+  akzeptiert. Lamellen- und Kombinationsaktionen werden für diesen Modus nicht
+  angeboten. Die frühere kombinierte Positionsrückführung blieb unbestätigt;
+  es wurde kein weiterer Befehl automatisch wiederholt.
   `LightsceneRGB` (`on`, `off`), `Radio` (`reset`) und `Pushbutton` (`pulse`)
   bleiben lediglich akzeptiert. Alle übrigen Aktionen bleiben entsprechend der
   User-Doku unverified.

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -284,12 +284,12 @@ Umbenennungs-, Experten- oder freien Kommandos.
 | Beleuchtung | `LightController` (V1) | ja | ja | `on`, `off`, `set_mood` | anhand offizieller Doku, nicht real verifiziert |
 | Beleuchtung | `LightControllerV2` | ja | ja | `off`, `set_mood` nur mit sichtbarer Mood-ID | real bestätigt: `set_mood`; Ausgangsstimmung wiederhergestellt |
 | Beleuchtung | `ColorPicker` (V1) | ja | ja | je Picker-Typ `on`, `off`, `set_color_hsv`, `set_color_temperature` | anhand offizieller Doku, nicht real verifiziert |
-| Beleuchtung | `ColorPickerV2` | ja | ja | je Picker-Typ `set_color_hsv`, `set_color_temperature` | Lesen real bestätigt; Write nicht real bestätigt, weil der Picker keine direkte Testzuordnung besitzt |
+| Beleuchtung | `ColorPickerV2` | ja | ja | je Picker-Typ `set_color_hsv`, `set_color_temperature` | real bestätigt: `set_color_hsv` an einem Subcontrol über seinen beidseitig zugeordneten Test-Parent; Ausgangsfarbe wiederhergestellt |
 | Beleuchtung | `LightsceneRGB` | ja | ja | `on`, `off`, `set_scene` nur mit sichtbarer Szenen-ID | Befehl real akzeptiert: `on`, `off`; Wirkung nicht über Feedback bestätigt |
 | Beleuchtung | `Pushbutton` | ja | ja | `pulse` | Befehl real akzeptiert; Wirkung nicht über Feedback bestätigt |
 | Beleuchtung | `Radio` | ja | ja | `select_output`; `reset` nur bei sichtbarem `allOff` | Befehl real akzeptiert: `reset`; `select_output` nicht real bestätigt |
 | Beleuchtung | `TimedSwitch` | ja | ja | `on`, `off`, `pulse` | real bestätigt: `on`, `off`; Ausgangszustand wiederhergestellt; `pulse` Vertrag getestet |
-| Beschattung | `Jalousie` | ja | ja | `open`, `close`, `shade`, `stop`, Position/Lamellen; Auto nur falls angeboten | Befehl real akzeptiert: `stop`; Wirkung nicht über Feedback bestätigt |
+| Beschattung | `Jalousie` | ja | ja | `open`, `close`, `shade`, `stop`, Position/Lamellen; Auto nur falls angeboten | real bestätigt: `open`, Position/Lamellen und `enable_auto`; `close`, `shade`, `stop` nur akzeptiert. Die abschließende Positionsrückführung blieb unbestätigt |
 | Beschattung | `CentralJalousie` | ja | nein | – | Lesen real bestätigt |
 | Klima/Lüftung | `IRoomControllerV2`, `IRCV2Daytimer`, `Ventilation`, `Daytimer` | ja | nein | – | in eigener Installation lesend prüfbar |
 | Klima/Lüftung | `ClimateControllerUS` | ja | nein | – | Lesen real bestätigt |

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -289,7 +289,7 @@ Umbenennungs-, Experten- oder freien Kommandos.
 | Beleuchtung | `Pushbutton` | ja | ja | `pulse` | Befehl real akzeptiert; Wirkung nicht über Feedback bestätigt |
 | Beleuchtung | `Radio` | ja | ja | `select_output`; `reset` nur bei sichtbarem `allOff` | Befehl real akzeptiert: `reset`; `select_output` nicht real bestätigt |
 | Beleuchtung | `TimedSwitch` | ja | ja | `on`, `off`, `pulse` | real bestätigt: `on`, `off`; Ausgangszustand wiederhergestellt; `pulse` Vertrag getestet |
-| Beschattung | `Jalousie` | ja | ja | `open`, `close`, `shade`, `stop`, Position; Lamellen nur bei `details.animation = 0`; Auto nur falls angeboten | real bestätigt am Rolladenmodus: `open`, `set_position` und `enable_auto`; `close`, `shade`, `stop` nur akzeptiert. Lamellenaktionen sind dort nicht anwendbar |
+| Beschattung | `Jalousie` | ja | ja | `open`, `close`, `shade`, `stop`, Position; Lamellen nur bei `details.animation = 0`; Auto nur falls angeboten | real bestätigt am Rolladenmodus: `open`, `set_position`, `enable_auto` und abschließendes `disable_auto`; `close`, `shade`, `stop` nur akzeptiert. Lamellenaktionen sind dort nicht anwendbar |
 | Beschattung | `CentralJalousie` | ja | nein | – | Lesen real bestätigt |
 | Klima/Lüftung | `IRoomControllerV2`, `IRCV2Daytimer`, `Ventilation`, `Daytimer` | ja | nein | – | in eigener Installation lesend prüfbar |
 | Klima/Lüftung | `ClimateControllerUS` | ja | nein | – | Lesen real bestätigt |

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -289,7 +289,7 @@ Umbenennungs-, Experten- oder freien Kommandos.
 | Beleuchtung | `Pushbutton` | ja | ja | `pulse` | Befehl real akzeptiert; Wirkung nicht über Feedback bestätigt |
 | Beleuchtung | `Radio` | ja | ja | `select_output`; `reset` nur bei sichtbarem `allOff` | Befehl real akzeptiert: `reset`; `select_output` nicht real bestätigt |
 | Beleuchtung | `TimedSwitch` | ja | ja | `on`, `off`, `pulse` | real bestätigt: `on`, `off`; Ausgangszustand wiederhergestellt; `pulse` Vertrag getestet |
-| Beschattung | `Jalousie` | ja | ja | `open`, `close`, `shade`, `stop`, Position/Lamellen; Auto nur falls angeboten | real bestätigt: `open`, Position/Lamellen und `enable_auto`; `close`, `shade`, `stop` nur akzeptiert. Die abschließende Positionsrückführung blieb unbestätigt |
+| Beschattung | `Jalousie` | ja | ja | `open`, `close`, `shade`, `stop`, Position; Lamellen nur bei `details.animation = 0`; Auto nur falls angeboten | real bestätigt am Rolladenmodus: `open`, `set_position` und `enable_auto`; `close`, `shade`, `stop` nur akzeptiert. Lamellenaktionen sind dort nicht anwendbar |
 | Beschattung | `CentralJalousie` | ja | nein | – | Lesen real bestätigt |
 | Klima/Lüftung | `IRoomControllerV2`, `IRCV2Daytimer`, `Ventilation`, `Daytimer` | ja | nein | – | in eigener Installation lesend prüfbar |
 | Klima/Lüftung | `ClimateControllerUS` | ja | nein | – | Lesen real bestätigt |
@@ -297,7 +297,10 @@ Umbenennungs-, Experten- oder freien Kommandos.
 | Sensorik/Status | `InfoOnlyAnalog`, `InfoOnlyDigital`, `InfoOnlyText`, `TextState`, `StatusMonitor`, `WindowMonitor`, `SmokeAlarm`, `Tracker` | ja | nein | – | in eigener Installation lesend prüfbar |
 | Energie/sonstige | `Meter`, `EFM`, `PvProductionForecast`, `Slider`, `Webpage` | ja | nein | – | in eigener Installation lesend prüfbar |
 
-„Lesen“ umfasst nur sichtbare Struktur und Zustände. Historie ist zusätzlich nur
+„Lesen“ umfasst nur sichtbare Struktur und Zustände. Bei `Jalousie` werden
+`set_slat_position` und `set_position_and_slats` nur angeboten, wenn die sichtbare
+Loxone-Struktur `details.animation = 0` (Jalousie/Raffstore) meldet; unbekannte
+oder andere Animationen bleiben auf Positionssteuerung begrenzt. Historie ist zusätzlich nur
 verfügbar, wenn das Control `hasHistory`, `statisticV2` beziehungsweise `statistic` meldet und
 der Client `loxone:history` erhalten hat. V1-Typen bleiben bewusst als **nicht
 verifiziert** markiert, bis ein realer Abnahmetest vorliegt.

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -269,7 +269,7 @@ room, bulk, learning, rename, expert, or free-form commands.
 | Lighting | `Pushbutton` | yes | yes | `pulse` | hardware command accepted; feedback did not confirm the effect |
 | Lighting | `Radio` | yes | yes | `select_output`; `reset` only with visible `allOff` | hardware command accepted: `reset`; `select_output` not hardware-confirmed |
 | Lighting | `TimedSwitch` | yes | yes | `on`, `off`, `pulse` | hardware confirmed: `on`, `off`; initial state restored; `pulse` contract tested |
-| Shading | `Jalousie` | yes | yes | open/close/shade/stop, position; slats only with `details.animation = 0`; auto only when advertised | hardware confirmed in shutter mode: `open`, `set_position`, and `enable_auto`; `close`, `shade`, and `stop` only accepted. Slat actions do not apply there |
+| Shading | `Jalousie` | yes | yes | open/close/shade/stop, position; slats only with `details.animation = 0`; auto only when advertised | hardware confirmed in shutter mode: `open`, `set_position`, `enable_auto`, and the final `disable_auto`; `close`, `shade`, and `stop` only accepted. Slat actions do not apply there |
 | Shading | `CentralJalousie` | yes | no | – | hardware read confirmed |
 | Climate/ventilation | `IRoomControllerV2`, `IRCV2Daytimer`, `Ventilation`, `Daytimer` | yes | no | – | readable in the maintainer installation |
 | Climate/ventilation | `ClimateControllerUS` | yes | no | – | hardware read confirmed |

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -269,7 +269,7 @@ room, bulk, learning, rename, expert, or free-form commands.
 | Lighting | `Pushbutton` | yes | yes | `pulse` | hardware command accepted; feedback did not confirm the effect |
 | Lighting | `Radio` | yes | yes | `select_output`; `reset` only with visible `allOff` | hardware command accepted: `reset`; `select_output` not hardware-confirmed |
 | Lighting | `TimedSwitch` | yes | yes | `on`, `off`, `pulse` | hardware confirmed: `on`, `off`; initial state restored; `pulse` contract tested |
-| Shading | `Jalousie` | yes | yes | open/close/shade/stop, position/slats; auto only when advertised | hardware confirmed: `open`, position/slats, and `enable_auto`; `close`, `shade`, and `stop` only accepted. The final position restoration remained unconfirmed |
+| Shading | `Jalousie` | yes | yes | open/close/shade/stop, position; slats only with `details.animation = 0`; auto only when advertised | hardware confirmed in shutter mode: `open`, `set_position`, and `enable_auto`; `close`, `shade`, and `stop` only accepted. Slat actions do not apply there |
 | Shading | `CentralJalousie` | yes | no | – | hardware read confirmed |
 | Climate/ventilation | `IRoomControllerV2`, `IRCV2Daytimer`, `Ventilation`, `Daytimer` | yes | no | – | readable in the maintainer installation |
 | Climate/ventilation | `ClimateControllerUS` | yes | no | – | hardware read confirmed |
@@ -277,7 +277,10 @@ room, bulk, learning, rename, expert, or free-form commands.
 | Sensors/status | `InfoOnlyAnalog`, `InfoOnlyDigital`, `InfoOnlyText`, `TextState`, `StatusMonitor`, `WindowMonitor`, `SmokeAlarm`, `Tracker` | yes | no | – | readable in the maintainer installation |
 | Energy/other | `Meter`, `EFM`, `PvProductionForecast`, `Slider`, `Webpage` | yes | no | – | readable in the maintainer installation |
 
-“Read” means only visible structure and states. History additionally requires
+“Read” means only visible structure and states. For `Jalousie`,
+`set_slat_position` and `set_position_and_slats` are offered only when the visible
+Loxone structure reports `details.animation = 0` (blinds); unknown or other
+animations remain limited to position control. History additionally requires
 `hasHistory`, `statisticV2`, or `statistic` on the control and a granted `loxone:history`
 scope. V1 types deliberately remain marked **unverified** until a real
 acceptance run exists.

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -264,12 +264,12 @@ room, bulk, learning, rename, expert, or free-form commands.
 | Lighting | `LightController` (V1) | yes | yes | `on`, `off`, `set_mood` | official documentation; not hardware-verified |
 | Lighting | `LightControllerV2` | yes | yes | `off`, `set_mood` with a visible mood ID | hardware confirmed: `set_mood`; initial mood restored |
 | Lighting | `ColorPicker` (V1) | yes | yes | by picker type: `on`, `off`, `set_color_hsv`, `set_color_temperature` | official documentation; not hardware-verified |
-| Lighting | `ColorPickerV2` | yes | yes | by picker type: `set_color_hsv`, `set_color_temperature` | hardware read confirmed; write not hardware-confirmed because the picker has no direct test assignment |
+| Lighting | `ColorPickerV2` | yes | yes | by picker type: `set_color_hsv`, `set_color_temperature` | hardware confirmed: `set_color_hsv` on a subcontrol through its test-assigned parent; initial color restored |
 | Lighting | `LightsceneRGB` | yes | yes | `on`, `off`, `set_scene` with a visible scene ID | hardware command accepted: `on`, `off`; feedback did not confirm the effect |
 | Lighting | `Pushbutton` | yes | yes | `pulse` | hardware command accepted; feedback did not confirm the effect |
 | Lighting | `Radio` | yes | yes | `select_output`; `reset` only with visible `allOff` | hardware command accepted: `reset`; `select_output` not hardware-confirmed |
 | Lighting | `TimedSwitch` | yes | yes | `on`, `off`, `pulse` | hardware confirmed: `on`, `off`; initial state restored; `pulse` contract tested |
-| Shading | `Jalousie` | yes | yes | open/close/shade/stop, position/slats; auto only when advertised | hardware command accepted: `stop`; feedback did not confirm the effect |
+| Shading | `Jalousie` | yes | yes | open/close/shade/stop, position/slats; auto only when advertised | hardware confirmed: `open`, position/slats, and `enable_auto`; `close`, `shade`, and `stop` only accepted. The final position restoration remained unconfirmed |
 | Shading | `CentralJalousie` | yes | no | – | hardware read confirmed |
 | Climate/ventilation | `IRoomControllerV2`, `IRCV2Daytimer`, `Ventilation`, `Daytimer` | yes | no | – | readable in the maintainer installation |
 | Climate/ventilation | `ClimateControllerUS` | yes | no | – | hardware read confirmed |

--- a/src/mcpserver/loxone/control.py
+++ b/src/mcpserver/loxone/control.py
@@ -77,9 +77,9 @@ def allowed_actions(control: Control) -> list[str]:
                 "shade",
                 "stop",
                 "set_position",
-                "set_slat_position",
-                "set_position_and_slats",
             ]
+            if control.shading_animation == 0:
+                actions.extend(["set_slat_position", "set_position_and_slats"])
             if control.is_automatic:
                 actions.extend(["enable_auto", "disable_auto"])
             return actions

--- a/src/mcpserver/loxone/models.py
+++ b/src/mcpserver/loxone/models.py
@@ -59,6 +59,7 @@ class Control:
     secured: bool = False
     has_notes: bool = False
     is_automatic: bool = False
+    shading_animation: int | None = None
     has_history: bool = False
     picker_type: str | None = None
     min_kelvin: int = 2700

--- a/src/mcpserver/loxone/structure.py
+++ b/src/mcpserver/loxone/structure.py
@@ -219,6 +219,13 @@ def _controls(value: object, *, referenced: bool = False) -> tuple[Control, ...]
         is_automatic = details.get("isAutomatic", False)
         if not isinstance(is_automatic, bool):
             raise LoxoneStructureError("Control details.isAutomatic must be boolean")
+        shading_animation = details.get("animation")
+        if (
+            not isinstance(shading_animation, int)
+            or isinstance(shading_animation, bool)
+            or shading_animation not in {0, 1, 2, 3, 4, 5}
+        ):
+            shading_animation = None
         has_history = _history_capability(details.get("hasHistory", False))
         picker_type = details.get("pickerType")
         if not isinstance(picker_type, str) or len(picker_type) > 32:
@@ -248,6 +255,7 @@ def _controls(value: object, *, referenced: bool = False) -> tuple[Control, ...]
                     item.get("hasControlNotes", False), field="hasControlNotes"
                 ),
                 is_automatic=is_automatic,
+                shading_animation=shading_animation,
                 has_history=has_history,
                 picker_type=picker_type,
                 min_kelvin=min_kelvin,

--- a/tests/test_control_commands.py
+++ b/tests/test_control_commands.py
@@ -79,6 +79,8 @@ def test_official_commands_are_mapped_without_raw_command_input(
     options: dict[str, object] = {}
     if control_type == "Radio":
         options["radio_output_ids"] = ("2",)
+    elif control_type == "Jalousie":
+        options["shading_animation"] = 0
     elif control_type == "LightsceneRGB":
         options["scene_ids"] = ("3",)
     elif control_type == "ColorPickerV2":
@@ -92,6 +94,32 @@ def test_automatic_actions_are_advertised_only_for_automatic_jalousie() -> None:
     assert "enable_auto" not in allowed_actions(_control("Jalousie"))
     assert "enable_auto" in allowed_actions(_control("Jalousie", automatic=True))
     assert allowed_actions(_control("Jalousie", automatic=True, read_only=True)) == []
+
+
+@pytest.mark.parametrize("animation", (None, 1, 2, 3, 4, 5))
+@pytest.mark.parametrize(
+    ("action", "kwargs"),
+    [
+        ("set_slat_position", {"slat_position": 50}),
+        ("set_position_and_slats", {"position": 50, "slat_position": 50}),
+    ],
+)
+def test_jalousie_without_blind_animation_rejects_slat_actions(
+    animation: int | None, action: str, kwargs: dict[str, int]
+) -> None:
+    control = _control("Jalousie", shading_animation=animation)
+
+    assert "set_slat_position" not in allowed_actions(control)
+    assert "set_position_and_slats" not in allowed_actions(control)
+    with pytest.raises(ValueError, match="not supported"):
+        prepare_control_command(control, action, **kwargs)
+
+
+def test_blind_animation_advertises_slat_actions() -> None:
+    control = _control("Jalousie", shading_animation=0)
+
+    assert "set_slat_position" in allowed_actions(control)
+    assert "set_position_and_slats" in allowed_actions(control)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_loxone_structure.py
+++ b/tests/test_loxone_structure.py
@@ -74,7 +74,7 @@ def test_structure_preserves_operability_flags_without_exposing_details() -> Non
                 "type": "Jalousie",
                 "uuidAction": "blind-action",
                 "restrictions": 32,
-                "details": {"isAutomatic": True, "private": "ignored"},
+                "details": {"isAutomatic": True, "animation": 1, "private": "ignored"},
                 "states": {},
             }
         },
@@ -85,7 +85,31 @@ def test_structure_preserves_operability_flags_without_exposing_details() -> Non
     assert control.action_uuid == "blind-action"
     assert control.read_only is True
     assert control.is_automatic is True
+    assert control.shading_animation == 1
     assert "private" not in repr(control)
+
+
+@pytest.mark.parametrize("animation", (True, False, -1, 6, "0", 0.0))
+def test_structure_ignores_invalid_jalousie_animation_values(animation: object) -> None:
+    raw = {
+        "lastModified": "now",
+        "msInfo": {"serialNr": "000000000000"},
+        "rooms": {},
+        "cats": {},
+        "controls": {
+            "blind": {
+                "name": "Blind",
+                "type": "Jalousie",
+                "uuidAction": "blind-action",
+                "details": {"animation": animation},
+                "states": {},
+            }
+        },
+    }
+
+    control = normalize_structure(raw, username="reader").controls[0]
+
+    assert control.shading_animation is None
 
 
 def test_absent_controls_remain_absent() -> None:


### PR DESCRIPTION
## Änderungen

- Normalisiert die dokumentierte Jalousie-Animation fail-closed und bietet Lamellen- bzw. Kombinationsaktionen nur für Animation `0` an.
- Verhindert dadurch `manualLamelle` und `manualPosBlind` für Rolladen, Vorhänge sowie unbekannte oder fehlerhafte Animationen.
- Ergänzt Regressionstests, ADR, Changelog, User Guides, Support-Matrix und die Phase-4-Abnahme.

## Ursache und Auswirkung

Die bisherigen Aktionen wurden für jede Jalousie angeboten. Ein im Rolladenmodus konfiguriertes Test-Control konnte deshalb Lamellenaktionen erhalten, obwohl diese für den Modus nicht gelten.

## Prüfung

- `git diff --check`
- Format, Ruff, Mypy und 485 Tests lokal grün (Python 3.12-Projektumgebung)
- `tools/test.py --profile changed` wählt wegen Changelog den Full-Pfad, verlangt dafür Python 3.13; die lokale Umgebung konnte diesen Interpreter nicht auflösen.
- Gezielter Hot-Swap der drei Laufzeitdateien auf Loxberry-Test mit erfolgreichem Health-Nachweis.
- Danach bestätigte eine rein lesende Beschreibung der MCP-Test-Rolladenfixture, dass Lamellen- und Kombinationsaktionen nicht mehr angeboten werden. Kein weiterer Jalousie-Befehl wurde ausgelöst.

CI läuft auf dem gepushten Commit mit Python 3.13.