### PR TITLE
Harden runtime structure refresh and cache limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ extracted from the matching version heading.
 
 ## 0.4.0-alpha.3 - 2026-08-13
 
+- Refresh the user-filtered LoxAPP3 structure after reconnects and at a bounded
+  configurable interval, including visible Notes, ratings, and favorites; reject
+  stale refreshes and oversized structures safely.
+- Bound runtime WebSocket sessions by activity and capacity, avoid concurrent
+  token-refresh/event reads, and close runtime connections together with OAuth
+  family revocation.
+- Replace the unused persistent statistics-cache mode with a bounded RAM-only
+  cache and add advanced, validated structure and runtime limits.
 - Preserve all bounded non-negative Loxone ratings, expose the independent
   favorite marker, and extend the bounded operation allowlist to virtual analog
   inputs, CentralJalousie, and digital Daytimer overrides.

--- a/config/default-config.json
+++ b/config/default-config.json
@@ -5,6 +5,13 @@
     "loxberry_operate_requests_per_minute": 3,
     "loxberry_requests_per_minute": 30,
     "max_parallel_calls": 4,
+    "max_active_runtime_sessions": 16,
+    "runtime_session_idle_seconds": 900,
+    "structure_refresh_seconds": 300,
+    "max_structure_controls": 20000,
+    "max_structure_state_references": 100000,
+    "max_structure_depth": 32,
+    "max_states_per_identity": 20000,
     "requests_per_minute": 60
   },
   "loxone": {
@@ -19,10 +26,9 @@
     "loxberry_read_bindings": []
   },
   "cache": {
-    "statistics_max_mib": 128,
-    "statistics_mode": "memory"
+    "statistics_memory_max_mib": 128
   },
-  "schema_version": 2,
+  "schema_version": 3,
   "server": {
     "enabled": false,
     "public_origin": ""

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -258,9 +258,17 @@ Statistiken werden für sichtbare `statisticV2`-Reihen und dokumentierte klassis
 `statistic.outputs` angeboten. Rohe Werte sind auf sieben Tage, verdichtete
 StatisticV2-Werte auf zehn Jahre begrenzt. Klassische Reihen unterstützen nur
 den Rohabruf und lesen höchstens zwei begrenzte Monats-Binärdateien über den
-authentifizierten WebSocket. Ergebnisse liegen 60 Sekunden im RAM. Der optionale
-Hybrid-Cache ist begrenzt und privat, die aktuellen Pfade schreiben jedoch keine
-Quelldateien dauerhaft. Legacy-XML und FTP werden nicht verwendet.
+authentifizierten WebSocket. Ergebnisse liegen 60 Sekunden in einem begrenzten
+RAM-Cache; es gibt keinen persistenten Statistik- oder FTP-/XML-Cache.
+
+Die sichtbare Loxone-Struktur wird beim Verbinden und nach einem Dienstneustart
+neu geladen. Während einer stabilen Verbindung prüft der Server sie zusätzlich
+in dem unter **Erweiterte Laufzeit- und Strukturgrenzen** konfigurierten Intervall
+(standardmäßig fünf Minuten). Dadurch werden auch geänderte Control-Hinweise,
+Bewertungen und Favoriten erkannt. Kann eine fällige Strukturprüfung nicht
+erfolgen, liefert der Server keine möglicherweise veraltete Struktur. Die
+konfigurierbaren Strukturgrenzen schützen umfangreiche Projekte; eine
+Überschreitung wird abgelehnt und ohne Control-Inhalte im Dienstlog vermerkt.
 
 `loxone_describe_control` liefert außerdem direkte Control-Beziehungen: Ein
 Subcontrol nennt unter `relationships.parent` seinen sichtbaren Parent; ein

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -240,9 +240,16 @@ structure. `loxone:history` additionally enables `loxone_get_statistics` and
 `statisticV2` series and documented legacy `statistic.outputs`. Raw queries are
 limited to seven days and aggregated StatisticV2 queries to ten years. Legacy
 series support raw queries only and are read from at most two bounded monthly binary
-files on the authenticated WebSocket. Results stay in RAM for 60 seconds. The
-optional hybrid cache is bounded and private, but the current paths do not persist
-source files. Legacy XML and FTP are not used.
+files on the authenticated WebSocket. Results remain in a bounded RAM cache for
+60 seconds; there is no persistent statistics cache and no FTP/XML cache.
+
+The visible Loxone structure is reloaded on connection and after a service
+restart. While a connection remains stable, the server also checks it at the
+interval configured under **Advanced runtime and structure limits** (five minutes
+by default). This detects changed Control Notes, ratings, and favorites. If a due
+structure check cannot complete, the server does not return a possibly outdated
+structure. Configurable structure limits protect large projects; an exceeded limit
+rejects the structure and writes a sanitized service-log entry.
 
 `loxone_describe_control` also returns direct control relationships: a subcontrol
 names its visible parent under `relationships.parent`, and a parent lists visible

--- a/src/mcpserver/config.py
+++ b/src/mcpserver/config.py
@@ -17,7 +17,7 @@ import idna
 
 from mcpserver.loxone.client import MiniserverEndpoint
 
-SCHEMA_VERSION: Final = 2
+SCHEMA_VERSION: Final = 3
 DEFAULT_CONNECTION_TIMEOUT: Final = 10.0
 DEFAULT_REQUESTS_PER_MINUTE: Final = 60
 DEFAULT_MAX_PARALLEL_CALLS: Final = 4
@@ -25,7 +25,14 @@ DEFAULT_CONTROL_REQUESTS_PER_MINUTE: Final = 10
 DEFAULT_LOXBERRY_REQUESTS_PER_MINUTE: Final = 30
 DEFAULT_HISTORY_REQUESTS_PER_MINUTE: Final = 12
 DEFAULT_LOXBERRY_OPERATE_REQUESTS_PER_MINUTE: Final = 3
-DEFAULT_STATISTICS_CACHE_MAX_MIB: Final = 128
+DEFAULT_STATISTICS_MEMORY_MAX_MIB: Final = 128
+DEFAULT_STRUCTURE_REFRESH_SECONDS: Final = 300
+DEFAULT_MAX_ACTIVE_RUNTIME_SESSIONS: Final = 16
+DEFAULT_RUNTIME_SESSION_IDLE_SECONDS: Final = 900
+DEFAULT_MAX_STRUCTURE_CONTROLS: Final = 20_000
+DEFAULT_MAX_STRUCTURE_STATE_REFERENCES: Final = 100_000
+DEFAULT_MAX_STRUCTURE_DEPTH: Final = 32
+DEFAULT_MAX_STATES_PER_IDENTITY: Final = 20_000
 MAX_LOXBERRY_BINDINGS: Final = 64
 DEFAULT_LOG_LEVEL: Final = "warning"
 SUPPORTED_LOG_LEVELS: Final = frozenset({"off", "error", "warning", "info", "debug"})
@@ -107,8 +114,14 @@ class PluginConfig:
     log_level: str = DEFAULT_LOG_LEVEL
     loxberry_read_bindings: tuple[str, ...] = ()
     loxberry_operate_bindings: tuple[str, ...] = ()
-    statistics_cache_mode: str = "memory"
-    statistics_cache_max_mib: int = DEFAULT_STATISTICS_CACHE_MAX_MIB
+    statistics_memory_max_mib: int = DEFAULT_STATISTICS_MEMORY_MAX_MIB
+    structure_refresh_seconds: int = DEFAULT_STRUCTURE_REFRESH_SECONDS
+    max_active_runtime_sessions: int = DEFAULT_MAX_ACTIVE_RUNTIME_SESSIONS
+    runtime_session_idle_seconds: int = DEFAULT_RUNTIME_SESSION_IDLE_SECONDS
+    max_structure_controls: int = DEFAULT_MAX_STRUCTURE_CONTROLS
+    max_structure_state_references: int = DEFAULT_MAX_STRUCTURE_STATE_REFERENCES
+    max_structure_depth: int = DEFAULT_MAX_STRUCTURE_DEPTH
+    max_states_per_identity: int = DEFAULT_MAX_STATES_PER_IDENTITY
     _source: dict[str, Any] | None = None
 
     @classmethod
@@ -118,7 +131,7 @@ class PluginConfig:
     @classmethod
     def from_document(cls, document: object) -> PluginConfig:
         root = _mapping(document, name="configuration")
-        if root.get("schema_version") not in {1, SCHEMA_VERSION}:
+        if root.get("schema_version") not in {1, 2, SCHEMA_VERSION}:
             raise ConfigError("schema_version is unsupported")
         server = _mapping(root.get("server", {}), name="server")
         loxone = _mapping(root.get("loxone", {}), name="loxone")
@@ -237,6 +250,48 @@ class PluginConfig:
             minimum=1,
             maximum=32,
         )
