### PR TITLE
Fix Firefox Explorer OAuth popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable user-visible changes are recorded here. GitHub release notes are
 extracted from the matching version heading.
 
+## 0.4.0-alpha.6 - 2026-08-13
+
+- Open the Tool Explorer OAuth popup synchronously from the user click, then
+  navigate it after asynchronous discovery and PKCE setup so Firefox does not
+  block a valid sign-in popup.
+
 ## 0.4.0-alpha.5 - 2026-08-13
 
 - Check the documented LoxAPP3 version marker before each due structure refresh

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Für jeden Assistenten sollte ein eigener Loxone-Benutzer mit den minimal erford
 ## Projektstatus
 
 Phase 1 bis Phase 3 sind abgenommen. Der vorbereitete Phase-4-Pre-Release
-`0.4.0-alpha.5` ergänzt eine versionsgeprüfte, begrenzte single-flight
+`0.4.0-alpha.6` ergänzt eine Firefox-sichere OAuth-Popup-Öffnung im MCP Tool
+Explorer sowie die versionsgeprüfte, begrenzte single-flight
 LoxAPP3-Aktualisierung, einen kontrollierten Runtime-Shutdown und einen
 ausschließlich flüchtigen Statistik-Cache. Das Schreibwerkzeug unterstützt auf Gen.-1-Controls die Typen
 `Switch`, `Dimmer`, `LightController`, `LightControllerV2`, `Jalousie`,

--- a/docs/development/support-matrix.md
+++ b/docs/development/support-matrix.md
@@ -1,13 +1,13 @@
 # Support-Matrix
 
 - **Stand:** Runtime-/Strukturhärtung, 2026-08-13
-- **Vorbereiteter Pre-Release:** `0.4.0-alpha.5`
+- **Vorbereiteter Pre-Release:** `0.4.0-alpha.6`
 - **Nächster Meilenstein:** gezielte reale Abnahme der noch unbestätigten
   Phase-4-Aktionen und V1-Varianten
 
 Diese Matrix unterscheidet reale Nachweise von implementierten, aber noch nicht
 real bestätigten Kombinationen. Phase 1, Phase 2 und Phase 3 sind abgenommen;
-`0.4.0-alpha.5` bleibt wegen seines Vorabversionsstatus ein Pre-Release.
+`0.4.0-alpha.6` bleibt wegen seines Vorabversionsstatus ein Pre-Release.
 Phase 4 ist implementiert und für die lesenden Statistik-/Historienpfade, die
 eng begrenzte plugin-eigene Cache-Operation und ausgewählte, reversible
 Control-Aktionen auf Hardware abgenommen; siehe

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -1,4 +1,4 @@
-# LoxBerry MCP Server 0.4.0-alpha.5
+# LoxBerry MCP Server 0.4.0-alpha.6
 
 ## Voraussetzungen
 
@@ -171,6 +171,12 @@ vorgesehen.
 zugängliche Browserseite für den lokalen MCP-Endpunkt. Sie meldet sich wie jeder
 andere MCP-Client mit einem Loxone-Benutzer an und übernimmt keine Rechte aus der
 LoxBerry-Admin-Sitzung.
+
+**Mit Loxone anmelden** öffnet den Freigabedialog in einem eigenen Fenster. Der
+Explorer öffnet dieses Fenster direkt durch den Klick, damit Firefox es nicht
+als unerwünschtes Popup blockiert. Blockiert ein Browser das Fenster dennoch,
+erlaube Popups für die aktuelle lokale HTTPS-Adresse und starte die Anmeldung
+erneut.
 
 Nach der Anmeldung zeigt der Explorer die aktuell veröffentlichten Tools samt
 Beschreibung, Schema und Read-/Write-Kennzeichnung. Argumente können entweder

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -1,4 +1,4 @@
-# LoxBerry MCP Server 0.4.0-alpha.5
+# LoxBerry MCP Server 0.4.0-alpha.6
 
 ## Requirements
 
@@ -160,6 +160,11 @@ change; the manual reissue covers that case.
 **Open MCP Tool Explorer** opens a separate, admin-only browser page for the
 local MCP endpoint. It signs in with a Loxone user like every other MCP client
 and does not inherit permissions from the LoxBerry admin session.
