### PR TITLE
Add bounded LoxAPP3 control support for alpha.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@
 All notable user-visible changes are recorded here. GitHub release notes are
 extracted from the matching version heading.
 
-## Unreleased
+## 0.4.0-alpha.3 - 2026-08-13
 
+- Preserve all bounded non-negative Loxone ratings, expose the independent
+  favorite marker, and extend the bounded operation allowlist to virtual analog
+  inputs, CentralJalousie, and digital Daytimer overrides.
 - Discover explicitly user-linked controls as `visibility: "linked"`, describe
   both directions of the link, and support the bounded `UpDownAnalog.set_value`
   action when the linked control is currently visible and authorized.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Für jeden Assistenten sollte ein eigener Loxone-Benutzer mit den minimal erford
 ## Projektstatus
 
 Phase 1 bis Phase 3 sind abgenommen. Der vorbereitete Phase-4-Pre-Release
-`0.4.0-alpha.2` erweitert das Schreibwerkzeug auf Gen.-1-Controls vom Typ
+`0.4.0-alpha.3` erweitert das Schreibwerkzeug auf Gen.-1-Controls vom Typ
 `Switch`, `Dimmer`, `LightController`, `LightControllerV2`, `Jalousie`,
 `TimedSwitch`, `Radio`, `LightsceneRGB`, `ColorPicker`, `ColorPickerV2` und
 `Pushbutton`. Es bleibt

--- a/docs/development/adr/0008-bounded-virtual-and-daytimer-controls.md
+++ b/docs/development/adr/0008-bounded-virtual-and-daytimer-controls.md
@@ -1,0 +1,33 @@
+# ADR 0008: Bounded virtual-input, central-shading and Daytimer controls
+
+- **Status:** accepted
+- **Date:** 2026-08-13
+
+## Decision
+
+`loxone_operate_control` is extended, without adding a raw-command input, for
+three narrowly bounded families visible in the user-filtered structure:
+
+- `Slider` and `LeftRightAnalog` reuse `set_value` only when the visible
+  `min`, `max`, and `step` form a valid range.
+- `CentralJalousie` accepts only documented whole-group commands: `open`,
+  `close`, `shade`, `stop`, `enable_auto`, and `disable_auto`.
+- A digital `Daytimer` accepts only `pulse`, `start_override` with a value of
+  zero or one and a duration from one second through 24 hours, and
+  `stop_override`. Calendar-entry and mode-list changes are excluded.
+
+All existing OAuth, local enablement, current-structure validation, rate-limit,
+audit, and no-retry rules apply. Virtual inputs and Daytimer overrides require
+their advertised state for confirmation. A CentralJalousie has no documented
+equivalent confirmation state in the current structure, so its result remains
+explicitly accepted-but-unconfirmed unless a future documented state proves it.
+
+`defaultRating` remains a bounded non-negative presentation value; it is not a
+five-star value. The distinct LoxAPP3 `isFavorite` flag is exposed separately.
+
+## Consequences
+
+Climate, ventilation, alarms, locks, schedule editing, secured details, and
+global operating-mode administration remain read-only or unavailable. They
+need their own parameter model, authorization review and hardware acceptance;
+this decision does not infer them from LoxAPP3 visibility.

--- a/docs/development/phase-4-acceptance.md
+++ b/docs/development/phase-4-acceptance.md
@@ -125,3 +125,14 @@ This confirms the fail-closed capability boundary on the target; no additional
 Jalousie command was dispatched for this check.
 
 Legacy XML/FTP compatibility remains out of scope and disabled.
+
+## Alpha 3 bounded-control acceptance
+
+On 2026-08-13, the focused plugin-owned deployment passed its retained-backup
+and health checks on the authorized LoxBerry test target. A `Slider` in the
+dedicated MCP test room and category accepted `set_value`, confirmed the new
+state, and then confirmed restoration of its initial value. A
+`CentralJalousie.stop` command in the same intersection was accepted. Its
+documented structure has no state suitable for confirmation, so this is only
+command-accepted evidence. No digital Daytimer exists in the authorized test
+intersection; Daytimer override actions remain hardware-unverified.

--- a/docs/development/support-matrix.md
+++ b/docs/development/support-matrix.md
@@ -1,13 +1,13 @@
 # Support-Matrix
 
 - **Stand:** Phase-4-Implementierung, 2026-08-12