+        structure_refresh_seconds = _integer(
+            limits.get("structure_refresh_seconds", DEFAULT_STRUCTURE_REFRESH_SECONDS),
+            name="limits.structure_refresh_seconds",
+            minimum=60,
+            maximum=3600,
+        )
+        max_active_runtime_sessions = _integer(
+            limits.get("max_active_runtime_sessions", DEFAULT_MAX_ACTIVE_RUNTIME_SESSIONS),
+            name="limits.max_active_runtime_sessions",
+            minimum=1,
+            maximum=128,
+        )
+        runtime_session_idle_seconds = _integer(
+            limits.get("runtime_session_idle_seconds", DEFAULT_RUNTIME_SESSION_IDLE_SECONDS),
+            name="limits.runtime_session_idle_seconds",
+            minimum=60,
+            maximum=86_400,
+        )
+        max_structure_controls = _integer(
+            limits.get("max_structure_controls", DEFAULT_MAX_STRUCTURE_CONTROLS),
+            name="limits.max_structure_controls",
+            minimum=1_000,
+            maximum=100_000,
+        )
+        max_structure_state_references = _integer(
+            limits.get("max_structure_state_references", DEFAULT_MAX_STRUCTURE_STATE_REFERENCES),
+            name="limits.max_structure_state_references",
+            minimum=10_000,
+            maximum=500_000,
+        )
+        max_structure_depth = _integer(
+            limits.get("max_structure_depth", DEFAULT_MAX_STRUCTURE_DEPTH),
+            name="limits.max_structure_depth",
+            minimum=4,
+            maximum=128,
+        )
+        max_states_per_identity = _integer(
+            limits.get("max_states_per_identity", DEFAULT_MAX_STATES_PER_IDENTITY),
+            name="limits.max_states_per_identity",
+            minimum=1_000,
+            maximum=100_000,
+        )
         log_level = _log_level(logging_config.get("level", DEFAULT_LOG_LEVEL))
         loxberry_read_bindings = _bindings(
             policies.get("loxberry_read_bindings", []), name="policies.loxberry_read_bindings"
@@ -245,12 +300,12 @@ class PluginConfig:
             policies.get("loxberry_operate_bindings", []),
             name="policies.loxberry_operate_bindings",
         )
-        cache_mode = cache.get("statistics_mode", "memory")
-        if cache_mode not in {"memory", "hybrid"}:
-            raise ConfigError("cache.statistics_mode is unsupported")
         cache_max_mib = _integer(
-            cache.get("statistics_max_mib", DEFAULT_STATISTICS_CACHE_MAX_MIB),
-            name="cache.statistics_max_mib",
+            cache.get(
+                "statistics_memory_max_mib",
+                cache.get("statistics_max_mib", DEFAULT_STATISTICS_MEMORY_MAX_MIB),
+            ),
+            name="cache.statistics_memory_max_mib",
             minimum=16,
             maximum=512,
         )
@@ -273,8 +328,14 @@ class PluginConfig:
             log_level=log_level,
             loxberry_read_bindings=loxberry_read_bindings,
             loxberry_operate_bindings=loxberry_operate_bindings,
-            statistics_cache_mode=cache_mode,
-            statistics_cache_max_mib=cache_max_mib,
+            statistics_memory_max_mib=cache_max_mib,
+            structure_refresh_seconds=structure_refresh_seconds,
+            max_active_runtime_sessions=max_active_runtime_sessions,
+            runtime_session_idle_seconds=runtime_session_idle_seconds,
+            max_structure_controls=max_structure_controls,
+            max_structure_state_references=max_structure_state_references,
+            max_structure_depth=max_structure_depth,
+            max_states_per_identity=max_states_per_identity,
             _source=copy.deepcopy(root),
         )
 
@@ -302,12 +363,20 @@ class PluginConfig:
             self.loxberry_operate_requests_per_minute
         )
         document["limits"]["max_parallel_calls"] = self.max_parallel_calls
+        document["limits"]["structure_refresh_seconds"] = self.structure_refresh_seconds
+        document["limits"]["max_active_runtime_sessions"] = self.max_active_runtime_sessions
+        document["limits"]["runtime_session_idle_seconds"] = self.runtime_session_idle_seconds
+        document["limits"]["max_structure_controls"] = self.max_structure_controls
+        document["limits"]["max_structure_state_references"] = self.max_structure_state_references
+        document["limits"]["max_structure_depth"] = self.max_structure_depth
+        document["limits"]["max_states_per_identity"] = self.max_states_per_identity
         document["logging"]["level"] = self.log_level
         document["logging"].pop("debug_until", None)
         document["policies"]["loxberry_read_bindings"] = list(self.loxberry_read_bindings)
         document["policies"]["loxberry_operate_bindings"] = list(self.loxberry_operate_bindings)
-        document["cache"]["statistics_mode"] = self.statistics_cache_mode
-        document["cache"]["statistics_max_mib"] = self.statistics_cache_max_mib
+        document["cache"].pop("statistics_mode", None)
+        document["cache"].pop("statistics_max_mib", None)
+        document["cache"]["statistics_memory_max_mib"] = self.statistics_memory_max_mib
         return document
 
 

--- a/src/mcpserver/loxone/client.py
+++ b/src/mcpserver/loxone/client.py
@@ -282,12 +282,18 @@ class LoxoneClient:
         client_name: str = "LoxBerry MCP Server",
         timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
         max_response_bytes: int = _MAX_RESPONSE_BYTES,
+        max_structure_controls: int = 20_000,
+        max_structure_state_references: int = 100_000,
+        max_structure_depth: int = 32,
     ) -> None:
         self.endpoint = endpoint
         self.client_uuid = client_uuid
         self.client_name = client_name
         self.timeout_seconds = timeout_seconds
         self.max_response_bytes = max_response_bytes
