### PR TITLE
Keep Explorer HTTPS guidance after click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable user-visible changes are recorded here. GitHub release notes are
 extracted from the matching version heading.
 
+## 0.4.0-alpha.8 - 2026-08-13
+
+- Keep the HTTP-to-HTTPS Explorer guidance visible after a sign-in click by
+  performing the HTTP origin check before testing the intentionally absent
+  authorization popup.
+
 ## 0.4.0-alpha.7 - 2026-08-13
 
 - Block MCP Tool Explorer sign-in on HTTP before OAuth discovery and provide a

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Für jeden Assistenten sollte ein eigener Loxone-Benutzer mit den minimal erford
 ## Projektstatus
 
 Phase 1 bis Phase 3 sind abgenommen. Der vorbereitete Phase-4-Pre-Release
-`0.4.0-alpha.7` blockiert die MCP-Tool-Explorer-Anmeldung auf HTTP mit einem
+`0.4.0-alpha.8` blockiert die MCP-Tool-Explorer-Anmeldung auf HTTP mit einem
 Link zur gleichen IP-Adresse oder demselben Hostnamen über HTTPS sowie die versionsgeprüfte, begrenzte single-flight
 LoxAPP3-Aktualisierung, einen kontrollierten Runtime-Shutdown und einen
 ausschließlich flüchtigen Statistik-Cache. Das Schreibwerkzeug unterstützt auf Gen.-1-Controls die Typen

--- a/docs/development/support-matrix.md
+++ b/docs/development/support-matrix.md
@@ -1,13 +1,13 @@
 # Support-Matrix
 
 - **Stand:** Runtime-/Strukturhärtung, 2026-08-13
-- **Vorbereiteter Pre-Release:** `0.4.0-alpha.7`
+- **Vorbereiteter Pre-Release:** `0.4.0-alpha.8`
 - **Nächster Meilenstein:** gezielte reale Abnahme der noch unbestätigten
   Phase-4-Aktionen und V1-Varianten
 
 Diese Matrix unterscheidet reale Nachweise von implementierten, aber noch nicht
 real bestätigten Kombinationen. Phase 1, Phase 2 und Phase 3 sind abgenommen;
-`0.4.0-alpha.7` bleibt wegen seines Vorabversionsstatus ein Pre-Release.
+`0.4.0-alpha.8` bleibt wegen seines Vorabversionsstatus ein Pre-Release.
 Phase 4 ist implementiert und für die lesenden Statistik-/Historienpfade, die
 eng begrenzte plugin-eigene Cache-Operation und ausgewählte, reversible
 Control-Aktionen auf Hardware abgenommen; siehe

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -1,4 +1,4 @@
-# LoxBerry MCP Server 0.4.0-alpha.7
+# LoxBerry MCP Server 0.4.0-alpha.8
 
 ## Voraussetzungen
 

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -1,4 +1,4 @@
-# LoxBerry MCP Server 0.4.0-alpha.7
+# LoxBerry MCP Server 0.4.0-alpha.8
 
 ## Requirements
 

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -3,11 +3,11 @@ NAME=Miraculix2050
 EMAIL=198097126+Miraculix2050@users.noreply.github.com
 
 [PLUGIN]
-VERSION=0.4.0-alpha.7
+VERSION=0.4.0-alpha.8
 NAME=mcpserver
 FOLDER=mcpserver
 TITLE=LoxBerry MCP Server
-WEBSITE=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/blob/v0.4.0-alpha.7/README.md
+WEBSITE=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/blob/v0.4.0-alpha.8/README.md
 
 [AUTOUPDATE]
 AUTOMATIC_UPDATES=false

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -52,7 +52,7 @@ fi
 
 python3.13 -m venv "$new_venv" || exit 2
 "$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" -r "$plugin_bin/runtime-arm64.lock" || exit 2
-"$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" loxberry-mcpserver==0.4.0a7 || exit 2
+"$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" loxberry-mcpserver==0.4.0a8 || exit 2
 if [ -d "$venv" ]; then
     mv "$venv" "$old_venv" || exit 2
 fi

--- a/prerelease.cfg
+++ b/prerelease.cfg
@@ -1,4 +1,4 @@
 [AUTOUPDATE]
-VERSION=0.4.0-alpha.7
-ARCHIVEURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/download/v0.4.0-alpha.7/LoxBerry-MCP-Server-0.4.0-alpha.7.zip
-INFOURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/tag/v0.4.0-alpha.7
+VERSION=0.4.0-alpha.8
+ARCHIVEURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/download/v0.4.0-alpha.8/LoxBerry-MCP-Server-0.4.0-alpha.8.zip
+INFOURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/tag/v0.4.0-alpha.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loxberry-mcpserver"
-version = "0.4.0-alpha.7"
+version = "0.4.0-alpha.8"
 description = "Local MCP server for LoxBerry and Loxone"
 requires-python = ">=3.13,<3.14"
 license = "Apache-2.0"