-- **Vorbereiteter Pre-Release:** `0.4.0-alpha.2`
+- **Vorbereiteter Pre-Release:** `0.4.0-alpha.3`
 - **Nächster Meilenstein:** gezielte reale Abnahme der noch unbestätigten
   Phase-4-Aktionen und V1-Varianten
 
 Diese Matrix unterscheidet reale Nachweise von implementierten, aber noch nicht
 real bestätigten Kombinationen. Phase 1, Phase 2 und Phase 3 sind abgenommen;
-`0.4.0-alpha.2` bleibt wegen seines Vorabversionsstatus ein Pre-Release.
+`0.4.0-alpha.3` bleibt wegen seines Vorabversionsstatus ein Pre-Release.
 Phase 4 ist implementiert und für die lesenden Statistik-/Historienpfade, die
 eng begrenzte plugin-eigene Cache-Operation und ausgewählte, reversible
 Control-Aktionen auf Hardware abgenommen; siehe

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -1,4 +1,4 @@
-# LoxBerry MCP Server 0.4.0-alpha.2
+# LoxBerry MCP Server 0.4.0-alpha.3
 
 ## Voraussetzungen
 
@@ -267,14 +267,14 @@ Subcontrol nennt unter `relationships.parent` seinen sichtbaren Parent; ein
 Parent listet sichtbare direkte Subcontrols unter `relationships.subcontrols`.
 Jeder Eintrag enthält UUID, Name und Typ und kann anschließend gezielt beschrieben
 werden. Darüber hinaus liefert das Tool Loxone-Darstellungsmetadaten: Bewertung,
-Passwortschutz, Nur-Lesen-Status und ob Control-Hinweise vorhanden sind.
+Favoriten-Markierung, Passwortschutz, Nur-Lesen-Status und ob Control-Hinweise vorhanden sind.
 Explizite Benutzerverlinkungen aus dem Loxone-Feld `links` stehen getrennt unter
 `relationships.linked_controls`; das Ziel nennt die sichtbaren Verlinker unter
 `relationships.linked_by`. Solche Controls erscheinen in Suchergebnissen mit
 `visibility: "linked"`, sind über ihren eigenen Namen auffindbar und für Zustände,
 Notes, Historie, Statistik und die bestehende Aktions-Allowlist genauso verfügbar
 wie andere sichtbare Controls.
-Bei `UpDownAnalog` stehen die Min-/Max-Grenzen und der Schritt für `set_value`
+Bei `UpDownAnalog`, `Slider` und `LeftRightAnalog` stehen die Min-/Max-Grenzen und der Schritt für `set_value`
 unter `capabilities.analog_range`.
 Bei `StatusMonitor` liefert `capabilities.status_monitor` die stabilen
 Input-Positionen mit lesbaren Namen und die konfigurierten Status-IDs. Der
@@ -314,10 +314,11 @@ Umbenennungs-, Experten- oder freien Kommandos.
 | Beleuchtung | `Pushbutton` | ja | ja | `pulse` | Befehl real akzeptiert; Wirkung nicht über Feedback bestätigt |
 | Beleuchtung | `Radio` | ja | ja | `select_output`; `reset` nur bei sichtbarem `allOff` | Befehl real akzeptiert: `reset`; `select_output` nicht real bestätigt |
 | Beleuchtung | `TimedSwitch` | ja | ja | `on`, `off`, `pulse` | real bestätigt: `on`, `off`; Ausgangszustand wiederhergestellt; `pulse` Vertrag getestet |
-| Allgemein | `UpDownAnalog` | ja | ja | `set_value` innerhalb der sichtbaren Min-/Max-Grenzen | Implementiert und automatisiert getestet; noch nicht hardware-verifiziert |
+| Allgemein | `UpDownAnalog`, `Slider`, `LeftRightAnalog` | ja | ja | `set_value` innerhalb der sichtbaren Min-/Max-Grenzen | `Slider.set_value` real bestätigt und Ausgangswert wiederhergestellt; übrige Typen automatisiert getestet |
 | Beschattung | `Jalousie` | ja | ja | `open`, `close`, `shade`, `stop`, Position; Lamellen nur bei `details.animation = 0`; Auto nur falls angeboten | real bestätigt am Rolladenmodus: `open`, `set_position`, `enable_auto` und abschließendes `disable_auto`; `close`, `shade`, `stop` nur akzeptiert. Lamellenaktionen sind dort nicht anwendbar |