+        self.max_structure_controls = max_structure_controls
+        self.max_structure_state_references = max_structure_state_references
+        self.max_structure_depth = max_structure_depth
 
     async def _get_json(self, path: str) -> Mapping[str, Any]:
         body, _encoding = await self._get_bytes(path)
@@ -491,6 +497,9 @@ class LoxoneClient:
             timeout_seconds=self.timeout_seconds,
             max_payload_bytes=self.max_response_bytes,
             secure_transport=self.endpoint.secure,
+            max_structure_controls=self.max_structure_controls,
+            max_structure_state_references=self.max_structure_state_references,
+            max_structure_depth=self.max_structure_depth,
         )
         try:
             await session.authenticate()
@@ -512,6 +521,9 @@ class LoxoneWebSocketSession:
         timeout_seconds: float,
         max_payload_bytes: int,
         secure_transport: bool = False,
+        max_structure_controls: int = 20_000,
+        max_structure_state_references: int = 100_000,
+        max_structure_depth: int = 32,
     ) -> None:
         self._websocket = websocket
         self._public_key = public_key
@@ -519,6 +531,9 @@ class LoxoneWebSocketSession:
         self._timeout = timeout_seconds
         self._max_payload = max_payload_bytes
         self._secure_transport = secure_transport
+        self._max_structure_controls = max_structure_controls
+        self._max_structure_state_references = max_structure_state_references
+        self._max_structure_depth = max_structure_depth
         self._encryptor = CommandEncryptor.generate()
 
     async def _receive(self) -> tuple[MessageHeader, str | bytes | None]:
@@ -568,8 +583,18 @@ class LoxoneWebSocketSession:
         if not isinstance(document, Mapping):
             raise LoxoneProtocolError("Miniserver structure response is invalid")
         try:
-            return normalize_structure(document, username=self._token.username)
+            return normalize_structure(
+                document,
+                username=self._token.username,
+                max_controls=self._max_structure_controls,
+                max_state_references=self._max_structure_state_references,
+                max_depth=self._max_structure_depth,
+            )
         except LoxoneStructureError as exc:
+            _LOGGER.error(
+                "component=structure outcome=rejected reason=%s",
+                str(exc).replace(" ", "_"),
+            )
             raise LoxoneProtocolError("Miniserver structure response is invalid") from exc
 
     async def refresh_token(self) -> None:

--- a/src/mcpserver/loxone/runtime.py
+++ b/src/mcpserver/loxone/runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import math
 import struct
 import time
@@ -47,6 +48,7 @@ _LOXONE_EPOCH_UNIX = 1_230_768_000
 _REFRESH_BEFORE_SECONDS = 24 * 60 * 60
 _MAX_LEGACY_STATISTIC_BYTES = 64 * 1024 * 1024
 _MAX_HISTORY_TIMESTAMP = 4_102_444_800
+_LOGGER = logging.getLogger(__name__)
 
 
 def _legacy_statistic_dates(start: int, end: int) -> tuple[str, ...]:
@@ -135,6 +137,7 @@ class RuntimeSnapshot:
     subject: str
     structure: LoxoneStructure
     connected: bool
+    structure_generation: int = 1
 
 
 @dataclass(slots=True)
@@ -144,6 +147,9 @@ class _ConnectionRecord:
     session: LoxoneWebSocketSession
     task: asyncio.Task[None]
     connected: bool = True
+    generation: int = 1
+    last_structure_check: float = 0.0
+    last_used: float = 0.0
 
 
 class LoxoneRuntime:
@@ -163,6 +169,13 @@ class LoxoneRuntime:
         statistics_cache: StatisticsCache | None = None,
         control_enabled: bool = False,
         history_enabled: bool = False,
+        structure_refresh_seconds: int = 300,
+        max_active_sessions: int = 16,
+        session_idle_seconds: int = 900,
+        max_states_per_identity: int = 20_000,
+        max_structure_controls: int = 20_000,
+        max_structure_state_references: int = 100_000,
+        max_structure_depth: int = 32,
     ) -> None:
         from mcpserver.loxone.client import MiniserverEndpoint
 
@@ -174,8 +187,11 @@ class LoxoneRuntime:
             endpoint,
             client_uuid=uuid5(NAMESPACE_URL, "https://loxberry.local/plugins/mcpserver"),
             timeout_seconds=timeout_seconds,
+            max_structure_controls=max_structure_controls,
+            max_structure_state_references=max_structure_state_references,
+            max_structure_depth=max_structure_depth,
         )
-        self.cache = UserStateCache()
+        self.cache = UserStateCache(max_states_per_user=max_states_per_identity)
         self._records: dict[str, _ConnectionRecord] = {}
         self._locks: defaultdict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
         self._rate: defaultdict[str, deque[float]] = defaultdict(deque)
@@ -190,6 +206,9 @@ class LoxoneRuntime:
         self.statistics_cache = statistics_cache or StatisticsCache(None)
         self.control_enabled = control_enabled
         self.history_enabled = history_enabled
+        self.structure_refresh_seconds = structure_refresh_seconds
+        self.max_active_sessions = max_active_sessions
+        self.session_idle_seconds = session_idle_seconds
 
     @asynccontextmanager
     async def call_slot(self, access: StoredAccessToken) -> AsyncIterator[None]:
@@ -450,7 +469,11 @@ class LoxoneRuntime:
 
     @asynccontextmanager
     async def _history_session(
-        self, access: StoredAccessToken, control_uuid: str, *, include_hidden: bool = False
+        self,
+        access: StoredAccessToken,
+        control_uuid: str,
+        *,
+        include_hidden: bool = False,
     ) -> AsyncIterator[tuple[Control, LoxoneWebSocketSession]]:
         if READ_SCOPE not in access.scopes or HISTORY_SCOPE not in access.scopes:
             raise ControlOperationError("permission_denied", "loxone:history is required")
@@ -539,7 +562,9 @@ class LoxoneRuntime:
             if series is None:
                 raise ControlOperationError("not_found", "statistic series is not visible")
             if cached is not None:
+                _LOGGER.debug("component=statistics outcome=cache_hit")
                 return control, series, cached
