### PR TITLE
Refresh LoxAPP3 by version marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 All notable user-visible changes are recorded here. GitHub release notes are
 extracted from the matching version heading.
 
-## 0.4.0-alpha.4 - 2026-08-13
+## 0.4.0-alpha.5 - 2026-08-13
 
+- Check the documented LoxAPP3 version marker before each due structure refresh
+  and download the full user-filtered structure only after a detected change.
 - Serialize due LoxAPP3 refreshes per OAuth family, close live Miniserver
   sessions on service shutdown without revoking persisted authorization, and
   extend the deterministic lifecycle tests.

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Für jeden Assistenten sollte ein eigener Loxone-Benutzer mit den minimal erford
 ## Projektstatus
 
 Phase 1 bis Phase 3 sind abgenommen. Der vorbereitete Phase-4-Pre-Release
-`0.4.0-alpha.4` ergänzt eine begrenzte, single-flight LoxAPP3-Aktualisierung,
-einen kontrollierten Runtime-Shutdown und einen ausschließlich flüchtigen
-Statistik-Cache. Das Schreibwerkzeug unterstützt auf Gen.-1-Controls die Typen
+`0.4.0-alpha.5` ergänzt eine versionsgeprüfte, begrenzte single-flight
+LoxAPP3-Aktualisierung, einen kontrollierten Runtime-Shutdown und einen
+ausschließlich flüchtigen Statistik-Cache. Das Schreibwerkzeug unterstützt auf Gen.-1-Controls die Typen
 `Switch`, `Dimmer`, `LightController`, `LightControllerV2`, `Jalousie`,
 `TimedSwitch`, `Radio`, `LightsceneRGB`, `ColorPicker`, `ColorPickerV2` und
 `Pushbutton`. Es bleibt

--- a/docs/development/support-matrix.md
+++ b/docs/development/support-matrix.md
@@ -1,13 +1,13 @@
 # Support-Matrix
 
 - **Stand:** Runtime-/Strukturhärtung, 2026-08-13
-- **Vorbereiteter Pre-Release:** `0.4.0-alpha.4`
+- **Vorbereiteter Pre-Release:** `0.4.0-alpha.5`
 - **Nächster Meilenstein:** gezielte reale Abnahme der noch unbestätigten
   Phase-4-Aktionen und V1-Varianten
 
 Diese Matrix unterscheidet reale Nachweise von implementierten, aber noch nicht
 real bestätigten Kombinationen. Phase 1, Phase 2 und Phase 3 sind abgenommen;
-`0.4.0-alpha.4` bleibt wegen seines Vorabversionsstatus ein Pre-Release.
+`0.4.0-alpha.5` bleibt wegen seines Vorabversionsstatus ein Pre-Release.
 Phase 4 ist implementiert und für die lesenden Statistik-/Historienpfade, die
 eng begrenzte plugin-eigene Cache-Operation und ausgewählte, reversible
 Control-Aktionen auf Hardware abgenommen; siehe

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -1,4 +1,4 @@
-# LoxBerry MCP Server 0.4.0-alpha.4
+# LoxBerry MCP Server 0.4.0-alpha.5
 
 ## Voraussetzungen
 
@@ -264,9 +264,11 @@ RAM-Cache; es gibt keinen persistenten Statistik- oder FTP-/XML-Cache.
 Die sichtbare Loxone-Struktur wird beim Verbinden und nach einem Dienstneustart
 neu geladen. Während einer stabilen Verbindung prüft der Server sie zusätzlich
 in dem unter **Erweiterte Laufzeit- und Strukturgrenzen** konfigurierten Intervall