-| Beschattung | `CentralJalousie` | ja | nein | – | Lesen real bestätigt |
-| Klima/Lüftung | `IRoomControllerV2`, `IRCV2Daytimer`, `Ventilation`, `Daytimer` | ja | nein | – | in eigener Installation lesend prüfbar |
+| Beschattung | `CentralJalousie` | ja | ja | `open`, `close`, `shade`, `stop`, `enable_auto`, `disable_auto` | `stop` real akzeptiert; die Struktur liefert keinen Bestätigungs-State |
+| Klima/Lüftung | digitaler `Daytimer` | ja | ja | `pulse`, zeitlich begrenztes `start_override`, `stop_override`; keine Kalender- oder Mode-Listen-Änderung | Implementiert und automatisiert getestet; noch nicht hardware-verifiziert |
+| Klima/Lüftung | `IRoomControllerV2`, `IRCV2Daytimer`, `Ventilation` | ja | nein | – | in eigener Installation lesend prüfbar |
 | Klima/Lüftung | `ClimateControllerUS` | ja | nein | – | Lesen real bestätigt |
 | Klima/Lüftung | entsprechende V1-Typen, sofern vom Miniserver sichtbar | ja | nein | – | generischer Lesepfad, nicht real verifiziert |
 | Sensorik/Status | `InfoOnlyAnalog`, `InfoOnlyDigital`, `InfoOnlyText`, `TextState`, `StatusMonitor`, `WindowMonitor`, `SmokeAlarm`, `Tracker` | ja | nein | – | in eigener Installation lesend prüfbar |

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -1,4 +1,4 @@
-# LoxBerry MCP Server 0.4.0-alpha.2
+# LoxBerry MCP Server 0.4.0-alpha.3
 
 ## Requirements
 
@@ -248,7 +248,7 @@ source files. Legacy XML and FTP are not used.
 names its visible parent under `relationships.parent`, and a parent lists visible
 direct subcontrols under `relationships.subcontrols`. Each reference contains its
 UUID, name, and type and can then be described directly. The tool also returns
-Loxone presentation metadata: rating, password protection, read-only status, and
+Loxone presentation metadata: rating, favorite marker, password protection, read-only status, and
 whether control notes are available. Call `loxone_get_control_notes` only when
 `presentation.has_notes` is `true`.
 Explicit user links from Loxone's `links` field are reported separately under
@@ -256,7 +256,7 @@ Explicit user links from Loxone's `links` field are reported separately under
 `relationships.linked_by`. Such controls appear in search results with
 `visibility: "linked"`, can be found by their own name, and use states, notes,
 history, statistics, and the existing action allowlist like other visible controls.
-For `UpDownAnalog`, the min/max bounds and step for `set_value` are available
+For `UpDownAnalog`, `Slider`, and `LeftRightAnalog`, the min/max bounds and step for `set_value` are available
 under `capabilities.analog_range`.
 For `StatusMonitor`, `capabilities.status_monitor` provides stable input
 positions with readable names and the configured status IDs. Map the
@@ -291,10 +291,11 @@ room, bulk, learning, rename, expert, or free-form commands.
 | Lighting | `Pushbutton` | yes | yes | `pulse` | hardware command accepted; feedback did not confirm the effect |
 | Lighting | `Radio` | yes | yes | `select_output`; `reset` only with visible `allOff` | hardware command accepted: `reset`; `select_output` not hardware-confirmed |
 | Lighting | `TimedSwitch` | yes | yes | `on`, `off`, `pulse` | hardware confirmed: `on`, `off`; initial state restored; `pulse` contract tested |
-| General | `UpDownAnalog` | yes | yes | `set_value` within the visible min/max bounds | Implemented and automatically tested; not hardware-verified yet |
+| General | `UpDownAnalog`, `Slider`, `LeftRightAnalog` | yes | yes | `set_value` within the visible min/max bounds | `Slider.set_value` hardware confirmed and restored; remaining types automatically tested |
 | Shading | `Jalousie` | yes | yes | open/close/shade/stop, position; slats only with `details.animation = 0`; auto only when advertised | hardware confirmed in shutter mode: `open`, `set_position`, `enable_auto`, and the final `disable_auto`; `close`, `shade`, and `stop` only accepted. Slat actions do not apply there |
