### PR TITLE
Preserve Loxone tokens on runtime shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ extracted from the matching version heading.
 ## 0.4.0-alpha.4 - 2026-08-13
 
 - Serialize due LoxAPP3 refreshes per OAuth family, close live Miniserver
-  sessions on service shutdown, and extend the deterministic lifecycle tests.
+  sessions on service shutdown without revoking persisted authorization, and
+  extend the deterministic lifecycle tests.
 - Move pure control discovery presentation into its own module and make local
   release-candidate source copies ignore untracked build and temporary artifacts.
 - Simplify `loxberry_clear_statistics_cache` to report only removed RAM entries;

--- a/src/mcpserver/loxone/runtime.py
+++ b/src/mcpserver/loxone/runtime.py
@@ -885,4 +885,4 @@ class LoxoneRuntime:
 
     async def close(self) -> None:
         for family_id in tuple(self._records):
-            await self.revoke(family_id)
+            await self.disconnect(family_id)

--- a/tests/test_loxone_runtime.py
+++ b/tests/test_loxone_runtime.py
@@ -132,15 +132,15 @@ async def test_due_structure_refresh_fails_closed() -> None:
 
 
 @pytest.mark.asyncio
-async def test_runtime_close_disconnects_all_records_and_deletes_tokens() -> None:
+async def test_runtime_close_disconnects_all_records_without_revoking_tokens() -> None:
     runtime = object.__new__(LoxoneRuntime)
     closed: list[str] = []
 
-    async def revoke(family_id: str) -> None:
+    async def disconnect(family_id: str) -> None:
         closed.append(family_id)
 
     runtime._records = {"one": object(), "two": object()}
-    runtime.revoke = revoke  # type: ignore[method-assign]
+    runtime.disconnect = disconnect  # type: ignore[method-assign]
 
     await runtime.close()
 


### PR DESCRIPTION
Summary: make the FastMCP shutdown lifecycle disconnect live Miniserver sessions and RAM state without deleting persisted Loxone authorization. Verification: Python 3.13 Full, 512 passed; targeted lifecycle regression tests.