-(standardmäßig fünf Minuten). Dadurch werden auch geänderte Control-Hinweise,
-Bewertungen und Favoriten erkannt. Kann eine fällige Strukturprüfung nicht
-erfolgen, liefert der Server keine möglicherweise veraltete Struktur. Die
+(standardmäßig fünf Minuten). Dabei fragt er zuerst nur den Loxone-
+Strukturzeitstempel ab und lädt `LoxAPP3.json` ausschließlich bei einer Änderung.
+Dadurch werden auch geänderte Control-Hinweise, Anzeigenamen, Bewertungen und
+Favoriten erkannt. Kann eine fällige Strukturprüfung nicht erfolgen, liefert der
+Server keine möglicherweise veraltete Struktur. Die
 konfigurierbaren Strukturgrenzen schützen umfangreiche Projekte; eine
 Überschreitung wird abgelehnt und ohne Control-Inhalte im Dienstlog vermerkt.
 

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -1,4 +1,4 @@
-# LoxBerry MCP Server 0.4.0-alpha.4
+# LoxBerry MCP Server 0.4.0-alpha.5
 
 ## Requirements
 
@@ -246,9 +246,11 @@ files on the authenticated WebSocket. Results remain in a bounded RAM cache for
 The visible Loxone structure is reloaded on connection and after a service
 restart. While a connection remains stable, the server also checks it at the
 interval configured under **Advanced runtime and structure limits** (five minutes
-by default). This detects changed Control Notes, ratings, and favorites. If a due
-structure check cannot complete, the server does not return a possibly outdated
-structure. Configurable structure limits protect large projects; an exceeded limit
+by default). It first requests only Loxone's structure-version marker and downloads
+`LoxAPP3.json` only when that marker changed. This detects changed Control Notes,
+display names, ratings, and favorites. If a due structure check cannot complete,
+the server does not return a possibly outdated structure. Configurable structure
+limits protect large projects; an exceeded limit
 rejects the structure and writes a sanitized service-log entry.
 
 `loxone_describe_control` also returns direct control relationships: a subcontrol

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -3,11 +3,11 @@ NAME=Miraculix2050
 EMAIL=198097126+Miraculix2050@users.noreply.github.com
 
 [PLUGIN]
-VERSION=0.4.0-alpha.4
+VERSION=0.4.0-alpha.5
 NAME=mcpserver
 FOLDER=mcpserver
 TITLE=LoxBerry MCP Server
-WEBSITE=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/blob/v0.4.0-alpha.4/README.md
+WEBSITE=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/blob/v0.4.0-alpha.5/README.md
 
 [AUTOUPDATE]
 AUTOMATIC_UPDATES=false

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -52,7 +52,7 @@ fi
 
 python3.13 -m venv "$new_venv" || exit 2
 "$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" -r "$plugin_bin/runtime-arm64.lock" || exit 2
-"$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" loxberry-mcpserver==0.4.0a4 || exit 2
+"$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" loxberry-mcpserver==0.4.0a5 || exit 2
 if [ -d "$venv" ]; then
     mv "$venv" "$old_venv" || exit 2
 fi

--- a/prerelease.cfg
+++ b/prerelease.cfg
@@ -1,4 +1,4 @@
 [AUTOUPDATE]
-VERSION=0.4.0-alpha.4
-ARCHIVEURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/download/v0.4.0-alpha.4/LoxBerry-MCP-Server-0.4.0-alpha.4.zip
-INFOURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/tag/v0.4.0-alpha.4
+VERSION=0.4.0-alpha.5
+ARCHIVEURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/download/v0.4.0-alpha.5/LoxBerry-MCP-Server-0.4.0-alpha.5.zip
+INFOURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/tag/v0.4.0-alpha.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loxberry-mcpserver"
-version = "0.4.0-alpha.4"
+version = "0.4.0-alpha.5"
 description = "Local MCP server for LoxBerry and Loxone"
 requires-python = ">=3.13,<3.14"
 license = "Apache-2.0"

--- a/src/mcpserver/__init__.py
+++ b/src/mcpserver/__init__.py
@@ -5,6 +5,6 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("loxberry-mcpserver")
 except PackageNotFoundError:  # pragma: no cover - source tree without installation
-    __version__ = "0.4.0-alpha.4"
+    __version__ = "0.4.0-alpha.5"
 
 __all__ = ["__version__"]

--- a/src/mcpserver/loxone/client.py
+++ b/src/mcpserver/loxone/client.py
@@ -597,6 +597,13 @@ class LoxoneWebSocketSession:
             )
             raise LoxoneProtocolError("Miniserver structure response is invalid") from exc
 