+            _LOGGER.debug("component=statistics outcome=cache_miss")
             try:
                 if series.source == "legacy":
                     if (
@@ -706,6 +731,7 @@ class LoxoneRuntime:
 
     async def snapshot(self, access: StoredAccessToken) -> RuntimeSnapshot:
         subject = access.family_id
+        await self._prune_sessions(subject)
         record = self._records.get(subject)
         if record is None or record.task.done():
             async with self._locks[subject]:
@@ -713,8 +739,14 @@ class LoxoneRuntime:
                 if record is None or record.task.done():
                     record = await self._connect(access)
                     self._records[subject] = record
+        record.last_used = time.monotonic()
+        if record.last_structure_check + self.structure_refresh_seconds <= record.last_used:
+            await self._refresh_structure(access, record)
         return RuntimeSnapshot(
-            subject, record.structure, record.connected and not record.task.done()
+            subject,
+            record.structure,
+            record.connected and not record.task.done(),
+            record.generation,
         )
 
     async def _connect(self, access: StoredAccessToken) -> _ConnectionRecord:
@@ -732,9 +764,58 @@ class LoxoneRuntime:
         allowed = _state_uuids(structure.controls + structure.hidden_controls)
         self.cache.begin_connection(access.family_id)
         placeholder = asyncio.create_task(asyncio.sleep(0))
-        record = _ConnectionRecord(structure, allowed, session, placeholder)
+        now = time.monotonic()
+        record = _ConnectionRecord(
+            structure,
+            allowed,
+            session,
+            placeholder,
+            last_structure_check=now,
+            last_used=now,
+        )
         record.task = asyncio.create_task(self._maintain(access, token, record))
         return record
+
+    async def _prune_sessions(self, keep_subject: str) -> None:
+        now = time.monotonic()
+        for subject, record in tuple(self._records.items()):
+            if subject != keep_subject and now - record.last_used >= self.session_idle_seconds:
+                await self.disconnect(subject)
+        active = [
+            (subject, record)
+            for subject, record in self._records.items()
+            if subject != keep_subject and not record.task.done()
+        ]
+        while len(active) >= self.max_active_sessions:
+            subject, _record = min(active, key=lambda item: item[1].last_used)
+            await self.disconnect(subject)
+            active = [item for item in active if item[0] != subject]
+
+    async def _refresh_structure(
+        self, access: StoredAccessToken, record: _ConnectionRecord
+    ) -> None:
+        try:
+            token = self.token_store.get(access.family_id, access.miniserver_id, access.identity_id)
+            if token is None:
+                raise LoxoneTokenStoreError("Loxone token is unavailable")
+            session = await self.client.open_session(token)
+            try:
+                structure = await session.load_structure()
+            finally:
+                await session.close()
+        except (LoxoneConnectionError, LoxoneProtocolError, LoxoneTokenStoreError) as exc:
+            _LOGGER.warning(
+                "component=structure outcome=refresh_failed error_type=%s",
+                type(exc).__name__,
+            )
+            raise RuntimeUnavailable("Miniserver structure refresh failed") from exc
+        record.last_structure_check = time.monotonic()
+        if structure.last_modified != record.structure.last_modified:
+            record.structure = structure
+            record.allowed_states = _state_uuids(structure.controls + structure.hidden_controls)
+            record.generation += 1
+            self.cache.apply(access.family_id, (), allowed_uuids=record.allowed_states)
+            _LOGGER.info("component=structure outcome=changed")
 
     async def _maintain(
         self,
@@ -752,13 +833,24 @@ class LoxoneRuntime:
                     await events
                     break
                 if refresh_at <= time.time():
-                    await record.session.refresh_token()
-                    self.token_store.put(
-                        access.family_id,
-                        access.miniserver_id,
-                        access.identity_id,
-                        token,
-                    )
+                    events.cancel()
+                    with suppress(asyncio.CancelledError):
+                        await events
+                    await record.session.close()
+                    refreshed = await self.client.open_session(token)
+                    try:
+                        await refreshed.refresh_token()
+                        self.token_store.put(
+                            access.family_id,
+                            access.miniserver_id,
+                            access.identity_id,
+                            token,
+                        )
+                    finally:
+                        await refreshed.close()
+                    record.connected = False
+                    self.cache.disconnect(access.family_id)
+                    break
         except Exception:
             record.connected = False
             self.cache.disconnect(access.family_id)
@@ -775,13 +867,16 @@ class LoxoneRuntime:
     def state(self, snapshot: RuntimeSnapshot, uuid: str) -> StateRecord:
         return self.cache.get(snapshot.subject, uuid)
 
-    async def revoke(self, family_id: str) -> None:
+    async def disconnect(self, family_id: str) -> None:
         record = self._records.pop(family_id, None)
         if record is not None:
             record.task.cancel()
             with suppress(asyncio.CancelledError):
                 await record.task
         self.cache.clear(family_id)
+
+    async def revoke(self, family_id: str) -> None:
+        await self.disconnect(family_id)
         self.token_store.delete(family_id)
 
     async def close(self) -> None:

--- a/src/mcpserver/loxone/statistics.py
+++ b/src/mcpserver/loxone/statistics.py
@@ -1,20 +1,14 @@
-"""Bounded statistic parsing and disposable plugin-owned caching."""
+"""Bounded statistic parsing and disposable in-memory caching."""
 
 from __future__ import annotations
 
-import gzip
 import hashlib
 import math
-import os
-import re
-import secrets
-import stat
 import struct
 import time
 from collections import OrderedDict
 from collections.abc import Callable
 from dataclasses import dataclass
-from pathlib import Path
 from threading import RLock
 from typing import Final
 
@@ -62,24 +56,24 @@ def parse_statistic_points(
 
 
 class StatisticsCache:
-    """Small RAM result cache plus an optional private compressed source cache."""
+    """Small bounded RAM cache for parsed statistic results."""
 
     def __init__(
         self,
-        directory: Path | None,
+        directory: object | None = None,
         *,
         maximum_bytes: int = 128 * 1024 * 1024,
         ttl_seconds: float = 60.0,
         maximum_memory_points: int = _MAX_MEMORY_POINTS,
         clock: Callable[[], float] = time.monotonic,
     ) -> None:
-        if directory is not None and not directory.is_absolute():
-            raise ValueError("statistics cache path must be absolute")
         if not 16 * 1024 * 1024 <= maximum_bytes <= 512 * 1024 * 1024:
             raise ValueError("statistics cache size is outside the supported range")
         if maximum_memory_points < 1:
             raise ValueError("statistics memory cache point limit must be positive")
-        self.directory = directory
+        # Kept as an ignored compatibility parameter while callers transition from
+        # the former hybrid cache. Statistics data is never persisted.
+        del directory
         self.maximum_bytes = maximum_bytes
         self.ttl_seconds = ttl_seconds
         self.maximum_memory_points = maximum_memory_points
@@ -109,8 +103,11 @@ class StatisticsCache:
                 return
             self._memory[key] = (now + self.ttl_seconds, value)
             self._memory.move_to_end(key)
-            while sum(len(points) for _expires_at, points in self._memory.values()) > (
-                self.maximum_memory_points
+            while (
+                sum(len(points) for _expires_at, points in self._memory.values())
+                > self.maximum_memory_points
+                or sum(len(points) * _POINT.size for _expires_at, points in self._memory.values())
+                > self.maximum_bytes
             ):
                 self._memory.popitem(last=False)
 
@@ -118,72 +115,10 @@ class StatisticsCache:
     def source_key(*parts: str) -> str:
         return hashlib.sha256("\0".join(parts).encode("utf-8")).hexdigest()
 
-    def put_legacy_source(self, key: str, payload: bytes) -> None:
-        """Persist only an already validated legacy source blob."""
-        if (
-            self.directory is None
-            or len(payload) > _MAX_SOURCE_BYTES
-            or re.fullmatch(r"[0-9a-f]{64}", key) is None
-        ):
-            return
-        with self._lock:
-            if self.directory.exists() and (
-                self.directory.is_symlink() or not self.directory.is_dir()
-            ):
-                return
-            self.directory.mkdir(mode=0o700, parents=True, exist_ok=True)
-            if self.directory.is_symlink() or not self.directory.is_dir():
-                return
-            os.chmod(self.directory, 0o700)
-            target = self.directory / f"{key}.gz"
-            temporary = self.directory / f".{key}.{secrets.token_hex(8)}.tmp"
-            try:
-                with gzip.open(temporary, "wb", compresslevel=6) as handle:
-                    handle.write(payload)
-                os.chmod(temporary, 0o600)
-                os.replace(temporary, target)
-                self._trim()
-            finally:
-                temporary.unlink(missing_ok=True)
-
-    def _entries(self) -> list[tuple[Path, os.stat_result]]:
-        if self.directory is None or not self.directory.exists() or self.directory.is_symlink():
-            return []
-        result: list[tuple[Path, os.stat_result]] = []
-        for path in self.directory.iterdir():
-            try:
-                metadata = path.lstat()
-            except OSError:
-                continue
-            if path.suffix == ".gz" and stat.S_ISREG(metadata.st_mode) and not path.is_symlink():
-                result.append((path, metadata))
-        return result
-
-    def _trim(self) -> None:
-        entries = self._entries()
-        total = sum(metadata.st_size for _path, metadata in entries)
-        for path, metadata in sorted(entries, key=lambda item: item[1].st_atime):
-            if total <= self.maximum_bytes:
-                break
-            path.unlink(missing_ok=True)
-            total -= metadata.st_size
-
     def clear(self) -> CacheClearResult:
-        """Clear cached data without holding the memory lock during filesystem I/O."""
+        """Clear cached in-memory data."""
         with self._lock:
             memory = len(self._memory)
             self._memory.clear()
-        # Directory enumeration and unlinking can block on slow storage. A timed-out
-        # MCP call cannot stop a Python worker thread, so it must not retain the lock
-        # that protects normal in-memory statistic reads and writes.
-        entries = self._entries()
-        removed = 0
-        freed = 0
-        for path, metadata in entries:
-            try:
-                path.unlink()
-            except OSError:
-                continue
-            removed += 1
-            freed += metadata.st_size
-        return CacheClearResult(memory, removed, freed)
+        # Keep the output schema stable for existing MCP clients.
+        return CacheClearResult(memory, 0, 0)

--- a/src/mcpserver/loxone/structure.py
+++ b/src/mcpserver/loxone/structure.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import math
 import re
 from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import Any
 
 from mcpserver.loxone.models import (
@@ -25,6 +26,27 @@ _READ_ONLY = _READ_ONLY_INTERNAL | _READ_ONLY_EXTERNAL
 
 class LoxoneStructureError(ValueError):
     """Raised when the user-filtered structure is malformed."""
+
+
+@dataclass(slots=True)
+class StructureBudget:
+    """Reject oversized or excessively nested untrusted structure documents."""
+
+    max_controls: int
+    max_state_references: int
+    max_depth: int
+    controls: int = 0
+    state_references: int = 0
+
+    def visit(self, *, depth: int, state_references: int) -> None:
+        if depth > self.max_depth:
+            raise LoxoneStructureError("Structure nesting depth exceeds the configured limit")
+        self.controls += 1
+        if self.controls > self.max_controls:
+            raise LoxoneStructureError("Structure control count exceeds the configured limit")
+        self.state_references += state_references
+        if self.state_references > self.max_state_references:
+            raise LoxoneStructureError("Structure state count exceeds the configured limit")
 
 
 def _text(value: object, *, field: str) -> str:
@@ -288,11 +310,13 @@ def _links(value: object) -> tuple[str, ...]:
     return tuple(item for item in value if isinstance(item, str) and 1 <= len(item) <= 128)
 
 
-def _linked_control_uuids(value: object) -> frozenset[str]:
+def _linked_control_uuids(value: object, *, maximum_controls: int) -> frozenset[str]:
     if not isinstance(value, Mapping):
         raise LoxoneStructureError("Structure field controls must be an object")
     result: set[str] = set()
-    for item in value.values():
+    for index, item in enumerate(value.values(), start=1):
+        if index > maximum_controls:
+            raise LoxoneStructureError("Structure control count exceeds the configured limit")
         if not isinstance(item, Mapping):
             continue
         restrictions = item.get("restrictions", 0)
@@ -311,6 +335,8 @@ def _controls(
     referenced: bool = False,
     linked_control_uuids: frozenset[str] = frozenset(),
     hidden_only: bool = False,
+    budget: StructureBudget,
+    depth: int = 1,
 ) -> tuple[Control, ...]:
     if not isinstance(value, Mapping):
         raise LoxoneStructureError("Structure field controls must be an object")
@@ -336,6 +362,7 @@ def _controls(
             for name, state_uuid in states_value.items()
             if isinstance(name, str) and isinstance(state_uuid, str)
         )
+        budget.visit(depth=depth, state_references=len(states))
         subcontrols_value = item.get("subControls", {})
         details = item.get("details", {})
         if not isinstance(details, Mapping):
@@ -406,7 +433,14 @@ def _controls(
                 status_monitor_inputs=status_monitor_inputs,
                 status_monitor_statuses=status_monitor_statuses,
                 subcontrols=(
-                    _controls(subcontrols_value, referenced=True) if subcontrols_value else ()
+                    _controls(
+                        subcontrols_value,
+                        referenced=True,
+                        budget=budget,
+                        depth=depth + 1,
+                    )
+                    if subcontrols_value
+                    else ()
                 ),
                 linked_control_uuids=_links(item.get("links")),
                 is_user_linked=(
@@ -430,7 +464,14 @@ def _group_references(controls: tuple[Control, ...], *, field: str) -> set[str]:
     return result
 
 
-def normalize_structure(document: Mapping[str, Any], *, username: str) -> LoxoneStructure:
+def normalize_structure(
+    document: Mapping[str, Any],
+    *,
+    username: str,
+    max_controls: int = 20_000,
+    max_state_references: int = 100_000,
+    max_depth: int = 32,
+) -> LoxoneStructure:
     """Return only fields required for read-only discovery and state association."""
     ms_info = document.get("msInfo")
     if not isinstance(ms_info, Mapping):
@@ -438,12 +479,14 @@ def normalize_structure(document: Mapping[str, Any], *, username: str) -> Loxone
     serial = ms_info.get("serialNr", ms_info.get("serial"))
     last_modified = document.get("lastModified", "")
     controls_value = document.get("controls", {})
-    linked_control_uuids = _linked_control_uuids(controls_value)
-    controls = _controls(controls_value, linked_control_uuids=linked_control_uuids)
+    linked_control_uuids = _linked_control_uuids(controls_value, maximum_controls=max_controls)
+    budget = StructureBudget(max_controls, max_state_references, max_depth)
+    controls = _controls(controls_value, linked_control_uuids=linked_control_uuids, budget=budget)
     hidden_controls = _controls(
         controls_value,
         linked_control_uuids=linked_control_uuids,
         hidden_only=True,
+        budget=budget,
     )
     return LoxoneStructure(
         identity=LoxoneIdentity(

--- a/src/mcpserver/server.py
+++ b/src/mcpserver/server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 from contextlib import suppress
@@ -325,11 +326,25 @@ def create_server(settings: ServerSettings) -> FastMCP:
             except Exception:
                 return False
 
+        runtime_ref: dict[str, LoxoneRuntime] = {}
+
+        def on_family_revoked(family_id: str) -> None:
+            if loxone_store is not None:
+                loxone_store.delete(family_id)
+            runtime_value = runtime_ref.get("runtime")
+            if runtime_value is None:
+                return
+            try:
+                asyncio.get_running_loop().create_task(runtime_value.revoke(family_id))
+            except RuntimeError:
+                # Startup cleanup has no running event loop; the token was still removed.
+                return
+
         provider = Phase0OAuthProvider(
             auth_store,
             issuer=settings.phase0_auth.issuer_url,
             resource=settings.phase0_auth.resource_url,
-            on_family_revoked=loxone_store.delete if loxone_store is not None else None,
+            on_family_revoked=on_family_revoked,
             control_enabled=bool(config and config.loxone_control_enabled),
             loxberry_read_enabled=bool(config and config.loxberry_read_enabled),
             loxberry_read_allowed=loxberry_binding_allowed,
@@ -352,15 +367,10 @@ def create_server(settings: ServerSettings) -> FastMCP:
         )
         token_verifier = _Phase0TokenVerifier(provider)
         if loxone_store is not None:
-            cache_directory = (
-                settings.phase0_auth.store_path.parent.parent / "statistics-cache"
-                if config is not None and config.statistics_cache_mode == "hybrid"
-                else None
-            )
             statistics_cache = StatisticsCache(
-                cache_directory,
+                None,
                 maximum_bytes=(
-                    config.statistics_cache_max_mib * 1024 * 1024
+                    config.statistics_memory_max_mib * 1024 * 1024
                     if config is not None
                     else 128 * 1024 * 1024
                 ),
@@ -380,7 +390,27 @@ def create_server(settings: ServerSettings) -> FastMCP:
                 statistics_cache=statistics_cache,
                 control_enabled=bool(config and config.loxone_control_enabled),
                 history_enabled=bool(config and config.loxone_history_enabled),
+                structure_refresh_seconds=(
+                    config.structure_refresh_seconds if config is not None else 300
+                ),
+                max_active_sessions=(
+                    config.max_active_runtime_sessions if config is not None else 16
+                ),
+                session_idle_seconds=(
+                    config.runtime_session_idle_seconds if config is not None else 900
+                ),
+                max_states_per_identity=(
+                    config.max_states_per_identity if config is not None else 20_000
+                ),
+                max_structure_controls=(
+                    config.max_structure_controls if config is not None else 20_000
+                ),
+                max_structure_state_references=(
+                    config.max_structure_state_references if config is not None else 100_000
+                ),
+                max_structure_depth=(config.max_structure_depth if config is not None else 32),
             )
+            runtime_ref["runtime"] = runtime
         if config and settings.phase0_auth.config_path is not None:
             home = Path(os.getenv("LBHOMEDIR", "/opt/loxberry"))
             if home.is_absolute():

--- a/src/mcpserver/tools.py
+++ b/src/mcpserver/tools.py
@@ -268,6 +268,7 @@ class SystemStatusData(BaseModel):
     miniserver_serial: str
     structure_last_modified: str
     cache_freshness: str
+    structure_generation: int = Field(description="Monotonic generation of the current structure.")
 
 
 class ToolEnvelope(BaseModel):
@@ -855,6 +856,7 @@ def register_read_tools(
                     "miniserver_serial": snapshot.structure.identity.miniserver_serial,
                     "structure_last_modified": snapshot.structure.last_modified,
                     "cache_freshness": "current" if snapshot.connected else "stale",
+                    "structure_generation": snapshot.structure_generation,
                 },
                 stale=not snapshot.connected,
             )

--- a/templates/index.html
+++ b/templates/index.html
@@ -160,10 +160,20 @@
         </section>
       </div>
       <p id="permission-policy-hint" class="mcp-help"><TMPL_VAR SETUP.PERMISSIONS_HINT></p>
-      <div class="mcp-grid">
-        <label class="mcp-field"><span><TMPL_VAR SETUP.CACHE_MODE></span><select name="statistics_mode"><option value="memory" <TMPL_IF STATISTICS_MODE_MEMORY>selected</TMPL_IF>><TMPL_VAR SETUP.CACHE_MEMORY></option><option value="hybrid" <TMPL_IF STATISTICS_MODE_HYBRID>selected</TMPL_IF>><TMPL_VAR SETUP.CACHE_HYBRID></option></select></label>
-        <label class="mcp-field"><span><TMPL_VAR SETUP.CACHE_SIZE></span><input name="statistics_max_mib" type="number" min="16" max="512" value="<TMPL_VAR STATISTICS_MAX_MIB ESCAPE=HTML>"></label>
-      </div>
+      <details class="mcp-persistent-section">
+        <summary><TMPL_VAR SETUP.ADVANCED_LIMITS></summary>
+        <div class="mcp-grid">
+          <label class="mcp-field"><span><TMPL_VAR SETUP.STRUCTURE_REFRESH></span><input name="structure_refresh_seconds" type="number" min="60" max="3600" value="<TMPL_VAR STRUCTURE_REFRESH_SECONDS ESCAPE=HTML>"></label>
+          <label class="mcp-field"><span><TMPL_VAR SETUP.RUNTIME_SESSIONS></span><input name="max_active_runtime_sessions" type="number" min="1" max="128" value="<TMPL_VAR MAX_ACTIVE_RUNTIME_SESSIONS ESCAPE=HTML>"></label>
+          <label class="mcp-field"><span><TMPL_VAR SETUP.RUNTIME_IDLE></span><input name="runtime_session_idle_seconds" type="number" min="60" max="86400" value="<TMPL_VAR RUNTIME_SESSION_IDLE_SECONDS ESCAPE=HTML>"></label>
+          <label class="mcp-field"><span><TMPL_VAR SETUP.STRUCTURE_CONTROLS></span><input name="max_structure_controls" type="number" min="1000" max="100000" value="<TMPL_VAR MAX_STRUCTURE_CONTROLS ESCAPE=HTML>"></label>
+          <label class="mcp-field"><span><TMPL_VAR SETUP.STRUCTURE_STATES></span><input name="max_structure_state_references" type="number" min="10000" max="500000" value="<TMPL_VAR MAX_STRUCTURE_STATE_REFERENCES ESCAPE=HTML>"></label>
+          <label class="mcp-field"><span><TMPL_VAR SETUP.STRUCTURE_DEPTH></span><input name="max_structure_depth" type="number" min="4" max="128" value="<TMPL_VAR MAX_STRUCTURE_DEPTH ESCAPE=HTML>"></label>
+          <label class="mcp-field"><span><TMPL_VAR SETUP.CACHE_SIZE></span><input name="statistics_memory_max_mib" type="number" min="16" max="512" value="<TMPL_VAR STATISTICS_MEMORY_MAX_MIB ESCAPE=HTML>"></label>
+          <label class="mcp-field"><span><TMPL_VAR SETUP.CACHED_STATES></span><input name="max_states_per_identity" type="number" min="1000" max="100000" value="<TMPL_VAR MAX_STATES_PER_IDENTITY ESCAPE=HTML>"></label>
+        </div>
+        <p class="mcp-help"><TMPL_VAR SETUP.ADVANCED_LIMITS_HELP></p>
+      </details>
       <div class="mcp-actions">
         <button class="lb-button" type="submit"><TMPL_VAR ACTION.SAVE></button>
       </div>

--- a/templates/lang/language_de.ini
+++ b/templates/lang/language_de.ini
@@ -43,10 +43,16 @@ OPERATE_OPTION=Statistik-Cache verwalten
 OPERATE_DESCRIPTION=Plugin-eigenen Statistik-Cache löschen.
 OPERATE_DEPENDENCY=Benötigt loxone:history und eine lokale Freigabe.
 PERMISSIONS_HINT=Die aktivierten Funktionen werden nicht automatisch an MCP-Clients vergeben. Der Benutzer bestätigt angeforderte Scopes separat bei der Anmeldung. LoxBerry-Berechtigungen benötigen zusätzlich eine lokale Administratorfreigabe.
-CACHE_MODE=Statistik-Cache-Modus
-CACHE_MEMORY=Nur Arbeitsspeicher
-CACHE_HYBRID=Hybrid (Arbeitsspeicher und begrenzter Legacy-Quellcache)
-CACHE_SIZE=Persistentes Cache-Limit (MiB)
+ADVANCED_LIMITS=Erweiterte Laufzeit- und Strukturgrenzen
+ADVANCED_LIMITS_HELP=Bei Überschreitung einer Strukturgrenze wird die Struktur sicher abgelehnt und im Dienstlog vermerkt.
+STRUCTURE_REFRESH=Strukturaktualisierung (Sekunden)
+RUNTIME_SESSIONS=Aktive Laufzeitverbindungen
+RUNTIME_IDLE=Leerlaufzeit einer Verbindung (Sekunden)
+STRUCTURE_CONTROLS=Maximale Controls in der Struktur
+STRUCTURE_STATES=Maximale State-Referenzen in der Struktur
+STRUCTURE_DEPTH=Maximale Verschachtelungstiefe
+CACHED_STATES=Maximale State-Werte je Anmeldung
+CACHE_SIZE=Statistik-RAM-Limit (MiB)
 
 [STATUS]
 TITLE=Status

--- a/templates/lang/language_en.ini
+++ b/templates/lang/language_en.ini
@@ -43,10 +43,16 @@ OPERATE_OPTION=Manage the statistics cache
 OPERATE_DESCRIPTION=Clear the plugin-owned statistics cache.
 OPERATE_DEPENDENCY=Requires loxone:history and local approval.
 PERMISSIONS_HINT=Enabled functions are not granted to MCP clients automatically. The user separately confirms requested scopes during sign-in. LoxBerry permissions additionally require local administrator approval.
-CACHE_MODE=Statistic cache mode
-CACHE_MEMORY=Memory only
-CACHE_HYBRID=Hybrid (memory and bounded legacy source cache)
-CACHE_SIZE=Persistent cache limit (MiB)
+ADVANCED_LIMITS=Advanced runtime and structure limits
+ADVANCED_LIMITS_HELP=When a structure limit is exceeded, the structure is safely rejected and an entry is written to the service log.
+STRUCTURE_REFRESH=Structure refresh (seconds)
+RUNTIME_SESSIONS=Active runtime connections
+RUNTIME_IDLE=Connection idle time (seconds)
+STRUCTURE_CONTROLS=Maximum controls in structure
+STRUCTURE_STATES=Maximum state references in structure
+STRUCTURE_DEPTH=Maximum nesting depth
+CACHED_STATES=Maximum state values per sign-in
+CACHE_SIZE=Statistics RAM limit (MiB)
 
 [STATUS]
 TITLE=Status

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,8 +24,9 @@ def test_defaults_are_disabled_and_bounded() -> None:
     assert config.loxberry_requests_per_minute == 30
     assert config.loxberry_read_bindings == ()
     assert config.loxberry_operate_bindings == ()
-    assert config.statistics_cache_mode == "memory"
-    assert config.statistics_cache_max_mib == 128
+    assert config.statistics_memory_max_mib == 128
+    assert config.structure_refresh_seconds == 300
+    assert config.max_structure_controls == 20_000
     assert config.max_parallel_calls == 4
     assert config.log_level == "warning"
 
@@ -47,7 +48,7 @@ def test_configuration_round_trip_preserves_unknown_keys(tmp_path: Path) -> None
 
     assert store.load().to_document() == config.to_document()
     assert json.loads(store.path.read_text(encoding="utf-8"))["future"] == {"keep": True}
-    assert config.to_document()["schema_version"] == 2
+    assert config.to_document()["schema_version"] == 3
 
 
 def test_phase_four_configuration_round_trips_bounded_settings() -> None:
@@ -63,7 +64,7 @@ def test_phase_four_configuration_round_trips_bounded_settings() -> None:
                 "history_requests_per_minute": 12,
                 "loxberry_operate_requests_per_minute": 2,
             },
-            "cache": {"statistics_mode": "hybrid", "statistics_max_mib": 64},
+            "cache": {"statistics_max_mib": 64},
             "policies": {"loxberry_operate_bindings": [binding]},
         }
     )
@@ -71,8 +72,7 @@ def test_phase_four_configuration_round_trips_bounded_settings() -> None:
     assert config.loxone_history_enabled is True
     assert config.loxberry_operate_enabled is True
     assert config.history_requests_per_minute == 12
-    assert config.statistics_cache_mode == "hybrid"
-    assert config.statistics_cache_max_mib == 64
+    assert config.statistics_memory_max_mib == 64
     assert config.loxberry_operate_bindings == (binding,)
 
 
@@ -80,7 +80,7 @@ def test_phase_four_configuration_round_trips_bounded_settings() -> None:
     "document",
     [
         {},
-        {"schema_version": 3},
+        {"schema_version": 4},
         {"schema_version": 1, "server": {"enabled": True}},
         {
             "schema_version": 1,

--- a/tests/test_loxone_structure.py
+++ b/tests/test_loxone_structure.py
@@ -175,6 +175,29 @@ def test_absent_controls_remain_absent() -> None:
     assert structure.controls == ()
 
 
+def test_structure_rejects_configured_control_and_depth_limits() -> None:
+    raw = {
+        "lastModified": "now",
+        "msInfo": {"serialNr": "000000000000"},
+        "rooms": {},
+        "cats": {},
+        "controls": {
+            "parent": {
+                "name": "Parent",
+                "type": "Switch",
+                "states": {},
+                "subControls": {"child": {"name": "Child", "type": "Switch", "states": {}}},
+            },
+            "second": {"name": "Second", "type": "Switch", "states": {}},
+        },
+    }
+
+    with pytest.raises(LoxoneStructureError, match="control count"):
+        normalize_structure(raw, username="reader", max_controls=1)
+    with pytest.raises(LoxoneStructureError, match="nesting depth"):
+        normalize_structure(raw, username="reader", max_depth=1)
+
+
 def test_structure_extracts_only_bounded_phase_four_capabilities() -> None:
     raw = {
         "lastModified": "now",

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -1,13 +1,8 @@
 from __future__ import annotations
 
-import gzip
 import math
-import os
 import struct
-from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
-from pathlib import Path
-from threading import Event
 
 import pytest
 
@@ -330,62 +325,21 @@ async def test_runtime_translates_history_and_statistic_timeouts() -> None:
         )
 
 
-def test_statistics_cache_expires_memory_and_clears_private_hybrid_files(
-    tmp_path: Path,
-) -> None:
+def test_statistics_cache_expires_memory_and_clears_only_ram() -> None:
     now = [10.0]
-    cache = StatisticsCache(tmp_path.resolve(), ttl_seconds=5, clock=lambda: now[0])
+    cache = StatisticsCache(ttl_seconds=5, clock=lambda: now[0])
     points = (StatisticPoint(100, 1.0),)
     key = cache.source_key("family", "control", "series")
 
     cache.put(key, points)
-    cache.put_legacy_source(key, b"bounded source")
 
     assert cache.get(key) == points
-    stored = list(tmp_path.glob("*.gz"))
-    assert len(stored) == 1
-    assert gzip.decompress(stored[0].read_bytes()) == b"bounded source"
     now[0] = 16.0
     assert cache.get(key) is None
     result = cache.clear()
-    assert result.persistent_entries_removed == 1
-    assert result.bytes_freed > 0
-    assert list(tmp_path.iterdir()) == []
-
-
-def test_statistics_cache_rejects_untrusted_persistent_key(tmp_path: Path) -> None:
-    cache = StatisticsCache(tmp_path.resolve())
-
-    cache.put_legacy_source("../escape", b"payload")
-
-    assert not tmp_path.exists() or list(tmp_path.iterdir()) == []
-
-
-def test_statistics_cache_clear_does_not_hold_memory_lock_during_persistent_io(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    cache = StatisticsCache(tmp_path.resolve())
-    point = StatisticPoint(100, 1.0)
-    entered_persistent_io = Event()
-    allow_persistent_io = Event()
-    entries = cache._entries
-
-    def slow_entries() -> list[tuple[Path, os.stat_result]]:
-        entered_persistent_io.set()
-        assert allow_persistent_io.wait(timeout=1)
-        return entries()
-
-    monkeypatch.setattr(cache, "_entries", slow_entries)
-
-    with ThreadPoolExecutor(max_workers=2) as executor:
-        clear = executor.submit(cache.clear)
-        assert entered_persistent_io.wait(timeout=1)
-        concurrent_put = executor.submit(cache.put, "live", (point,))
-        concurrent_put.result(timeout=0.2)
-        allow_persistent_io.set()
-        clear.result(timeout=1)
-
-    assert cache.get("live") == (point,)
+    assert result.memory_entries_removed == 0
+    assert result.persistent_entries_removed == 0
+    assert result.bytes_freed == 0
 
 
 def test_statistics_cache_purges_expired_and_bounds_memory_points() -> None:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -147,6 +147,7 @@ def test_read_results_and_expected_errors_are_debug_only(
             "miniserver_serial": "masked",
             "structure_last_modified": "",
             "cache_freshness": "current",
+            "structure_generation": 1,
         },
     )
     _error(SystemStatusEnvelope, "invalid_input", "invalid")

--- a/webfrontend/htmlauth/index.cgi
+++ b/webfrontend/htmlauth/index.cgi
@@ -344,7 +344,7 @@ if ($action ne '') {
     my $result;
     if ($action eq 'save_config') {
         my $document = {
-            schema_version => 2,
+            schema_version => 3,
             server => {
                 enabled => $q->{enabled} ? JSON::PP::true : JSON::PP::false,
                 public_origin => $q->{public_origin} // '',
@@ -371,10 +371,16 @@ if ($action ne '') {
                 history_requests_per_minute => 0 + ($q->{history_requests_per_minute} // 12),
                 loxberry_operate_requests_per_minute => 0 + ($q->{loxberry_operate_requests_per_minute} // 3),
                 max_parallel_calls => 0 + ($q->{max_parallel_calls} // 4),
+                structure_refresh_seconds => 0 + ($q->{structure_refresh_seconds} // 300),
+                max_active_runtime_sessions => 0 + ($q->{max_active_runtime_sessions} // 16),
+                runtime_session_idle_seconds => 0 + ($q->{runtime_session_idle_seconds} // 900),
+                max_structure_controls => 0 + ($q->{max_structure_controls} // 20000),
+                max_structure_state_references => 0 + ($q->{max_structure_state_references} // 100000),
+                max_structure_depth => 0 + ($q->{max_structure_depth} // 32),
+                max_states_per_identity => 0 + ($q->{max_states_per_identity} // 20000),
             },
             cache => {
-                statistics_mode => $q->{statistics_mode} // 'memory',
-                statistics_max_mib => 0 + ($q->{statistics_max_mib} // 128),
+                statistics_memory_max_mib => 0 + ($q->{statistics_memory_max_mib} // 128),
             },
         };
         $result = admin_call('save_config', $document);
@@ -551,10 +557,15 @@ $template->param(
     LOXBERRY_REQUESTS_PER_MINUTE => $config->{limits}{loxberry_requests_per_minute} // 30,
     HISTORY_REQUESTS_PER_MINUTE => $config->{limits}{history_requests_per_minute} // 12,
     LOXBERRY_OPERATE_REQUESTS_PER_MINUTE => $config->{limits}{loxberry_operate_requests_per_minute} // 3,
-    STATISTICS_MODE_MEMORY => ($config->{cache}{statistics_mode} // 'memory') eq 'memory' ? 1 : 0,
-    STATISTICS_MODE_HYBRID => ($config->{cache}{statistics_mode} // 'memory') eq 'hybrid' ? 1 : 0,
-    STATISTICS_MAX_MIB => $config->{cache}{statistics_max_mib} // 128,
+    STATISTICS_MEMORY_MAX_MIB => $config->{cache}{statistics_memory_max_mib} // $config->{cache}{statistics_max_mib} // 128,
     MAX_PARALLEL_CALLS => $config->{limits}{max_parallel_calls} // 4,
+    STRUCTURE_REFRESH_SECONDS => $config->{limits}{structure_refresh_seconds} // 300,
+    MAX_ACTIVE_RUNTIME_SESSIONS => $config->{limits}{max_active_runtime_sessions} // 16,
+    RUNTIME_SESSION_IDLE_SECONDS => $config->{limits}{runtime_session_idle_seconds} // 900,
+    MAX_STRUCTURE_CONTROLS => $config->{limits}{max_structure_controls} // 20000,
+    MAX_STRUCTURE_STATE_REFERENCES => $config->{limits}{max_structure_state_references} // 100000,
+    MAX_STRUCTURE_DEPTH => $config->{limits}{max_structure_depth} // 32,
+    MAX_STATES_PER_IDENTITY => $config->{limits}{max_states_per_identity} // 20000,
     LOG_LEVEL => $config->{logging}{level} // 'warning',
     LOG_LEVEL_OFF => ($config->{logging}{level} // 'warning') eq 'off' ? 1 : 0,
     LOG_LEVEL_ERROR => ($config->{logging}{level} // 'warning') eq 'error' ? 1 : 0,


### PR DESCRIPTION
Summary: bounded LoxAPP3 refresh, runtime sessions, RAM-only cache, UI and DE/EN docs. Verification: Python 3.13 full profile: 505 passed; git diff --check.