### PR TITLE
Guide Explorer sign-in to HTTPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,15 @@
 All notable user-visible changes are recorded here. GitHub release notes are
 extracted from the matching version heading.
 
+## 0.4.0-alpha.7 - 2026-08-13
+
+- Block MCP Tool Explorer sign-in on HTTP before OAuth discovery and provide a
+  link that reloads the same IP address or hostname over HTTPS.
+
 ## 0.4.0-alpha.6 - 2026-08-13
 
 - Open the Tool Explorer OAuth popup synchronously from the user click, then
-  navigate it after asynchronous discovery and PKCE setup so Firefox does not
-  block a valid sign-in popup.
+  navigate it after asynchronous discovery and PKCE setup.
 
 ## 0.4.0-alpha.5 - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ extracted from the matching version heading.
 ## 0.4.0-alpha.7 - 2026-08-13
 
 - Block MCP Tool Explorer sign-in on HTTP before OAuth discovery and provide a
-  link that reloads the same IP address or hostname over HTTPS.
+  link that reloads the same IP address or hostname over HTTPS; open the HTTPS
+  authorization popup synchronously so Firefox retains the click activation.
 
 ## 0.4.0-alpha.6 - 2026-08-13
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Für jeden Assistenten sollte ein eigener Loxone-Benutzer mit den minimal erford
 ## Projektstatus
 
 Phase 1 bis Phase 3 sind abgenommen. Der vorbereitete Phase-4-Pre-Release
-`0.4.0-alpha.6` ergänzt eine Firefox-sichere OAuth-Popup-Öffnung im MCP Tool
-Explorer sowie die versionsgeprüfte, begrenzte single-flight
+`0.4.0-alpha.7` blockiert die MCP-Tool-Explorer-Anmeldung auf HTTP mit einem
+Link zur gleichen IP-Adresse oder demselben Hostnamen über HTTPS sowie die versionsgeprüfte, begrenzte single-flight
 LoxAPP3-Aktualisierung, einen kontrollierten Runtime-Shutdown und einen
 ausschließlich flüchtigen Statistik-Cache. Das Schreibwerkzeug unterstützt auf Gen.-1-Controls die Typen
 `Switch`, `Dimmer`, `LightController`, `LightControllerV2`, `Jalousie`,

--- a/docs/development/phase-4-acceptance.md
+++ b/docs/development/phase-4-acceptance.md
@@ -136,3 +136,16 @@ state, and then confirmed restoration of its initial value. A
 documented structure has no state suitable for confirmation, so this is only
 command-accepted evidence. No digital Daytimer exists in the authorized test
 intersection; Daytimer override actions remain hardware-unverified.
+
+## Structure-version refresh acceptance
+
+On 2026-08-13, the deployed `0.4.0-alpha.5` structure-version refresh was
+read-only accepted on the authorized LoxBerry test target. On one visible
+control in the dedicated MCP test room and category, the user changed the
+display name, a Control Note, and the rating independently. After each change,
+the next read reported a newer Loxone structure marker and current cache
+freshness; the corresponding display name, bounded note result, and rating were
+visible through the MCP tools without restarting the Miniserver or plugin. The
+independent favorite boolean was returned as `false` during the rating check;
+changing that boolean itself remains hardware-unverified. No identifiers or
+user-authored note text are recorded here.

--- a/docs/development/support-matrix.md
+++ b/docs/development/support-matrix.md
@@ -1,13 +1,13 @@
 # Support-Matrix
 
 - **Stand:** Runtime-/Strukturhärtung, 2026-08-13
-- **Vorbereiteter Pre-Release:** `0.4.0-alpha.6`
+- **Vorbereiteter Pre-Release:** `0.4.0-alpha.7`
 - **Nächster Meilenstein:** gezielte reale Abnahme der noch unbestätigten
   Phase-4-Aktionen und V1-Varianten
 
 Diese Matrix unterscheidet reale Nachweise von implementierten, aber noch nicht
 real bestätigten Kombinationen. Phase 1, Phase 2 und Phase 3 sind abgenommen;
-`0.4.0-alpha.6` bleibt wegen seines Vorabversionsstatus ein Pre-Release.
+`0.4.0-alpha.7` bleibt wegen seines Vorabversionsstatus ein Pre-Release.
 Phase 4 ist implementiert und für die lesenden Statistik-/Historienpfade, die
 eng begrenzte plugin-eigene Cache-Operation und ausgewählte, reversible
 Control-Aktionen auf Hardware abgenommen; siehe