-| Shading | `CentralJalousie` | yes | no | – | hardware read confirmed |
-| Climate/ventilation | `IRoomControllerV2`, `IRCV2Daytimer`, `Ventilation`, `Daytimer` | yes | no | – | readable in the maintainer installation |
+| Shading | `CentralJalousie` | yes | yes | `open`, `close`, `shade`, `stop`, `enable_auto`, `disable_auto` | `stop` hardware accepted; the structure provides no confirmation state |
+| Climate/ventilation | digital `Daytimer` | yes | yes | `pulse`, time-bounded `start_override`, `stop_override`; no calendar or mode-list changes | Implemented and automatically tested; not hardware-verified yet |
+| Climate/ventilation | `IRoomControllerV2`, `IRCV2Daytimer`, `Ventilation` | yes | no | – | readable in the maintainer installation |
 | Climate/ventilation | `ClimateControllerUS` | yes | no | – | hardware read confirmed |
 | Climate/ventilation | corresponding visible V1 types | yes | no | – | generic read path; not hardware-verified |
 | Sensors/status | `InfoOnlyAnalog`, `InfoOnlyDigital`, `InfoOnlyText`, `TextState`, `StatusMonitor`, `WindowMonitor`, `SmokeAlarm`, `Tracker` | yes | no | – | readable in the maintainer installation |

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -3,11 +3,11 @@ NAME=Miraculix2050
 EMAIL=198097126+Miraculix2050@users.noreply.github.com
 
 [PLUGIN]
-VERSION=0.4.0-alpha.2
+VERSION=0.4.0-alpha.3
 NAME=mcpserver
 FOLDER=mcpserver
 TITLE=LoxBerry MCP Server
-WEBSITE=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/blob/v0.4.0-alpha.2/README.md
+WEBSITE=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/blob/v0.4.0-alpha.3/README.md
 
 [AUTOUPDATE]
 AUTOMATIC_UPDATES=false

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -52,7 +52,7 @@ fi
 
 python3.13 -m venv "$new_venv" || exit 2
 "$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" -r "$plugin_bin/runtime-arm64.lock" || exit 2
-"$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" loxberry-mcpserver==0.4.0a2 || exit 2
+"$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" loxberry-mcpserver==0.4.0a3 || exit 2
 if [ -d "$venv" ]; then
     mv "$venv" "$old_venv" || exit 2
 fi

--- a/prerelease.cfg
+++ b/prerelease.cfg
@@ -1,4 +1,4 @@
 [AUTOUPDATE]
-VERSION=0.4.0-alpha.2
-ARCHIVEURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/download/v0.4.0-alpha.2/LoxBerry-MCP-Server-0.4.0-alpha.2.zip
-INFOURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/tag/v0.4.0-alpha.2
+VERSION=0.4.0-alpha.3
+ARCHIVEURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/download/v0.4.0-alpha.3/LoxBerry-MCP-Server-0.4.0-alpha.3.zip
+INFOURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/tag/v0.4.0-alpha.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loxberry-mcpserver"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 description = "Local MCP server for LoxBerry and Loxone"
 requires-python = ">=3.13,<3.14"
 license = "Apache-2.0"

--- a/src/mcpserver/__init__.py
+++ b/src/mcpserver/__init__.py
@@ -5,6 +5,6 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("loxberry-mcpserver")
 except PackageNotFoundError:  # pragma: no cover - source tree without installation
-    __version__ = "0.4.0-alpha.2"
+    __version__ = "0.4.0-alpha.3"
 
 __all__ = ["__version__"]

--- a/src/mcpserver/loxone/control.py
+++ b/src/mcpserver/loxone/control.py
@@ -25,6 +25,10 @@ SUPPORTED_CONTROL_TYPES = frozenset(
         "ColorPickerV2",
         "Pushbutton",
         "UpDownAnalog",
+        "Slider",
+        "LeftRightAnalog",
+        "CentralJalousie",
+        "Daytimer",
     }
 )
 _MOOD_ID = re.compile(r"(?:0|[1-9][0-9]{0,9})\Z")
@@ -85,6 +89,12 @@ def allowed_actions(control: Control) -> list[str]:
             if control.is_automatic:
                 actions.extend(["enable_auto", "disable_auto"])
             return actions
+        case "CentralJalousie":
+            return ["open", "close", "shade", "stop", "enable_auto", "disable_auto"]
+        case "Daytimer":
+            return (
+                ["pulse", "start_override", "stop_override"] if control.is_analog is False else []
+            )
         case "TimedSwitch":
             return ["on", "off", "pulse"]
         case "Radio":