+    async def structure_version(self) -> str:
+        """Return the current LoxAPP3 modification marker without downloading it."""
+        value = await self._command("jdev/sps/LoxAPPversion3", encrypted=not self._secure_transport)
+        if not isinstance(value, str) or not value or len(value) > 128:
+            raise LoxoneProtocolError("Miniserver structure version response is invalid")
+        return value
+
     async def refresh_token(self) -> None:
         """Rotate the in-memory JWT over the authenticated encrypted WebSocket."""
         digest = await self._fresh_token_digest()

--- a/src/mcpserver/loxone/runtime.py
+++ b/src/mcpserver/loxone/runtime.py
@@ -804,6 +804,11 @@ class LoxoneRuntime:
                 raise LoxoneTokenStoreError("Loxone token is unavailable")
             session = await self.client.open_session(token)
             try:
+                version = await session.structure_version()
+                if version == record.structure.last_modified:
+                    record.last_structure_check = time.monotonic()
+                    _LOGGER.debug("component=structure outcome=unchanged")
+                    return
                 structure = await session.load_structure()
             finally:
                 await session.close()
@@ -814,12 +819,14 @@ class LoxoneRuntime:
             )
             raise RuntimeUnavailable("Miniserver structure refresh failed") from exc
         record.last_structure_check = time.monotonic()