--- a/docs/development/support-matrix.md
+++ b/docs/development/support-matrix.md
@@ -13,6 +13,11 @@ eng begrenzte plugin-eigene Cache-Operation und ausgewählte, reversible
 Control-Aktionen auf Hardware abgenommen; siehe
 [Phase-4-Abnahmebericht](phase-4-acceptance.md).
 
+Die versionsmarkerbasierte Strukturaktualisierung ist zudem für geänderten
+Anzeigenamen, Control-Hinweis und Bewertung auf der autorisierten Testfixture
+hardware-abgenommen. Die separate Favoriten-Markierung bleibt ungetestet; siehe
+denselben Abnahmebericht.
+
 ## Plattformen und Geräte
 
 | Komponente | Getesteter Stand | Status | Nachweis und Grenze |

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -1,4 +1,4 @@
-# LoxBerry MCP Server 0.4.0-alpha.6
+# LoxBerry MCP Server 0.4.0-alpha.7
 
 ## Voraussetzungen
 
@@ -172,11 +172,9 @@ zugängliche Browserseite für den lokalen MCP-Endpunkt. Sie meldet sich wie jed
 andere MCP-Client mit einem Loxone-Benutzer an und übernimmt keine Rechte aus der
 LoxBerry-Admin-Sitzung.
 
-**Mit Loxone anmelden** öffnet den Freigabedialog in einem eigenen Fenster. Der
-Explorer öffnet dieses Fenster direkt durch den Klick, damit Firefox es nicht
-als unerwünschtes Popup blockiert. Blockiert ein Browser das Fenster dennoch,
-erlaube Popups für die aktuelle lokale HTTPS-Adresse und starte die Anmeldung
-erneut.
+**Mit Loxone anmelden** erfordert HTTPS. Bei einem über HTTP geöffneten
+Explorer wird keine OAuth-Anmeldung gestartet; stattdessen zeigt die Seite einen
+Link, der dieselbe IP-Adresse oder denselben Hostnamen über HTTPS lädt.
 
 Nach der Anmeldung zeigt der Explorer die aktuell veröffentlichten Tools samt
 Beschreibung, Schema und Read-/Write-Kennzeichnung. Argumente können entweder

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -1,4 +1,4 @@
-# LoxBerry MCP Server 0.4.0-alpha.6
+# LoxBerry MCP Server 0.4.0-alpha.7
 
 ## Requirements
 
@@ -161,10 +161,9 @@ change; the manual reissue covers that case.
 local MCP endpoint. It signs in with a Loxone user like every other MCP client
 and does not inherit permissions from the LoxBerry admin session.
 
-**Sign in with Loxone** opens the consent flow in a separate window. The
-Explorer opens that window directly from the click so Firefox does not treat it
-as an unsolicited popup. If a browser still blocks it, allow popups for the
-current local HTTPS address and start the sign-in again.
+**Sign in with Loxone** requires HTTPS. When the Explorer was opened over HTTP,
+it does not start OAuth; instead, it shows a link that reloads the same IP
+address or hostname over HTTPS.
 
 After sign-in, the explorer lists the currently published tools with their
 description, schema and read/write classification. Arguments can be edited in

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -3,11 +3,11 @@ NAME=Miraculix2050
 EMAIL=198097126+Miraculix2050@users.noreply.github.com
 
 [PLUGIN]
-VERSION=0.4.0-alpha.6
+VERSION=0.4.0-alpha.7
 NAME=mcpserver
 FOLDER=mcpserver
 TITLE=LoxBerry MCP Server
-WEBSITE=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/blob/v0.4.0-alpha.6/README.md
+WEBSITE=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/blob/v0.4.0-alpha.7/README.md
 
 [AUTOUPDATE]
 AUTOMATIC_UPDATES=false

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -52,7 +52,7 @@ fi
 
 python3.13 -m venv "$new_venv" || exit 2
 "$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" -r "$plugin_bin/runtime-arm64.lock" || exit 2
-"$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" loxberry-mcpserver==0.4.0a6 || exit 2
+"$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" loxberry-mcpserver==0.4.0a7 || exit 2
 if [ -d "$venv" ]; then
     mv "$venv" "$old_venv" || exit 2
 fi

--- a/prerelease.cfg
+++ b/prerelease.cfg
@@ -1,4 +1,4 @@
 [AUTOUPDATE]