+
+**Sign in with Loxone** opens the consent flow in a separate window. The
+Explorer opens that window directly from the click so Firefox does not treat it
+as an unsolicited popup. If a browser still blocks it, allow popups for the
+current local HTTPS address and start the sign-in again.
 
 After sign-in, the explorer lists the currently published tools with their
 description, schema and read/write classification. Arguments can be edited in

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -3,11 +3,11 @@ NAME=Miraculix2050
 EMAIL=198097126+Miraculix2050@users.noreply.github.com
 
 [PLUGIN]
-VERSION=0.4.0-alpha.5
+VERSION=0.4.0-alpha.6
 NAME=mcpserver
 FOLDER=mcpserver
 TITLE=LoxBerry MCP Server
-WEBSITE=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/blob/v0.4.0-alpha.5/README.md
+WEBSITE=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/blob/v0.4.0-alpha.6/README.md
 
 [AUTOUPDATE]
 AUTOMATIC_UPDATES=false

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -52,7 +52,7 @@ fi
 
 python3.13 -m venv "$new_venv" || exit 2
 "$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" -r "$plugin_bin/runtime-arm64.lock" || exit 2
-"$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" loxberry-mcpserver==0.4.0a5 || exit 2
+"$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" loxberry-mcpserver==0.4.0a6 || exit 2
 if [ -d "$venv" ]; then
     mv "$venv" "$old_venv" || exit 2
 fi

--- a/prerelease.cfg
+++ b/prerelease.cfg
@@ -1,4 +1,4 @@
 [AUTOUPDATE]
-VERSION=0.4.0-alpha.5
-ARCHIVEURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/download/v0.4.0-alpha.5/LoxBerry-MCP-Server-0.4.0-alpha.5.zip
-INFOURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/tag/v0.4.0-alpha.5
+VERSION=0.4.0-alpha.6
+ARCHIVEURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/download/v0.4.0-alpha.6/LoxBerry-MCP-Server-0.4.0-alpha.6.zip
+INFOURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/tag/v0.4.0-alpha.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loxberry-mcpserver"
-version = "0.4.0-alpha.5"
+version = "0.4.0-alpha.6"
 description = "Local MCP server for LoxBerry and Loxone"
 requires-python = ">=3.13,<3.14"
 license = "Apache-2.0"

--- a/src/mcpserver/__init__.py
+++ b/src/mcpserver/__init__.py
@@ -5,6 +5,6 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("loxberry-mcpserver")
 except PackageNotFoundError:  # pragma: no cover - source tree without installation
-    __version__ = "0.4.0-alpha.5"
+    __version__ = "0.4.0-alpha.6"
 
 __all__ = ["__version__"]

--- a/tests/test_explorer_ui.py
+++ b/tests/test_explorer_ui.py
@@ -125,6 +125,19 @@ def test_explorer_uses_current_https_origin_for_validated_oauth_endpoints() -> N
     )
 
 