@@ -110,7 +120,7 @@ def allowed_actions(control: Control) -> list[str]:
             return actions
         case "Pushbutton":
             return ["pulse"]
-        case "UpDownAnalog":
+        case "UpDownAnalog" | "Slider" | "LeftRightAnalog":
             return (
                 ["set_value"]
                 if control.minimum is not None
@@ -150,6 +160,7 @@ def prepare_control_command(
     brightness: float | None = None,
     kelvin: int | None = None,
     value: float | None = None,
+    duration_seconds: int | None = None,
 ) -> PreparedControlCommand:
     """Validate one exact action/parameter combination and build its Loxone command."""
     provided = {
@@ -164,6 +175,7 @@ def prepare_control_command(
         "brightness": brightness,
         "kelvin": kelvin,
         "value": value,
+        "duration_seconds": duration_seconds,
     }
 
     def require_only(*names: str) -> None:
@@ -222,7 +234,7 @@ def prepare_control_command(
         require_only()
         return PreparedControlCommand("pulse")
 
-    if control.control_type == "UpDownAnalog":
+    if control.control_type in {"UpDownAnalog", "Slider", "LeftRightAnalog"}:
         require_only("value")
         if (
             value is None
@@ -238,6 +250,36 @@ def prepare_control_command(
         if not math.isclose(steps, round(steps), rel_tol=0, abs_tol=1e-9):
             raise ValueError("value is not aligned to the visible step")
         return PreparedControlCommand(_number(target), (("value", target),))
+
+    if control.control_type == "Daytimer":
+        if action == "pulse":
+            require_only()
+            return PreparedControlCommand("pulse")
+        if action == "stop_override":
+            require_only()
+            return PreparedControlCommand("stopOverride", (("override", 0.0),))
+        require_only("value", "duration_seconds")
+        if value not in {0, 1} or duration_seconds is None or not 1 <= duration_seconds <= 86_400:
+            raise ValueError(
+                "digital daytimer override requires value 0 or 1 and duration_seconds "
+                "from 1 to 86400"
+            )
+        return PreparedControlCommand(
+            f"startOverride/{_number(float(value))}/{duration_seconds}",
+            (("override", "__positive__"),),
+        )
+
+    if control.control_type == "CentralJalousie":
+        require_only()
+        commands = {
+            "open": "FullUp",
+            "close": "FullDown",
+            "shade": "shade",
+            "stop": "stop",
+            "enable_auto": "auto",
+            "disable_auto": "NoAuto",
+        }
+        return PreparedControlCommand(commands[action])
 
     if control.control_type == "Radio":
         if action == "reset":

--- a/src/mcpserver/loxone/models.py
+++ b/src/mcpserver/loxone/models.py
@@ -77,6 +77,7 @@ class Control:
     restrictions: int = 0
     read_only: bool = False
     rating: int | None = None
+    is_favorite: bool = False
     secured: bool = False
     has_notes: bool = False
     is_automatic: bool = False
@@ -92,6 +93,7 @@ class Control:
     minimum: float | None = None
     maximum: float | None = None
     step: float | None = None
+    is_analog: bool | None = None
     statistic_series: tuple[StatisticSeries, ...] = ()
     status_monitor_inputs: tuple[StatusMonitorInput, ...] = ()
     status_monitor_statuses: tuple[StatusMonitorStatus, ...] = ()

--- a/src/mcpserver/loxone/runtime.py
+++ b/src/mcpserver/loxone/runtime.py
@@ -264,6 +264,7 @@ class LoxoneRuntime:
         brightness: float | None = None,
         kelvin: int | None = None,
         value: float | None = None,
+        duration_seconds: int | None = None,
     ) -> ControlOperation:
         """Execute one bounded documented operation for the immutable OAuth identity."""
         if READ_SCOPE not in access.scopes or CONTROL_SCOPE not in access.scopes:
@@ -344,6 +345,7 @@ class LoxoneRuntime:
                         brightness=brightness,
                         kelvin=kelvin,
                         value=value,
+                        duration_seconds=duration_seconds,
                     )
                 except ValueError as exc:
                     raise ControlOperationError("invalid_input", str(exc)) from exc

--- a/src/mcpserver/loxone/structure.py
+++ b/src/mcpserver/loxone/structure.py
@@ -120,7 +120,9 @@ def _radio_outputs(value: object) -> tuple[tuple[str, str], ...]:
 
 
 def _rating(value: object) -> int | None:
-    if isinstance(value, int) and not isinstance(value, bool) and 0 <= value <= 5:
+    # LoxAPP3 ratings are not limited to the five-star presentation convention.
+    # Keep a generous finite bound so a malformed structure cannot create unbounded data.
+    if isinstance(value, int) and not isinstance(value, bool) and 0 <= value <= 100:
         return value
     return None
 
@@ -362,6 +364,9 @@ def _controls(
             min_kelvin, max_kelvin = 2700, 6500
         radio_outputs = _radio_outputs(details.get("outputs"))
         minimum, maximum, step = _up_down_range(details)
+        analog = details.get("analog")
+        if not isinstance(analog, bool):
+            analog = None
         status_monitor_inputs, status_monitor_statuses = (
             _status_monitor_details(details) if item.get("type") == "StatusMonitor" else ((), ())
         )
@@ -377,6 +382,7 @@ def _controls(
                 restrictions=restrictions,
                 read_only=bool(restrictions & _READ_ONLY),
                 rating=_rating(item.get("defaultRating")),
+                is_favorite=item.get("isFavorite", False) is True,
                 secured=item.get("isSecured", False) is True,
                 has_notes=_capability_flag(
                     item.get("hasControlNotes", False), field="hasControlNotes"
@@ -395,6 +401,7 @@ def _controls(
                 minimum=minimum,
                 maximum=maximum,
                 step=step,
+                is_analog=analog,
                 statistic_series=_statistic_series(item),
                 status_monitor_inputs=status_monitor_inputs,
                 status_monitor_statuses=status_monitor_statuses,

--- a/src/mcpserver/tools.py
+++ b/src/mcpserver/tools.py
@@ -167,7 +167,7 @@ class CapabilitiesData(BaseModel):
 
 class ControlPresentationData(BaseModel):
     rating: int | None = Field(
-        default=None, description="Visible Loxone rating from 0 through 5, when advertised."
+        default=None, description="Visible non-negative Loxone rating, when advertised."
     )
     secured: bool = Field(
         description="Whether Loxone marks the control as protected by a visualization password."
@@ -175,6 +175,9 @@ class ControlPresentationData(BaseModel):
     read_only: bool = Field(description="Whether Loxone marks the visible control as read-only.")
     has_notes: bool = Field(
         description="Whether bounded user-authored control notes are available."
+    )
+    is_favorite: bool = Field(
+        description="Whether Loxone marks this visible control as a favorite."
     )
 
 
@@ -1085,7 +1088,8 @@ def register_read_tools(
                         "maximum": control.maximum,
                         "step": control.step,
                     }
-                    if control.minimum is not None
+                    if control.control_type in {"UpDownAnalog", "Slider", "LeftRightAnalog"}
+                    and control.minimum is not None
                     and control.maximum is not None
                     and control.step is not None
                     else None
@@ -1121,6 +1125,7 @@ def register_read_tools(
                 "secured": control.secured,
                 "read_only": control.read_only,
                 "has_notes": control.has_notes,
+                "is_favorite": control.is_favorite,
             }
             parent = _parent_control(snapshot.structure.controls, control.uuid)
             controls = _controls_for_diagnosis(snapshot.structure, include_hidden=include_hidden)
@@ -1699,7 +1704,8 @@ def register_control_tool(server: FastMCP, runtime: LoxoneRuntime | None) -> Non
         description=(
             "Operate one visible and operable supported control: Switch, Dimmer, "
             "LightController V1/V2, Jalousie, TimedSwitch, Radio, LightsceneRGB, "
-            "ColorPicker V1/V2, Pushbutton, or UpDownAnalog. Use an explicit documented action. "
+            "ColorPicker V1/V2, Pushbutton, UpDownAnalog, Slider, LeftRightAnalog, "
+            "CentralJalousie, or a digital Daytimer. Use an explicit documented action. "
             "Requires loxone:control. Never retries an uncertain command."
         ),
         annotations=annotations,
@@ -1732,6 +1738,8 @@ def register_control_tool(server: FastMCP, runtime: LoxoneRuntime | None) -> Non
                 "set_color_hsv",
                 "set_color_temperature",
                 "set_value",
+                "start_override",
+                "stop_override",
             ],
             Field(description="Explicit action advertised by loxone_describe_control."),
         ],
@@ -1825,6 +1833,16 @@ def register_control_tool(server: FastMCP, runtime: LoxoneRuntime | None) -> Non
                 ),
             ),
         ] = None,
+        duration_seconds: Annotated[
+            int | None,
+            Field(
+                description=(
+                    "Digital Daytimer override duration from 1 to 86400 seconds; required "
+                    "only for start_override."
+                ),
+                json_schema_extra={"minimum": 1, "maximum": 86400},
+            ),
+        ] = None,
     ) -> ControlOperationEnvelope:
         access: StoredAccessToken | None = None
         try:
@@ -1848,6 +1866,7 @@ def register_control_tool(server: FastMCP, runtime: LoxoneRuntime | None) -> Non
                 brightness=brightness,
                 kelvin=kelvin,
                 value=value,
+                duration_seconds=duration_seconds,
             )
             warnings = (
                 []

--- a/tests/test_control_commands.py
+++ b/tests/test_control_commands.py
@@ -48,6 +48,18 @@ def _control(
         ("TimedSwitch", "pulse", {}, "pulse"),
         ("Pushbutton", "pulse", {}, "pulse"),
         ("UpDownAnalog", "set_value", {"value": 2}, "2"),
+        ("Slider", "set_value", {"value": 2}, "2"),
+        ("LeftRightAnalog", "set_value", {"value": 2}, "2"),
+        ("CentralJalousie", "open", {}, "FullUp"),
+        ("CentralJalousie", "disable_auto", {}, "NoAuto"),
+        ("Daytimer", "pulse", {}, "pulse"),
+        (
+            "Daytimer",
+            "start_override",
+            {"value": 1, "duration_seconds": 300},
+            "startOverride/1/300",
+        ),
+        ("Daytimer", "stop_override", {}, "stopOverride"),
         (
             "Radio",
             "select_output",
@@ -86,8 +98,10 @@ def test_official_commands_are_mapped_without_raw_command_input(
         options["scene_ids"] = ("3",)
     elif control_type == "ColorPickerV2":
         options["picker_type"] = "Rgb/Lumitech"
-    elif control_type == "UpDownAnalog":
+    elif control_type in {"UpDownAnalog", "Slider", "LeftRightAnalog"}:
         options.update({"minimum": 0.0, "maximum": 3.0, "step": 1.0})
+    elif control_type == "Daytimer":
+        options["is_analog"] = False
     prepared = prepare_control_command(_control(control_type, **options), action, **kwargs)  # type: ignore[arg-type]
 
     assert prepared.command == command
@@ -97,6 +111,15 @@ def test_automatic_actions_are_advertised_only_for_automatic_jalousie() -> None:
     assert "enable_auto" not in allowed_actions(_control("Jalousie"))
     assert "enable_auto" in allowed_actions(_control("Jalousie", automatic=True))
     assert allowed_actions(_control("Jalousie", automatic=True, read_only=True)) == []
+
+
+def test_daytimer_actions_are_only_advertised_for_digital_controls() -> None:
+    assert allowed_actions(_control("Daytimer", is_analog=False)) == [
+        "pulse",
+        "start_override",
+        "stop_override",
+    ]
+    assert allowed_actions(_control("Daytimer", is_analog=True)) == []
 
 
 @pytest.mark.parametrize("animation", (None, 1, 2, 3, 4, 5))
@@ -139,6 +162,18 @@ def test_blind_animation_advertises_slat_actions() -> None:
         (_control("Radio", radio_output_ids=("2",)), "select_output", {"output_id": "3"}),
         (_control("Radio"), "reset", {}),
         (_control("Pushbutton"), "off", {}),
+        (_control("CentralJalousie"), "set_position", {"position": 20}),
+        (
+            _control("Daytimer", is_analog=False),
+            "start_override",
+            {"value": 2, "duration_seconds": 1},
+        ),
+        (
+            _control("Daytimer", is_analog=False),
+            "start_override",
+            {"value": 1, "duration_seconds": 0},
+        ),
+        (_control("Daytimer", is_analog=True), "pulse", {}),
         (
             _control("UpDownAnalog", minimum=0.0, maximum=3.0, step=1.0),
             "set_value",

--- a/tests/test_loxone_structure.py
+++ b/tests/test_loxone_structure.py
@@ -242,6 +242,29 @@ def test_structure_extracts_only_bounded_phase_four_capabilities() -> None:
     assert (up_down.minimum, up_down.maximum, up_down.step) == (0.0, 3.0, 1.0)
 
 
+def test_structure_preserves_documented_favorite_and_high_rating() -> None:
+    raw = {
+        "lastModified": "now",
+        "msInfo": {"serialNr": "000000000000"},
+        "rooms": {},
+        "cats": {},
+        "controls": {
+            "control": {
+                "name": "Favorite",
+                "type": "Switch",
+                "defaultRating": 9,
+                "isFavorite": True,
+                "states": {},
+            }
+        },
+    }
+
+    control = normalize_structure(raw, username="reader").controls[0]
+
+    assert control.rating == 9
+    assert control.is_favorite is True
+
+
 def test_structure_exposes_documented_legacy_statistic_outputs() -> None:
     raw = {
         "lastModified": "now",

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -120,7 +120,7 @@ def test_plugin_identity_and_platform_contract() -> None:
     assert parser["PLUGIN"]["NAME"] == "mcpserver"
     assert parser["PLUGIN"]["FOLDER"] == "mcpserver"
     assert parser["PLUGIN"]["TITLE"] == "LoxBerry MCP Server"
-    assert parser["PLUGIN"]["VERSION"] == "0.4.0-alpha.2"
+    assert parser["PLUGIN"]["VERSION"] == "0.4.0-alpha.3"
     assert parser["SYSTEM"]["LB_MINIMUM"] == "4.0.0"
     assert parser["SYSTEM"]["INTERFACE"] == "2.0"
     for name in ("release.cfg", "prerelease.cfg"):
@@ -455,7 +455,7 @@ def test_plugin_archive_verifier_accepts_builder_output(tmp_path: Path) -> None:
     for name, version in _locked_requirements(ROOT / "requirements" / "runtime-arm64.lock").items():
         wheel_name = name.replace("-", "_")
         (wheelhouse / f"{wheel_name}-{version}-py3-none-any.whl").write_bytes(b"wheel")
-    project_wheel = wheelhouse / "loxberry_mcpserver-0.4.0a2-py3-none-any.whl"
+    project_wheel = wheelhouse / "loxberry_mcpserver-0.4.0a3-py3-none-any.whl"
     _write_project_wheel(project_wheel)
     hash_lock = tmp_path / "runtime-arm64.sha256"
     hash_lock.write_text(
@@ -852,12 +852,12 @@ def test_plugin_archive_verifier_rejects_checksum_mismatch(tmp_path: Path) -> No
 
 
 def test_release_metadata_and_changelog_match_current_prerelease() -> None:
-    notes = validate_release_metadata(ROOT, "0.4.0-alpha.2", "prerelease")
+    notes = validate_release_metadata(ROOT, "0.4.0-alpha.3", "prerelease")
 
-    assert "loxone:history" in notes
-    assert "loxberry:operate" in notes
+    assert "favorite marker" in notes
+    assert "digital Daytimer overrides" in notes
     with pytest.raises(ValueError, match="stable releases"):
-        validate_release_metadata(ROOT, "0.4.0-alpha.2", "stable")
+        validate_release_metadata(ROOT, "0.4.0-alpha.3", "stable")
     with pytest.raises(ValueError, match="versions do not match"):
         validate_release_metadata(ROOT, "0.3.0-alpha.2", "prerelease")
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -441,6 +441,8 @@ def test_control_tool_contract_is_explicitly_mutating_and_non_idempotent() -> No
         "set_color_hsv",
         "set_color_temperature",
         "set_value",
+        "start_override",
+        "stop_override",
     }
 
 
@@ -505,6 +507,7 @@ def test_tool_input_schemas_explain_every_argument() -> None:
             "brightness",
             "kelvin",
             "value",
+            "duration_seconds",
         },
     }
     for tool_name, field_names in expected_fields.items():


### PR DESCRIPTION
## Summary
- Preserve independent LoxAPP3 favorites and non-negative ratings.
- Add bounded Slider, LeftRightAnalog, CentralJalousie, and digital Daytimer contracts.
- Prepare 0.4.0-alpha.3 metadata, documentation, tests, and acceptance evidence.

## Validation
- Python 3.13 Full: 506 passed.
- Native focused deploy and health check on Loxberry-Test.
- Slider set_value hardware-confirmed and restored; CentralJalousie stop accepted without a documented confirmation state.

## Safety
- No schedule editing, lock control, secured details, or free-form commands are exposed.