-VERSION=0.4.0-alpha.6
-ARCHIVEURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/download/v0.4.0-alpha.6/LoxBerry-MCP-Server-0.4.0-alpha.6.zip
-INFOURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/tag/v0.4.0-alpha.6
+VERSION=0.4.0-alpha.7
+ARCHIVEURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/download/v0.4.0-alpha.7/LoxBerry-MCP-Server-0.4.0-alpha.7.zip
+INFOURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/tag/v0.4.0-alpha.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loxberry-mcpserver"
-version = "0.4.0-alpha.6"
+version = "0.4.0-alpha.7"
 description = "Local MCP server for LoxBerry and Loxone"
 requires-python = ">=3.13,<3.14"
 license = "Apache-2.0"

--- a/src/mcpserver/__init__.py
+++ b/src/mcpserver/__init__.py
@@ -5,6 +5,6 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("loxberry-mcpserver")
 except PackageNotFoundError:  # pragma: no cover - source tree without installation
-    __version__ = "0.4.0-alpha.6"
+    __version__ = "0.4.0-alpha.7"
 
 __all__ = ["__version__"]

--- a/tests/test_explorer_ui.py
+++ b/tests/test_explorer_ui.py
@@ -87,6 +87,18 @@ def test_explorer_requires_and_links_to_the_canonical_https_origin() -> None:
         )
         is None
     )
+    assert (
+        run_core(
+            "core.httpsExplorerUrl('http://192.0.2.10/admin/plugins/mcpserver/explorer.cgi?lang=de')"
+        )
+        == "https://192.0.2.10/admin/plugins/mcpserver/explorer.cgi?lang=de"
+    )
+    assert (
+        run_core(
+            "core.httpsExplorerUrl('https://loxberry.example/admin/plugins/mcpserver/explorer.cgi')"
+        )
+        is None
+    )
 
 
 def test_explorer_uses_current_https_origin_for_validated_oauth_endpoints() -> None:
@@ -125,17 +137,16 @@ def test_explorer_uses_current_https_origin_for_validated_oauth_endpoints() -> N
     )
 
 
-def test_explorer_opens_oauth_popup_in_the_connect_click_handler() -> None:
+def test_explorer_blocks_insecure_origins_before_oauth_discovery() -> None:
     source = SCRIPT.read_text(encoding="utf-8")