--- a/src/mcpserver/__init__.py
+++ b/src/mcpserver/__init__.py
@@ -5,6 +5,6 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("loxberry-mcpserver")
 except PackageNotFoundError:  # pragma: no cover - source tree without installation
-    __version__ = "0.4.0-alpha.7"
+    __version__ = "0.4.0-alpha.8"
 
 __all__ = ["__version__"]

--- a/tests/test_explorer_ui.py
+++ b/tests/test_explorer_ui.py
@@ -147,6 +147,13 @@ def test_explorer_blocks_insecure_origins_before_oauth_discovery() -> None:
     assert "if (window.location.protocol !== 'https:')" in discover
     assert "error.canonicalUrl = core.httpsExplorerUrl(window.location.href);" in discover
     assert discover.index("window.location.protocol") < discover.index("fetchJson(")
+    authorize_start = source.index("async function authorize(popup)")
+    authorize = source[
+        authorize_start : source.index("async function refreshAccessToken", authorize_start)
+    ]
+    assert authorize.index("const discovered = await discover();") < authorize.index(
+        "if (!popup) throw new Error(label('popupBlocked'));"
+    )
 
 
 def test_explorer_opens_oauth_popup_synchronously_only_for_https() -> None:

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -120,7 +120,7 @@ def test_plugin_identity_and_platform_contract() -> None:
     assert parser["PLUGIN"]["NAME"] == "mcpserver"
     assert parser["PLUGIN"]["FOLDER"] == "mcpserver"
     assert parser["PLUGIN"]["TITLE"] == "LoxBerry MCP Server"
-    assert parser["PLUGIN"]["VERSION"] == "0.4.0-alpha.7"
+    assert parser["PLUGIN"]["VERSION"] == "0.4.0-alpha.8"
     assert parser["SYSTEM"]["LB_MINIMUM"] == "4.0.0"
     assert parser["SYSTEM"]["INTERFACE"] == "2.0"
     for name in ("release.cfg", "prerelease.cfg"):
@@ -455,7 +455,7 @@ def test_plugin_archive_verifier_accepts_builder_output(tmp_path: Path) -> None:
     for name, version in _locked_requirements(ROOT / "requirements" / "runtime-arm64.lock").items():
         wheel_name = name.replace("-", "_")
         (wheelhouse / f"{wheel_name}-{version}-py3-none-any.whl").write_bytes(b"wheel")
-    project_wheel = wheelhouse / "loxberry_mcpserver-0.4.0a7-py3-none-any.whl"
+    project_wheel = wheelhouse / "loxberry_mcpserver-0.4.0a8-py3-none-any.whl"
     _write_project_wheel(project_wheel)
     hash_lock = tmp_path / "runtime-arm64.sha256"
     hash_lock.write_text(
@@ -861,12 +861,12 @@ def test_plugin_archive_verifier_rejects_checksum_mismatch(tmp_path: Path) -> No
 
 
 def test_release_metadata_and_changelog_match_current_prerelease() -> None:
-    notes = validate_release_metadata(ROOT, "0.4.0-alpha.7", "prerelease")
+    notes = validate_release_metadata(ROOT, "0.4.0-alpha.8", "prerelease")
 
-    assert "Block MCP Tool Explorer sign-in on HTTP" in notes
-    assert "same IP address or hostname over HTTPS" in notes
+    assert "Keep the HTTP-to-HTTPS Explorer guidance visible" in notes
+    assert "performing the HTTP origin check before testing" in notes
     with pytest.raises(ValueError, match="stable releases"):
-        validate_release_metadata(ROOT, "0.4.0-alpha.7", "stable")
+        validate_release_metadata(ROOT, "0.4.0-alpha.8", "stable")
     with pytest.raises(ValueError, match="versions do not match"):
         validate_release_metadata(ROOT, "0.3.0-alpha.2", "prerelease")
 

--- a/webfrontend/htmlauth/explorer.js
+++ b/webfrontend/htmlauth/explorer.js
@@ -969,9 +969,9 @@
   }
 
   async function authorize(popup) {
-    if (!popup) throw new Error(label('popupBlocked'));
     const resumeUntil = Date.now() + core.EXPLORER_SESSION_MS;
     const discovered = await discover();
+    if (!popup) throw new Error(label('popupBlocked'));
     const supported = new Set(discovered.resourceMetadata.scopes_supported || []);
     if (!supported.has('loxone:read')) throw new Error(label('error'));
     if (!supported.has('loxone:history')) supported.delete('loxberry:operate');


### PR DESCRIPTION
## Summary
- retain the HTTP-to-HTTPS guidance after an Explorer sign-in click
- run the HTTP origin check before testing the intentionally absent popup
- prepare version 0.4.0-alpha.8

## Validation
- python tools/test.py --profile full (516 passed, 1 expected deprecation warning)