+def test_explorer_opens_oauth_popup_in_the_connect_click_handler() -> None:
+    source = SCRIPT.read_text(encoding="utf-8")
+    handler_start = source.index("elements.connect.addEventListener('click'")
+    handler = source[
+        handler_start : source.index("elements.disconnect.addEventListener", handler_start)
+    ]
+
+    assert "const authorizationPopup = openAuthorizationPopup();" in handler
+    assert handler.index("openAuthorizationPopup()") < handler.index("setBusy(true)")
+    assert "state.oauth = await authorize(authorizationPopup);" in handler
+    assert "authorizationPopup?.close()" in handler
+
+
 def test_explorer_reuses_only_schema_compatible_values() -> None:
     tools = [
         {

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -120,7 +120,7 @@ def test_plugin_identity_and_platform_contract() -> None:
     assert parser["PLUGIN"]["NAME"] == "mcpserver"
     assert parser["PLUGIN"]["FOLDER"] == "mcpserver"
     assert parser["PLUGIN"]["TITLE"] == "LoxBerry MCP Server"
-    assert parser["PLUGIN"]["VERSION"] == "0.4.0-alpha.5"
+    assert parser["PLUGIN"]["VERSION"] == "0.4.0-alpha.6"
     assert parser["SYSTEM"]["LB_MINIMUM"] == "4.0.0"
     assert parser["SYSTEM"]["INTERFACE"] == "2.0"
     for name in ("release.cfg", "prerelease.cfg"):
@@ -455,7 +455,7 @@ def test_plugin_archive_verifier_accepts_builder_output(tmp_path: Path) -> None:
     for name, version in _locked_requirements(ROOT / "requirements" / "runtime-arm64.lock").items():
         wheel_name = name.replace("-", "_")
         (wheelhouse / f"{wheel_name}-{version}-py3-none-any.whl").write_bytes(b"wheel")
-    project_wheel = wheelhouse / "loxberry_mcpserver-0.4.0a5-py3-none-any.whl"
+    project_wheel = wheelhouse / "loxberry_mcpserver-0.4.0a6-py3-none-any.whl"
     _write_project_wheel(project_wheel)
     hash_lock = tmp_path / "runtime-arm64.sha256"
     hash_lock.write_text(
@@ -861,12 +861,12 @@ def test_plugin_archive_verifier_rejects_checksum_mismatch(tmp_path: Path) -> No
 
 
 def test_release_metadata_and_changelog_match_current_prerelease() -> None:
-    notes = validate_release_metadata(ROOT, "0.4.0-alpha.5", "prerelease")
+    notes = validate_release_metadata(ROOT, "0.4.0-alpha.6", "prerelease")
 
-    assert "Serialize due LoxAPP3 refreshes" in notes
-    assert "hybrid-cache compatibility fields" in notes
+    assert "Open the Tool Explorer OAuth popup synchronously" in notes
+    assert "block a valid sign-in popup" in notes
     with pytest.raises(ValueError, match="stable releases"):
-        validate_release_metadata(ROOT, "0.4.0-alpha.5", "stable")
+        validate_release_metadata(ROOT, "0.4.0-alpha.6", "stable")
     with pytest.raises(ValueError, match="versions do not match"):
         validate_release_metadata(ROOT, "0.3.0-alpha.2", "prerelease")
 

--- a/webfrontend/htmlauth/explorer.js
+++ b/webfrontend/htmlauth/explorer.js
@@ -936,7 +936,16 @@
     });
   }
 
-  async function authorize() {
+  function openAuthorizationPopup() {
+    return window.open(
+      '',
+      'mcp-explorer-oauth',
+      'popup=yes,width=680,height=900,resizable=yes,scrollbars=yes',
+    );
+  }
+
+  async function authorize(popup) {
+    if (!popup) throw new Error(label('popupBlocked'));
     const resumeUntil = Date.now() + core.EXPLORER_SESSION_MS;
     const discovered = await discover();
     const supported = new Set(discovered.resourceMetadata.scopes_supported || []);
@@ -955,12 +964,7 @@
       code_challenge: challenge, code_challenge_method: 'S256', state: oauthState,
       scope, resource: discovered.resourceMetadata.resource,
     }).toString();
-    const popup = window.open(
-      authorizationUrl.href,
-      'mcp-explorer-oauth',
-      'popup=yes,width=680,height=900,resizable=yes,scrollbars=yes',
-    );
-    if (!popup) throw new Error(label('popupBlocked'));
+    popup.location.replace(authorizationUrl.href);
     const code = await waitForAuthorization(popup, oauthState);
     if (!code) throw new Error(label('authCancelled'));
     const token = await exchangeToken(
@@ -1591,10 +1595,13 @@
   }
 
   elements.connect.addEventListener('click', async () => {
+    // Open synchronously in the user gesture. Firefox otherwise treats the
+    // popup as unsolicited after the asynchronous discovery and PKCE setup.
+    const authorizationPopup = openAuthorizationPopup();
     setBusy(true);
     setStatus(label('working'), 'working');
     try {
-      state.oauth = await authorize();
+      state.oauth = await authorize(authorizationPopup);
       state.oauth.resumeEnabled = await acquireSessionOwnership(state.oauth.sessionId);
       if (state.oauth.resumeEnabled && !saveStoredSession(state.oauth)) {
         state.oauth.resumeEnabled = false;
@@ -1605,6 +1612,7 @@
       if (state.tools.length) selectTool(state.tools[0].name);
       setStatus(label('connected'), 'success');
     } catch (error) {
+      try { authorizationPopup?.close(); } catch (_closeError) { /* already gone */ }
       if (state.oauth) await revokeAndClear();
       else core.clearSensitiveState(state);
       showConnectionError(error, label('error'));


### PR DESCRIPTION
## Summary
- open the Explorer OAuth popup synchronously from the sign-in click
- navigate the popup only after asynchronous discovery and PKCE preparation
- close an unneeded popup on failure and document the behavior in German and English
- prepare version 0.4.0-alpha.6

## Validation
- python tools/test.py --profile full (515 passed, 1 expected deprecation warning)