-    handler_start = source.index("elements.connect.addEventListener('click'")
-    handler = source[
-        handler_start : source.index("elements.disconnect.addEventListener", handler_start)
+    discover_start = source.index("async function discover()")
+    discover = source[
+        discover_start : source.index("async function registerClient", discover_start)
     ]
 
-    assert "const authorizationPopup = openAuthorizationPopup();" in handler
-    assert handler.index("openAuthorizationPopup()") < handler.index("setBusy(true)")
-    assert "state.oauth = await authorize(authorizationPopup);" in handler
-    assert "authorizationPopup?.close()" in handler
+    assert "if (window.location.protocol !== 'https:')" in discover
+    assert "error.canonicalUrl = core.httpsExplorerUrl(window.location.href);" in discover
+    assert discover.index("window.location.protocol") < discover.index("fetchJson(")
 
 
 def test_explorer_reuses_only_schema_compatible_values() -> None:

--- a/tests/test_explorer_ui.py
+++ b/tests/test_explorer_ui.py
@@ -149,6 +149,20 @@ def test_explorer_blocks_insecure_origins_before_oauth_discovery() -> None:
     assert discover.index("window.location.protocol") < discover.index("fetchJson(")
 
 
+def test_explorer_opens_oauth_popup_synchronously_only_for_https() -> None:
+    source = SCRIPT.read_text(encoding="utf-8")
+    handler_start = source.index("elements.connect.addEventListener('click'")
+    handler = source[
+        handler_start : source.index("elements.disconnect.addEventListener", handler_start)
+    ]
+
+    assert "const insecureOrigin = window.location.protocol !== 'https:';" in handler
+    assert "const authorizationPopup = insecureOrigin ? null : openAuthorizationPopup();" in handler
+    assert handler.index("openAuthorizationPopup()") < handler.index("setBusy(true)")
+    assert "state.oauth = await authorize(authorizationPopup);" in handler
+    assert "authorizationPopup?.close()" in handler
+
+
 def test_explorer_reuses_only_schema_compatible_values() -> None:
     tools = [
         {

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -120,7 +120,7 @@ def test_plugin_identity_and_platform_contract() -> None:
     assert parser["PLUGIN"]["NAME"] == "mcpserver"
     assert parser["PLUGIN"]["FOLDER"] == "mcpserver"
     assert parser["PLUGIN"]["TITLE"] == "LoxBerry MCP Server"
-    assert parser["PLUGIN"]["VERSION"] == "0.4.0-alpha.6"
+    assert parser["PLUGIN"]["VERSION"] == "0.4.0-alpha.7"
     assert parser["SYSTEM"]["LB_MINIMUM"] == "4.0.0"
     assert parser["SYSTEM"]["INTERFACE"] == "2.0"
     for name in ("release.cfg", "prerelease.cfg"):
@@ -455,7 +455,7 @@ def test_plugin_archive_verifier_accepts_builder_output(tmp_path: Path) -> None:
     for name, version in _locked_requirements(ROOT / "requirements" / "runtime-arm64.lock").items():
         wheel_name = name.replace("-", "_")
         (wheelhouse / f"{wheel_name}-{version}-py3-none-any.whl").write_bytes(b"wheel")
-    project_wheel = wheelhouse / "loxberry_mcpserver-0.4.0a6-py3-none-any.whl"
+    project_wheel = wheelhouse / "loxberry_mcpserver-0.4.0a7-py3-none-any.whl"
     _write_project_wheel(project_wheel)
     hash_lock = tmp_path / "runtime-arm64.sha256"
     hash_lock.write_text(
@@ -861,12 +861,12 @@ def test_plugin_archive_verifier_rejects_checksum_mismatch(tmp_path: Path) -> No
 
 
 def test_release_metadata_and_changelog_match_current_prerelease() -> None:
-    notes = validate_release_metadata(ROOT, "0.4.0-alpha.6", "prerelease")
+    notes = validate_release_metadata(ROOT, "0.4.0-alpha.7", "prerelease")
 
-    assert "Open the Tool Explorer OAuth popup synchronously" in notes
-    assert "block a valid sign-in popup" in notes
+    assert "Block MCP Tool Explorer sign-in on HTTP" in notes
+    assert "same IP address or hostname over HTTPS" in notes
     with pytest.raises(ValueError, match="stable releases"):
-        validate_release_metadata(ROOT, "0.4.0-alpha.6", "stable")
+        validate_release_metadata(ROOT, "0.4.0-alpha.7", "stable")
     with pytest.raises(ValueError, match="versions do not match"):
         validate_release_metadata(ROOT, "0.3.0-alpha.2", "prerelease")
 

--- a/webfrontend/htmlauth/explorer.js
+++ b/webfrontend/htmlauth/explorer.js
@@ -960,7 +960,16 @@
     });
   }
 
-  async function authorize() {
+  function openAuthorizationPopup() {
+    return window.open(
+      '',
+      'mcp-explorer-oauth',
+      'popup=yes,width=680,height=900,resizable=yes,scrollbars=yes',
+    );
+  }
+
+  async function authorize(popup) {
+    if (!popup) throw new Error(label('popupBlocked'));
     const resumeUntil = Date.now() + core.EXPLORER_SESSION_MS;
     const discovered = await discover();
     const supported = new Set(discovered.resourceMetadata.scopes_supported || []);
@@ -979,12 +988,7 @@
       code_challenge: challenge, code_challenge_method: 'S256', state: oauthState,
       scope, resource: discovered.resourceMetadata.resource,
     }).toString();
-    const popup = window.open(
-      authorizationUrl.href,
-      'mcp-explorer-oauth',
-      'popup=yes,width=680,height=900,resizable=yes,scrollbars=yes',
-    );
-    if (!popup) throw new Error(label('popupBlocked'));
+    popup.location.replace(authorizationUrl.href);
     const code = await waitForAuthorization(popup, oauthState);
     if (!code) throw new Error(label('authCancelled'));
     const token = await exchangeToken(
@@ -1615,10 +1619,14 @@
   }
 
   elements.connect.addEventListener('click', async () => {
+    const insecureOrigin = window.location.protocol !== 'https:';
+    // A blank window retains the click's transient user activation in Firefox.
+    // HTTP is rejected without opening a window and offers the HTTPS link below.
+    const authorizationPopup = insecureOrigin ? null : openAuthorizationPopup();
     setBusy(true);
     setStatus(label('working'), 'working');
     try {
-      state.oauth = await authorize();
+      state.oauth = await authorize(authorizationPopup);
       state.oauth.resumeEnabled = await acquireSessionOwnership(state.oauth.sessionId);
       if (state.oauth.resumeEnabled && !saveStoredSession(state.oauth)) {
         state.oauth.resumeEnabled = false;
@@ -1629,6 +1637,7 @@
       if (state.tools.length) selectTool(state.tools[0].name);
       setStatus(label('connected'), 'success');
     } catch (error) {
+      try { authorizationPopup?.close(); } catch (_closeError) { /* already gone */ }
       if (state.oauth) await revokeAndClear();
       else core.clearSensitiveState(state);
       showConnectionError(error, label('error'));

--- a/webfrontend/htmlauth/explorer.js
+++ b/webfrontend/htmlauth/explorer.js
@@ -123,6 +123,24 @@
     }
   }
 
+  function httpsExplorerUrl(currentUrl) {
+    if (typeof currentUrl !== 'string') return null;
+    try {
+      const page = new URL(currentUrl);
+      if (
+        page.protocol !== 'http:'
+        || page.username
+        || page.password
+        || page.pathname !== EXPLORER_PATH
+      ) return null;
+      page.protocol = 'https:';
+      if (page.port === '80') page.port = '';
+      return page.href;
+    } catch (_error) {
+      return null;
+    }
+  }
+
   function localAuthorizationMetadata(metadata, currentOrigin) {
     let issuer;
     let local;
@@ -600,6 +618,7 @@
     revokeOAuthGrant,
     fieldControlId,
     canonicalExplorerUrl,
+    httpsExplorerUrl,
     localAuthorizationMetadata,
     createFieldLabel,
     createOptionalToggle,
@@ -843,6 +862,11 @@
   }
 
   async function discover() {
+    if (window.location.protocol !== 'https:') {
+      const error = new Error(label('originMismatch'));
+      error.canonicalUrl = core.httpsExplorerUrl(window.location.href);
+      throw error;
+    }
     const resourceMetadata = await fetchJson('/.well-known/oauth-protected-resource/plugins/mcpserver/mcp', {cache: 'no-store'});
     const issuer = Array.isArray(resourceMetadata.authorization_servers) ? resourceMetadata.authorization_servers[0] : null;
     const canonicalUrl = core.canonicalExplorerUrl(
@@ -936,16 +960,7 @@
     });
   }
 
-  function openAuthorizationPopup() {
-    return window.open(
-      '',
-      'mcp-explorer-oauth',
-      'popup=yes,width=680,height=900,resizable=yes,scrollbars=yes',
-    );
-  }
-
-  async function authorize(popup) {
-    if (!popup) throw new Error(label('popupBlocked'));
+  async function authorize() {
     const resumeUntil = Date.now() + core.EXPLORER_SESSION_MS;
     const discovered = await discover();
     const supported = new Set(discovered.resourceMetadata.scopes_supported || []);
@@ -964,7 +979,12 @@
       code_challenge: challenge, code_challenge_method: 'S256', state: oauthState,
       scope, resource: discovered.resourceMetadata.resource,
     }).toString();
-    popup.location.replace(authorizationUrl.href);
+    const popup = window.open(
+      authorizationUrl.href,
+      'mcp-explorer-oauth',
+      'popup=yes,width=680,height=900,resizable=yes,scrollbars=yes',
+    );
+    if (!popup) throw new Error(label('popupBlocked'));
     const code = await waitForAuthorization(popup, oauthState);
     if (!code) throw new Error(label('authCancelled'));
     const token = await exchangeToken(
@@ -1595,13 +1615,10 @@
   }
 
   elements.connect.addEventListener('click', async () => {
-    // Open synchronously in the user gesture. Firefox otherwise treats the
-    // popup as unsolicited after the asynchronous discovery and PKCE setup.
-    const authorizationPopup = openAuthorizationPopup();
     setBusy(true);
     setStatus(label('working'), 'working');
     try {
-      state.oauth = await authorize(authorizationPopup);
+      state.oauth = await authorize();
       state.oauth.resumeEnabled = await acquireSessionOwnership(state.oauth.sessionId);
       if (state.oauth.resumeEnabled && !saveStoredSession(state.oauth)) {
         state.oauth.resumeEnabled = false;
@@ -1612,7 +1629,6 @@
       if (state.tools.length) selectTool(state.tools[0].name);
       setStatus(label('connected'), 'success');
     } catch (error) {
-      try { authorizationPopup?.close(); } catch (_closeError) { /* already gone */ }
       if (state.oauth) await revokeAndClear();
       else core.clearSensitiveState(state);
       showConnectionError(error, label('error'));


### PR DESCRIPTION
## Summary
- block Tool Explorer OAuth discovery when the page uses HTTP
- offer a secure reload link preserving the current IP address or hostname
- restore the original OAuth popup behavior and prepare 0.4.0-alpha.7

## Validation
- python tools/test.py --profile full (515 passed, 1 expected deprecation warning)