-        if structure.last_modified != record.structure.last_modified:
-            record.structure = structure
-            record.allowed_states = _state_uuids(structure.controls + structure.hidden_controls)
-            record.generation += 1
-            self.cache.apply(access.family_id, (), allowed_uuids=record.allowed_states)
-            _LOGGER.info("component=structure outcome=changed")
+        if structure.last_modified == record.structure.last_modified:
+            _LOGGER.warning("component=structure outcome=version_mismatch_without_change")
+            return
+        record.structure = structure
+        record.allowed_states = _state_uuids(structure.controls + structure.hidden_controls)
+        record.generation += 1
+        self.cache.apply(access.family_id, (), allowed_uuids=record.allowed_states)
+        _LOGGER.info("component=structure outcome=changed")
 
     async def _maintain(
         self,

--- a/tests/test_loxone_client.py
+++ b/tests/test_loxone_client.py
@@ -919,6 +919,29 @@ async def test_structure_accepts_gen1_text_content_in_file_message(
 
 
 @pytest.mark.asyncio
+async def test_structure_version_uses_authenticated_bounded_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = LoxoneWebSocketSession(
+        cast(Any, object()),
+        public_key="unused",
+        token=LoxoneToken("jwt", "reader", "key", "SHA256", 100),
+        timeout_seconds=1,
+        max_payload_bytes=100,
+    )
+    commands: list[tuple[str, bool]] = []
+
+    async def fake_command(command: str, *, encrypted: bool = False) -> object:
+        commands.append((command, encrypted))
+        return "2026-08-13 16:09:49"
+
+    monkeypatch.setattr(session, "_command", fake_command)
+
+    assert await session.structure_version() == "2026-08-13 16:09:49"
+    assert commands == [("jdev/sps/LoxAPPversion3", True)]
+
+
+@pytest.mark.asyncio
 async def test_refresh_rotates_in_memory_token_with_dynamic_hash(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_loxone_runtime.py
+++ b/tests/test_loxone_runtime.py
@@ -58,6 +58,9 @@ async def test_due_structure_refresh_is_single_flight_and_increments_generation(
             return object()
 
     class RefreshSession(_Session):
+        async def structure_version(self) -> str:
+            return "new"
+
         async def load_structure(self) -> LoxoneStructure:
             return _structure("new")
 
@@ -125,6 +128,47 @@ async def test_due_structure_refresh_fails_closed() -> None:
 
     with pytest.raises(RuntimeUnavailable, match="structure refresh failed"):
         await runtime.snapshot(_access())
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_due_structure_refresh_checks_version_without_reloading_unchanged_structure() -> None:
+    class Store:
+        def get(self, *_parts: str) -> object:
+            return object()
+
+    class RefreshSession(_Session):
+        async def structure_version(self) -> str:
+            return "current"
+
+        async def load_structure(self) -> LoxoneStructure:
+            raise AssertionError("unchanged structure must not be downloaded")
+
+    class Client:
+        async def open_session(self, _token: object) -> RefreshSession:
+            return RefreshSession()
+
+    runtime = object.__new__(LoxoneRuntime)
+    task = asyncio.create_task(asyncio.sleep(60))
+    record = _ConnectionRecord(
+        _structure("current"), frozenset(), _Session(), task, last_structure_check=0
+    )
+    runtime._records = {"family": record}
+    runtime._locks = defaultdict(asyncio.Lock)
+    runtime._prune_sessions = lambda _subject: asyncio.sleep(0)  # type: ignore[method-assign]
+    runtime.token_store = Store()
+    runtime.client = Client()
+    runtime.cache = UserStateCache()
+    runtime.structure_refresh_seconds = 1
+
+    snapshot = await runtime.snapshot(_access())
+
+    assert snapshot.structure_generation == 1
+    assert snapshot.structure.last_modified == "current"
+    assert record.last_structure_check > 0
 
     task.cancel()
     with pytest.raises(asyncio.CancelledError):

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -120,7 +120,7 @@ def test_plugin_identity_and_platform_contract() -> None:
     assert parser["PLUGIN"]["NAME"] == "mcpserver"
     assert parser["PLUGIN"]["FOLDER"] == "mcpserver"
     assert parser["PLUGIN"]["TITLE"] == "LoxBerry MCP Server"
-    assert parser["PLUGIN"]["VERSION"] == "0.4.0-alpha.4"
+    assert parser["PLUGIN"]["VERSION"] == "0.4.0-alpha.5"
     assert parser["SYSTEM"]["LB_MINIMUM"] == "4.0.0"
     assert parser["SYSTEM"]["INTERFACE"] == "2.0"
     for name in ("release.cfg", "prerelease.cfg"):
@@ -455,7 +455,7 @@ def test_plugin_archive_verifier_accepts_builder_output(tmp_path: Path) -> None:
     for name, version in _locked_requirements(ROOT / "requirements" / "runtime-arm64.lock").items():
         wheel_name = name.replace("-", "_")
         (wheelhouse / f"{wheel_name}-{version}-py3-none-any.whl").write_bytes(b"wheel")
-    project_wheel = wheelhouse / "loxberry_mcpserver-0.4.0a4-py3-none-any.whl"
+    project_wheel = wheelhouse / "loxberry_mcpserver-0.4.0a5-py3-none-any.whl"
     _write_project_wheel(project_wheel)
     hash_lock = tmp_path / "runtime-arm64.sha256"
     hash_lock.write_text(
@@ -861,12 +861,12 @@ def test_plugin_archive_verifier_rejects_checksum_mismatch(tmp_path: Path) -> No
 
 
 def test_release_metadata_and_changelog_match_current_prerelease() -> None:
-    notes = validate_release_metadata(ROOT, "0.4.0-alpha.4", "prerelease")
+    notes = validate_release_metadata(ROOT, "0.4.0-alpha.5", "prerelease")
 
     assert "Serialize due LoxAPP3 refreshes" in notes
     assert "hybrid-cache compatibility fields" in notes
     with pytest.raises(ValueError, match="stable releases"):
-        validate_release_metadata(ROOT, "0.4.0-alpha.4", "stable")
+        validate_release_metadata(ROOT, "0.4.0-alpha.5", "stable")
     with pytest.raises(ValueError, match="versions do not match"):
         validate_release_metadata(ROOT, "0.3.0-alpha.2", "prerelease")
 


### PR DESCRIPTION
## Summary
- check the documented LoxAPP3 version marker before downloading the full structure
- keep due refreshes single-flight and fail closed on a version-check error
- document the version-first refresh behavior and prepare 0.4.0-alpha.5

## Root cause
The prior refresh path downloaded LoxAPP3.json unconditionally, while Loxone provides a lightweight version marker for cache validation.

## Validation
- Python 3.13: tools/test.py --profile full (514 passed)