### PR TITLE
Share Explorer OAuth sessions across tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable user-visible changes are recorded here. GitHub release notes are
 extracted from the matching version heading.
 
+## Unreleased
+
+- Reuse the MCP Tool Explorer OAuth session in new browser tabs for up to eight
+  hours without storing refresh credentials in browser storage; disconnect now
+  revokes the shared Explorer session in every tab.
+
 ## 0.4.0-alpha.8 - 2026-08-13
 
 - Keep the HTTP-to-HTTPS Explorer guidance visible after a sign-in click by

--- a/docs/development/adr/0004-integrated-tool-explorer.md
+++ b/docs/development/adr/0004-integrated-tool-explorer.md
@@ -19,8 +19,9 @@ calling runtime adapters or administrative helpers directly.
 The plugin ships a separate `htmlauth` Tool Explorer for its own fixed MCP
 endpoint. It uses OAuth discovery, dynamic client registration, Authorization
 Code with PKCE, Streamable HTTP initialization, `tools/list` and `tools/call`.
-It cannot connect to arbitrary URLs and does not add a proxy or server-side token
-store.
+It cannot connect to arbitrary URLs. A plugin-owned, encrypted server-side
+Explorer session retains the refresh credential so new Explorer tabs can reuse
+one OAuth client and family for at most eight hours.
 
 The Explorer uses the HTTPS origin from which its page was opened for browser
 requests. The configured OAuth issuer and resource remain canonical protocol
@@ -30,33 +31,31 @@ keeps links, callbacks and permission selection on the address chosen by the
 operator without allowing arbitrary origins.
 
 Access tokens, arguments, results and call history exist only in memory in the
-open browser tab. A strictly validated refresh token and its minimal binding data
-may additionally exist in that tab's `sessionStorage`. This allows a reload to
-rotate the refresh token immediately and restore the MCP connection without
-persisting the credential as normal local browser data after the tab is closed.
-A Web Lock tied to a random session identifier prevents a duplicated tab from
-automatically replaying the same single-use refresh token. The resumable record
-is removed before every rotation, so a reload that interrupts an in-flight
-rotation fails closed instead of replaying a possibly consumed token. The
-non-secret public `client_id` is retained only in that tab's `sessionStorage`
-and for at most eight hours. Older persistent `localStorage` registrations are
-discarded so a browser cannot reuse an identifier after the server has removed
-the corresponding dynamic client registration.
+open browser tab. The browser never persists OAuth credentials in
+`sessionStorage` or `localStorage`. The encrypted server-side Explorer session
+retains the client id, OAuth family, refresh credential and current token state.
+The visible transcript, rendered result panels and unsent drafts remain
+tab-scoped and are never shared with another tab.
 
-`sessionStorage` is isolated by origin and top-level browsing context, not by URL
-path. The LoxBerry admin origin is therefore part of the Explorer trust boundary:
-other same-origin code running in the same tab could read the refresh credential.
-This design does not claim isolation from a malicious or compromised same-origin
-plugin. Operators must install only trusted admin plugins; stronger isolation
-would require a separate origin or a server-side browser-session architecture.
+Refresh-token rotation is serialized by the server per Explorer session. A new
+tab restores a short-lived access token through the private session endpoint and
+does not receive a refresh credential. Browser Web Locks are therefore not used
+for OAuth refresh coordination.
+
+The refresh credential is not available to scripts running in the Explorer's
+origin. The browser session identifier is delivered only in a `Secure`,
+`HttpOnly`, `SameSite=Strict` cookie. Session requests require the canonical
+Origin, JSON content type and an explicitly parsed request body. The same-origin
+policy and a strict Content Security Policy remain important boundaries for the
+access token held in tab memory.
 
 Browsers cannot reliably distinguish reload from tab close or guarantee an
 unload request. The explorer therefore does not claim automatic revocation on
-page unload. Explicit disconnect performs RFC 7009 revocation, Explorer OAuth
-families identified by both their fixed name and exact local callback expire
-after at most eight hours instead of the normal 30 days, and the existing session
-UI remains the reliable recovery path after a crash or close. Startup garbage
-collection also caps matching families created before this rule was installed.
+page unload. Explicit disconnect performs RFC 7009 revocation and deletes the
+shared Explorer session for every tab. Explorer OAuth families identified by
+both their fixed name and exact local callback expire after at most eight hours
+instead of the normal 30 days; session cleanup also deletes their encrypted
+Explorer session.
 
 Input schemas produce a small accessible form for the schema subset used by the
 published tools. A synchronized raw JSON editor remains authoritative for shapes
@@ -80,9 +79,9 @@ remain authoritative.
 
 - No new production dependency, service, port, configuration key or MCP contract
   is introduced.
-- Reloading preserves only the Explorer sign-in. Reloading or closing still loses
-  drafts, results, history and transcript data; closing also normally discards the
-  tab-scoped refresh credential.
+- Reloading or opening a second tab preserves the Explorer sign-in while its
+  eight-hour session remains valid. Drafts, results, history and transcript data
+  remain tab-scoped.
 - Resources, prompts, sampling, arbitrary-server connections and protocol
   conformance suites remain responsibilities of external tools such as the
   official MCP Inspector.

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -204,19 +204,12 @@ oder identischen History-Einträgen vollständig.
 Der MCP-Transkriptbereich zeigt bereinigte JSON-RPC-Nachrichten, Status und Dauer.
 Authorization-Header, OAuth-Werte und als geheim erkannte Argumente werden nicht
 angezeigt. Access-Token, Entwürfe, Ergebnisse und der auf 50 Aufrufe begrenzte
-Verlauf bleiben nur im Speicher des Tabs. Das Refresh-Token wird im
-`sessionStorage` desselben Tabs gehalten, damit ein Neuladen die Anmeldung
-wiederherstellen und das Token sofort rotieren kann. Eine Browser-Tab-Sperre
-verhindert die automatische Wiederverwendung in einem duplizierten Tab. Andere
-Seiten derselben LoxBerry-Admin-Origin sind keine Sicherheitsgrenze und müssen
-aus vertrauenswürdigen Plugins stammen. Beim Schließen des Tabs
-verwirft der Browser diesen lokalen Wert normalerweise, kann die Serversitzung
-aber nicht zuverlässig sofort widerrufen. Explorer-Sitzungen laufen deshalb
-spätestens nach acht Stunden ab. **Trennen und widerrufen** beendet sie sofort
-und bleibt vor dem Schließen der zuverlässige Abmeldeweg.
-Auch die öffentliche OAuth-Clientregistrierung ist auf den Tab und höchstens
-acht Stunden begrenzt; veraltete Registrierungen früherer Plugin-Versionen
-werden automatisch verworfen und neu angelegt.
+Verlauf bleiben nur im Speicher des Tabs. Das Refresh-Token bleibt verschlüsselt
+auf dem Server; ein `Secure`, `HttpOnly`, `SameSite=Strict`-Cookie verbindet neue
+Explorer-Tabs mit derselben höchstens achtstündigen Sitzung. Andere Seiten
+derselben LoxBerry-Admin-Origin sind keine Sicherheitsgrenze und müssen aus
+vertrauenswürdigen Plugins stammen. **Trennen und widerrufen** beendet die
+gemeinsame Sitzung sofort in allen Explorer-Tabs.
 
 Der Explorer fordert beim Start automatisch alle Berechtigungen an, die der
 installierte Server anbietet. Die einzige sichtbare Auswahl erfolgt anschließend

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -192,18 +192,12 @@ or identical history records.
 The MCP transcript shows sanitized JSON-RPC messages, status and duration.
 Authorization headers, OAuth values and secret-shaped arguments are never shown.
 Access tokens, drafts, results and the history bounded to 50 calls remain only in
-tab memory. The refresh token is kept in that tab's `sessionStorage` so a reload
-can restore the sign-in and rotate the token immediately. A browser tab lock
-prevents automatic reuse in a duplicated tab. Other pages on the same LoxBerry
-admin origin are not a security boundary and must come from trusted plugins.
-Closing the tab normally
-discards that local value, but the browser cannot reliably revoke the server
-session immediately. Explorer sessions therefore expire after eight hours at the
-latest. **Disconnect and revoke** ends the session immediately and remains the
-reliable sign-out path before closing the tab.
-The public OAuth client registration is likewise limited to the tab and at most
-eight hours; stale registrations from earlier plugin versions are discarded and
-registered again automatically.
+tab memory. The refresh token stays encrypted on the server; a `Secure`,
+`HttpOnly`, `SameSite=Strict` cookie connects new Explorer tabs to the same
+session for no more than eight hours. Other pages on the same LoxBerry admin
+origin are not a security boundary and must come from trusted plugins.
+**Disconnect and revoke** ends the shared session immediately in every Explorer
+tab.
 
 The Explorer automatically requests every permission advertised by the
 installed server. The only visible selection then occurs in the OAuth consent

--- a/src/mcpserver/auth/loxone_store.py
+++ b/src/mcpserver/auth/loxone_store.py
@@ -10,6 +10,7 @@ import stat
 import sys
 import threading
 from contextlib import contextmanager, suppress
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, BinaryIO, Final
 
@@ -51,6 +52,21 @@ def _unlock_file(handle: BinaryIO) -> None:
 
 class LoxoneTokenStoreError(RuntimeError):
     """The encrypted Loxone token store cannot be used safely."""
+
+
+@dataclass(frozen=True)
+class ExplorerSession:
+    """Encrypted server-side credentials for one browser Explorer session."""
+
+    session_id: str
+    family_id: str
+    client_id: str
+    resource: str
+    scope: str
+    access_token: str
+    access_expires_at: int
+    refresh_token: str
+    expires_at: int
 
 
 def _encoded(value: bytes) -> str:
@@ -99,7 +115,9 @@ class EncryptedLoxoneTokenStore:
             os.chmod(self.path.parent, 0o700)
             with self._locked():
                 if not self.path.exists():
-                    self._write({"schema_version": _SCHEMA_VERSION, "tokens": {}})
+                    self._write(
+                        {"schema_version": _SCHEMA_VERSION, "tokens": {}, "explorer_sessions": {}}
+                    )
                 else:
                     self._read()
         except LoxoneTokenStoreError:
@@ -127,9 +145,10 @@ class EncryptedLoxoneTokenStore:
     def _validate(document: object) -> dict[str, Any]:
         if (
             not isinstance(document, dict)
-            or set(document) != {"schema_version", "tokens"}
+            or set(document) != {"schema_version", "tokens", "explorer_sessions"}
             or document.get("schema_version") != _SCHEMA_VERSION
             or not isinstance(document.get("tokens"), dict)
+            or not isinstance(document.get("explorer_sessions"), dict)
         ):
             raise LoxoneTokenStoreError("encrypted token store is invalid")
         return document
@@ -139,7 +158,10 @@ class EncryptedLoxoneTokenStore:
             metadata = self.path.lstat()
             if not stat.S_ISREG(metadata.st_mode) or self.path.is_symlink():
                 raise LoxoneTokenStoreError("encrypted token store path is unsafe")
-            return self._validate(json.loads(self.path.read_text(encoding="utf-8")))
+            document = json.loads(self.path.read_text(encoding="utf-8"))
+            if isinstance(document, dict) and set(document) == {"schema_version", "tokens"}:
+                document["explorer_sessions"] = {}
+            return self._validate(document)
         except LoxoneTokenStoreError:
             raise
         except (OSError, UnicodeError, json.JSONDecodeError) as exc:
@@ -247,6 +269,116 @@ class EncryptedLoxoneTokenStore:
         with self._locked():
             document = self._read()
             if document["tokens"].pop(family_id, None) is not None:
+                self._write(document)
+
+    @staticmethod
+    def _explorer_aad(session_id: str, family_id: str, client_id: str) -> bytes:
+        return f"{_SCHEMA_VERSION}\0explorer\0{session_id}\0{family_id}\0{client_id}".encode()
+
+    def put_explorer_session(self, session: ExplorerSession) -> None:
+        if not all(
+            (
+                session.session_id,
+                session.family_id,
+                session.client_id,
+                session.resource,
+                session.scope,
+                session.access_token,
+                session.refresh_token,
+            )
+        ):
+            raise ValueError("explorer session fields must not be empty")
+        plaintext = json.dumps(
+            {
+                "resource": session.resource,
+                "scope": session.scope,
+                "access_token": session.access_token,
+                "access_expires_at": session.access_expires_at,
+                "refresh_token": session.refresh_token,
+                "expires_at": session.expires_at,
+            },
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode()
+        nonce = secrets.token_bytes(12)
+        ciphertext = AESGCM(self._key).encrypt(
+            nonce,
+            plaintext,
+            self._explorer_aad(session.session_id, session.family_id, session.client_id),
+        )
+        with self._locked():
+            document = self._read()
+            document["explorer_sessions"][session.session_id] = {
+                "family_id": session.family_id,
+                "client_id": session.client_id,
+                "nonce": _encoded(nonce),
+                "ciphertext": _encoded(ciphertext),
+            }
+            self._write(document)
+
+    def get_explorer_session(self, session_id: str) -> ExplorerSession | None:
+        with self._locked():
+            record = self._read()["explorer_sessions"].get(session_id)
+        if record is None:
+            return None
+        if (
+            not isinstance(record, dict)
+            or not isinstance(record.get("family_id"), str)
+            or not isinstance(record.get("client_id"), str)
+        ):
+            raise LoxoneTokenStoreError("encrypted Explorer session binding is invalid")
+        family_id, client_id = record["family_id"], record["client_id"]
+        try:
+            plaintext = AESGCM(self._key).decrypt(
+                _decoded(record.get("nonce")),
+                _decoded(record.get("ciphertext")),
+                self._explorer_aad(session_id, family_id, client_id),
+            )
+            value = json.loads(plaintext)
+            expected = {
+                "resource": str,
+                "scope": str,
+                "access_token": str,
+                "access_expires_at": int,
+                "refresh_token": str,
+                "expires_at": int,
+            }
+            if not isinstance(value, dict) or not all(
+                isinstance(value.get(key), kind) for key, kind in expected.items()
+            ):
+                raise ValueError
+        except Exception as exc:
+            raise LoxoneTokenStoreError("encrypted Explorer session is invalid") from exc
+        return ExplorerSession(
+            session_id,
+            family_id,
+            client_id,
+            value["resource"],
+            value["scope"],
+            value["access_token"],
+            value["access_expires_at"],
+            value["refresh_token"],
+            value["expires_at"],
+        )
+
+    def delete_explorer_session(self, session_id: str) -> None:
+        with self._locked():
+            document = self._read()
+            if document["explorer_sessions"].pop(session_id, None) is not None:
+                self._write(document)
+
+    def delete_explorer_family(self, family_id: str) -> None:
+        with self._locked():
+            document = self._read()
+            removed = [
+                key
+                for key, value in document["explorer_sessions"].items()
+                if value.get("family_id") == family_id
+            ]
+            for key in removed:
+                document["explorer_sessions"].pop(key, None)
+            if removed:
                 self._write(document)
 
     def family_ids(self) -> tuple[str, ...]:

--- a/src/mcpserver/auth/provider.py
+++ b/src/mcpserver/auth/provider.py
@@ -295,6 +295,10 @@ class Phase0OAuthProvider(
             and origin in self.explorer_origins
         )
 
+    def is_explorer_client(self, client: OAuthClientInformationFull) -> bool:
+        """Return whether a registered public client is the fixed local Explorer."""
+        return self._is_explorer_client(client.model_dump(mode="json"))
+
     async def authorize(
         self, client: OAuthClientInformationFull, params: AuthorizationParams
     ) -> str:

--- a/src/mcpserver/auth/web.py
+++ b/src/mcpserver/auth/web.py
@@ -352,7 +352,7 @@ class Phase0OAuthWeb:
                     code.family_id,
                     client.client_id or "",
                     self.resource,
-                    token.scope,
+                    token.scope or scope_text(list(code.scopes)),
                     token.access_token or "",
                     now + int(token.expires_in or 0),
                     token.refresh_token or "",
@@ -376,9 +376,9 @@ class Phase0OAuthWeb:
         if action == "logout" and set(payload) == {"action"}:
             await self.provider.revoke_raw_token(session.refresh_token, session.client_id)
             self.loxone_store.delete_explorer_session(session.session_id)
-            response = Response(status_code=204, headers=_security_headers())
-            self._delete_explorer_cookie(response)
-            return response
+            logout_response = Response(status_code=204, headers=_security_headers())
+            self._delete_explorer_cookie(logout_response)
+            return logout_response
         if action != "access" or set(payload) != {"action"}:
             return _json({"error": "invalid_request"}, status=400)
         lock = self._explorer_locks.setdefault(session.session_id, asyncio.Lock())
@@ -404,7 +404,7 @@ class Phase0OAuthWeb:
                     current.family_id,
                     current.client_id,
                     current.resource,
-                    token.scope,
+                    token.scope or current.scope,
                     token.access_token or "",
                     self.provider.now() + int(token.expires_in or 0),
                     token.refresh_token or "",

--- a/src/mcpserver/auth/web.py
+++ b/src/mcpserver/auth/web.py
@@ -23,14 +23,20 @@ from urllib.parse import urlencode, urlsplit
 from uuid import NAMESPACE_URL, uuid5
 
 from mcp.server.auth.provider import RegistrationError, TokenError
-from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata
+from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthToken
 from pydantic import ValidationError
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 
-from mcpserver.auth.loxone_store import EncryptedLoxoneTokenStore
+from mcpserver.auth.loxone_store import (
+    EncryptedLoxoneTokenStore,
+    ExplorerSession,
+    LoxoneTokenStoreError,
+)
 from mcpserver.auth.provider import (
     CONTROL_SCOPE,
+    EXPLORER_CLIENT_NAME,
+    EXPLORER_REFRESH_FAMILY_TTL,
     HISTORY_SCOPE,
     LOXBERRY_OPERATE_SCOPE,
     LOXBERRY_READ_SCOPE,
@@ -59,6 +65,7 @@ _MAX_RATE_KEYS: Final = 512
 _REGISTRATION_RATE_WINDOW: Final = 5 * 60
 _MAX_REGISTRATIONS_PER_WINDOW: Final = 16
 _COOKIE_NAME: Final = "phase0_oauth_tx"
+_EXPLORER_COOKIE_NAME: Final = "mcp_explorer_session"
 _PKCE_CHALLENGE = re.compile(r"^[A-Za-z0-9_-]{43}$")
 _PKCE_VERIFIER = re.compile(r"^[A-Za-z0-9._~-]{43,128}$")
 
@@ -216,6 +223,8 @@ class Phase0OAuthWeb:
         self.issuer = issuer
         self.resource = resource
         self.loxone_store = loxone_store
+        self.explorer_origin = issuer.rsplit("/plugins/mcpserver/oauth", 1)[0]
+        self._explorer_locks: dict[str, asyncio.Lock] = {}
         self.transactions: dict[str, LoginTransaction] = {}
         self._client_uuid = uuid5(NAMESPACE_URL, issuer)
         self._login_slots = asyncio.Semaphore(2)
@@ -248,6 +257,167 @@ class Phase0OAuthWeb:
             async with transaction.lock:
                 if self.transactions.get(key) is transaction and await self._kill(transaction):
                     self.transactions.pop(key, None)
+
+    def _explorer_response(self, token: OAuthToken, expires_at: int) -> JSONResponse:
+        return _json(
+            {
+                "access_token": token.access_token,
+                "expires_in": token.expires_in,
+                "scope": token.scope,
+                "expires_at": expires_at,
+            }
+        )
+
+    def _explorer_cookie(self, response: Response, session_id: str) -> None:
+        response.set_cookie(
+            _EXPLORER_COOKIE_NAME,
+            session_id,
+            max_age=EXPLORER_REFRESH_FAMILY_TTL,
+            path="/plugins/mcpserver/oauth",
+            secure=True,
+            httponly=True,
+            samesite="strict",
+        )
+
+    def _delete_explorer_cookie(self, response: Response) -> None:
+        response.delete_cookie(
+            _EXPLORER_COOKIE_NAME,
+            path="/plugins/mcpserver/oauth",
+            secure=True,
+            httponly=True,
+            samesite="strict",
+        )
+
+    async def _explorer_payload(self, request: Request) -> dict[str, str] | None:
+        if request.headers.get("origin") != self.explorer_origin:
+            return None
+        if (
+            request.headers.get("content-type", "").split(";", 1)[0].strip().lower()
+            != "application/json"
+        ):
+            return None
+        raw = await _limited_body(request, _MAX_JSON_BYTES)
+        if raw is None:
+            return None
+        try:
+            payload = json.loads(raw)
+        except (UnicodeError, json.JSONDecodeError):
+            return None
+        if not isinstance(payload, dict) or any(
+            not isinstance(key, str) or not isinstance(value, str) for key, value in payload.items()
+        ):
+            return None
+        return payload
+
+    async def explorer_session(self, request: Request) -> Response:
+        """Broker a short-lived Explorer OAuth family through an HttpOnly browser cookie."""
+        payload = await self._explorer_payload(request)
+        if payload is None or self.loxone_store is None:
+            return _json({"error": "invalid_request"}, status=400)
+        action = payload.get("action")
+        if action == "complete":
+            allowed = {"action", "client_id", "code", "redirect_uri", "code_verifier", "resource"}
+            if set(payload) != allowed or payload["resource"] != self.resource:
+                return _json({"error": "invalid_request"}, status=400)
+            client = await self.provider.get_client(payload["client_id"])
+            if (
+                client is None
+                or client.client_name != EXPLORER_CLIENT_NAME
+                or not self.provider.is_explorer_client(client)
+            ):
+                return _json({"error": "invalid_client"}, status=401)
+            code = await self.provider.load_authorization_code(client, payload["code"])
+            verifier = payload["code_verifier"]
+            if (
+                code is None
+                or str(code.redirect_uri) != payload["redirect_uri"]
+                or code.resource != self.resource
+                or not _PKCE_VERIFIER.fullmatch(verifier)
+            ):
+                return _json({"error": "invalid_grant"}, status=400)
+            challenge = (
+                base64.urlsafe_b64encode(hashlib.sha256(verifier.encode("ascii")).digest())
+                .rstrip(b"=")
+                .decode("ascii")
+            )
+            if not hmac.compare_digest(challenge, code.code_challenge):
+                return _json({"error": "invalid_grant"}, status=400)
+            token = await self.provider.exchange_authorization_code(client, code)
+            session_id = secrets.token_urlsafe(32)
+            now = self.provider.now()
+            expires_at = now + EXPLORER_REFRESH_FAMILY_TTL
+            self.loxone_store.put_explorer_session(
+                ExplorerSession(
+                    session_id,
+                    code.family_id,
+                    client.client_id or "",
+                    self.resource,
+                    token.scope,
+                    token.access_token or "",
+                    now + int(token.expires_in or 0),
+                    token.refresh_token or "",
+                    expires_at,
+                )
+            )
+            response = self._explorer_response(token, expires_at)
+            self._explorer_cookie(response, session_id)
+            return response
+        session_id = request.cookies.get(_EXPLORER_COOKIE_NAME, "")
+        try:
+            session = self.loxone_store.get_explorer_session(session_id)
+        except LoxoneTokenStoreError:
+            session = None
+        if session is None or session.expires_at <= self.provider.now():
+            response = _json({"error": "invalid_session"}, status=401)
+            self._delete_explorer_cookie(response)
+            if session_id:
+                self.loxone_store.delete_explorer_session(session_id)
+            return response
+        if action == "logout" and set(payload) == {"action"}:
+            await self.provider.revoke_raw_token(session.refresh_token, session.client_id)
+            self.loxone_store.delete_explorer_session(session.session_id)
+            response = Response(status_code=204, headers=_security_headers())
+            self._delete_explorer_cookie(response)
+            return response
+        if action != "access" or set(payload) != {"action"}:
+            return _json({"error": "invalid_request"}, status=400)
+        lock = self._explorer_locks.setdefault(session.session_id, asyncio.Lock())
+        async with lock:
+            current = self.loxone_store.get_explorer_session(session.session_id)
+            if current is None or current.expires_at <= self.provider.now():
+                return _json({"error": "invalid_session"}, status=401)
+            if current.access_expires_at <= self.provider.now() + 15:
+                client = await self.provider.get_client(current.client_id)
+                refresh = (
+                    None
+                    if client is None
+                    else await self.provider.load_refresh_token(client, current.refresh_token)
+                )
+                if client is None or refresh is None:
+                    self.loxone_store.delete_explorer_session(current.session_id)
+                    return _json({"error": "invalid_session"}, status=401)
+                token = await self.provider.exchange_refresh_token(
+                    client, refresh, current.scope.split()
+                )
+                current = ExplorerSession(
+                    current.session_id,
+                    current.family_id,
+                    current.client_id,
+                    current.resource,
+                    token.scope,
+                    token.access_token or "",
+                    self.provider.now() + int(token.expires_in or 0),
+                    token.refresh_token or "",
+                    current.expires_at,
+                )
+                self.loxone_store.put_explorer_session(current)
+            token = OAuthToken(
+                access_token=current.access_token,
+                token_type="Bearer",
+                expires_in=max(0, current.access_expires_at - self.provider.now()),
+                scope=current.scope,
+            )
+            return self._explorer_response(token, current.expires_at)
 
     @staticmethod
     def _prune_times(values: deque[int], *, now: int, window: int) -> None:

--- a/src/mcpserver/server.py
+++ b/src/mcpserver/server.py
@@ -342,6 +342,7 @@ def create_server(settings: ServerSettings) -> FastMCP:
         def on_family_revoked(family_id: str) -> None:
             if loxone_store is not None:
                 loxone_store.delete(family_id)
+                loxone_store.delete_explorer_family(family_id)
             runtime_value = runtime_ref.get("runtime")
             if runtime_value is None:
                 return
@@ -485,6 +486,9 @@ def create_server(settings: ServerSettings) -> FastMCP:
             oauth_web.register
         )
         server.custom_route("/revoke", methods=["POST"], include_in_schema=False)(oauth_web.revoke)
+        server.custom_route("/explorer-session", methods=["POST"], include_in_schema=False)(
+            oauth_web.explorer_session
+        )
         server.custom_route(
             "/.well-known/oauth-authorization-server/plugins/mcpserver/oauth",
             methods=["GET"],

--- a/templates/lang/language_de.ini
+++ b/templates/lang/language_de.ini
@@ -180,7 +180,7 @@ ALLOW_LOXBERRY_OPERATE=loxberry:operate freigeben
 [EXPLORER]
 TITLE=MCP Tool Explorer
 BACK=Zurück zur Einrichtung
-INTRO=Verfügbare Werkzeuge des lokalen MCP-Servers untersuchen, aufrufen und validieren. Verlauf und Anmeldung bleiben nur in diesem Browser-Tab.
+INTRO=Verfügbare Werkzeuge des lokalen MCP-Servers untersuchen, aufrufen und validieren. Verlauf bleibt im Tab; die Anmeldung kann innerhalb von acht Stunden in neuen Tabs wiederverwendet werden.
 CONNECTION=Verbindung
 ACCESS_MODE=Berechtigung für diese Anmeldung
 READ_ONLY=Nur lesen
@@ -256,7 +256,7 @@ TOKEN_EXPIRED=Die Sitzung konnte nicht erneuert werden. Melden Sie sich erneut a
 RESTORING_SESSION=Gespeicherte Anmeldung wird wiederhergestellt …
 RESTORE_FAILED=Die gespeicherte Anmeldung konnte wegen eines vorübergehenden Verbindungsfehlers nicht wiederhergestellt werden. Laden Sie die Seite zum erneuten Versuch neu.
 SESSION_OTHER_TAB=Diese gespeicherte Anmeldung wird bereits in einem anderen Tab verwendet oder der Browser unterstützt keine sichere Tab-Sperre. Melden Sie sich in diesem Tab neu an.
-SESSION_POLICY=Ein Neuladen stellt die Anmeldung in diesem Tab in unterstützten Browsern wieder her. Beim Schließen verwirft der Browser die lokalen Zugangsdaten, kann die Serversitzung aber nicht zuverlässig sofort widerrufen. Verwenden Sie dafür „Trennen und widerrufen“. Explorer-Sitzungen laufen spätestens nach acht Stunden ab.
+SESSION_POLICY=Neue Explorer-Tabs verwenden die sichere gemeinsame Browser-Sitzung bis höchstens acht Stunden. Zugangsdaten bleiben serverseitig; „Trennen und widerrufen“ meldet alle Explorer-Tabs sofort ab.
 SESSION_EXPIRES=Explorer-Sitzung läuft spätestens ab:
 TIMEOUT=Zeitüberschreitung bei der Anfrage.
 PROTOCOL=Protokoll

--- a/templates/lang/language_en.ini
+++ b/templates/lang/language_en.ini
@@ -180,7 +180,7 @@ ALLOW_LOXBERRY_OPERATE=Allow loxberry:operate
 [EXPLORER]
 TITLE=MCP Tool Explorer
 BACK=Back to setup
-INTRO=Inspect, call and validate the tools exposed by the local MCP server. History and sign-in remain in this browser tab only.
+INTRO=Inspect, call and validate the tools exposed by the local MCP server. History stays in this tab; sign-in can be reused by new tabs for up to eight hours.
 CONNECTION=Connection
 ACCESS_MODE=Permissions for this sign-in
 READ_ONLY=Read only
@@ -256,7 +256,7 @@ TOKEN_EXPIRED=The session could not be refreshed. Sign in again.
 RESTORING_SESSION=Restoring the saved sign-in …
 RESTORE_FAILED=The saved sign-in could not be restored because of a temporary connection failure. Reload the page to retry.
 SESSION_OTHER_TAB=This saved sign-in is already used in another tab, or the browser does not support safe tab locking. Sign in again in this tab.
-SESSION_POLICY=Reloading restores the sign-in in this tab in supported browsers. Closing the tab discards the local credentials, but the browser cannot reliably revoke the server session immediately. Use “Disconnect and revoke” for that. Explorer sessions expire after eight hours at the latest.
+SESSION_POLICY=New Explorer tabs reuse the secure shared browser session for no more than eight hours. Credentials remain server-side; “Disconnect and revoke” signs out every Explorer tab immediately.
 SESSION_EXPIRES=Explorer session expires no later than:
 TIMEOUT=The request timed out.
 PROTOCOL=Protocol

--- a/tests/test_explorer_ui.py
+++ b/tests/test_explorer_ui.py
@@ -470,22 +470,6 @@ def test_explorer_oauth_guards_and_resource_binding() -> None:
         )
         is False
     )
-    assert run_core(
-        "core.authorizationCodeTokenFields('client','code','https://local/callback','verifier','https://local/mcp')"
-    ) == {
-        "grant_type": "authorization_code",
-        "client_id": "client",
-        "code": "code",
-        "redirect_uri": "https://local/callback",
-        "code_verifier": "verifier",
-        "resource": "https://local/mcp",
-    }
-    assert run_core("core.refreshTokenFields('client','refresh','https://local/mcp')") == {
-        "grant_type": "refresh_token",
-        "client_id": "client",
-        "refresh_token": "refresh",
-        "resource": "https://local/mcp",
-    }
 
 
 def test_explorer_disconnect_clears_all_in_memory_session_data() -> None:
@@ -512,41 +496,6 @@ def test_explorer_disconnect_clears_all_in_memory_session_data() -> None:
     }
 
 
-@pytest.mark.parametrize("revocation_fails", [False, True])
-def test_explorer_revocation_always_clears_session(revocation_fails: bool) -> None:
-    revoke = (
-        "async()=>{events.push('revoke-attempt');throw new Error('offline')}"
-        if revocation_fails
-        else "async()=>{events.push('revoke')}"
-    )
-    expression = f"""(() => {{
-      const events=[];
-      return core.revokeThenClear({{refreshToken:'refresh'}},{revoke},()=>events.push('cleared'))
-        .then(()=>events);
-    }})()"""
-
-    expected = ["revoke-attempt", "cleared"] if revocation_fails else ["revoke", "cleared"]
-    assert run_core_async(expression) == expected
-
-
-def test_explorer_revocation_request_uses_bounded_timeout() -> None:
-    expression = """(() => {
-      const seen={};
-      const fetcher=async(url,options,timeout)=>Object.assign(seen,
-        {url,timeout,body:options.body.toString(),keepalive:options.keepalive});
-      const oauth={metadata:{revocation_endpoint:'https://local/revoke'},
-        refreshToken:'refresh',clientId:'client'};
-      return core.revokeOAuthGrant(fetcher,oauth,core.REVOCATION_TIMEOUT_MS).then(()=>seen);
-    })()"""
-
-    assert run_core_async(expression) == {
-        "url": "https://local/revoke",
-        "timeout": 5000,
-        "body": "token=refresh&token_type_hint=refresh_token&client_id=client",
-        "keepalive": True,
-    }
-
-
 def test_session_clear_prevents_call_artifacts_from_being_recreated() -> None:
     source = SCRIPT.read_text(encoding="utf-8")
 
@@ -556,117 +505,15 @@ def test_session_clear_prevents_call_artifacts_from_being_recreated() -> None:
     assert source.count("if (!sessionCleared) {") >= 2
 
 
-def test_explorer_resume_record_contains_only_valid_tab_scoped_refresh_data() -> None:
-    token = "a" * 43
-    resource = "https://local/plugins/mcpserver/mcp"
-    oauth = {
-        "metadata": {"token_endpoint": "https://local/token"},
-        "clientId": token,
-        "sessionId": token,
-        "scope": "loxone:read",
-        "accessToken": "must-not-be-stored",
-        "refreshToken": token,
-        "resource": resource,
-        "expiresAt": 123,
-        "resumeUntil": 1_000_000,
-    }
-    record = run_core(f"core.resumableSession({json.dumps(oauth)})")
+def test_explorer_keeps_refresh_credentials_out_of_browser_storage() -> None:
+    source = SCRIPT.read_text(encoding="utf-8")
 
-    assert record == {
-        "version": 1,
-        "sessionId": token,
-        "clientId": token,
-        "scope": "loxone:read",
-        "refreshToken": token,
-        "resource": resource,
-        "resumeUntil": 1_000_000,
-    }
-    encoded = json.dumps(record)
-    assert (
-        run_core(f"core.validateResumableSession({encoded},{json.dumps(resource)},999999)")
-        == record
-    )
-    assert (
-        run_core(f"core.validateResumableSession({encoded},{json.dumps(resource)},1000000)") is None
-    )
-    assert (
-        run_core(
-            f"core.validateResumableSession({encoded},'https://other/plugins/mcpserver/mcp',999999)"
-        )
-        is None
-    )
-
-
-def test_explorer_client_registration_is_tab_scoped_and_expires_before_server_cleanup() -> None:
-    client_id = "a" * 43
-    registered_at = 1_000_000
-    record = run_core(f"core.clientRegistration('{client_id}',{registered_at})")
-
-    assert record == {"version": 2, "clientId": client_id, "registeredAt": registered_at}
-    encoded = json.dumps(record)
-    assert run_core(f"core.validateClientRegistration({encoded},{registered_at})") == record
-    assert (
-        run_core(
-            f"core.validateClientRegistration({encoded},"
-            f"{registered_at}+core.EXPLORER_CLIENT_REGISTRATION_MS-1)"
-        )
-        == record
-    )
-    assert (
-        run_core(
-            f"core.validateClientRegistration({encoded},"
-            f"{registered_at}+core.EXPLORER_CLIENT_REGISTRATION_MS)"
-        )
-        is None
-    )
-    assert (
-        run_core(
-            f"core.validateClientRegistration("
-            f"{json.dumps({'version': 2, 'clientId': 'invalid', 'registeredAt': registered_at})},"
-            f"{registered_at})"
-        )
-        is None
-    )
-    assert (
-        run_core(
-            f"core.validateClientRegistration("
-            f"{json.dumps({'version': 1, 'clientId': client_id, 'registeredAt': registered_at})},"
-            f"{registered_at})"
-        )
-        is None
-    )
-
-
-@pytest.mark.parametrize("exchange_fails", [False, True])
-def test_explorer_refresh_removes_replayable_state_before_rotation(
-    exchange_fails: bool,
-) -> None:
-    exchange = (
-        "async()=>{events.push('exchange');throw new Error('offline')}"
-        if exchange_fails
-        else "async()=>{events.push('exchange');return {access_token:'new-access',"
-        "refresh_token:'new-refresh',expires_in:600,scope:'loxone:read'}}"
-    )
-    expression = f"""(async()=>{{
-      const events=[];
-      const oauth={{resumeEnabled:true,clientId:'client',refreshToken:'old-refresh',
-        resource:'https://local/mcp',scope:'loxone:read'}};
-      try {{
-        const saved=await core.rotateRefreshToken(oauth,{exchange},
-          ()=>events.push('clear'),()=>{{events.push('save');return true}},1000);
-        return {{events,saved,refreshToken:oauth.refreshToken}};
-      }} catch (_error) {{ return {{events,refreshToken:oauth.refreshToken}}; }}
-    }})()"""
-
-    actual = run_core_async(expression)
-    if exchange_fails:
-        assert actual == {"events": ["clear", "exchange"], "refreshToken": "old-refresh"}
-    else:
-        assert actual == {
-            "events": ["clear", "exchange", "save"],
-            "saved": True,
-            "refreshToken": "new-refresh",
-        }
+    assert "explorer-session" in source
+    assert "credentials: 'same-origin'" in source
+    assert "BroadcastChannel" in source
+    assert "sessionStorage" not in source
+    assert "localStorage" not in source
+    assert "refreshToken" not in source
 
 
 def test_explorer_generated_field_ids_are_unique_and_labelled() -> None:
@@ -728,16 +575,6 @@ def test_explorer_tabs_support_roving_focus_and_arrow_keys() -> None:
     assert "elements.jsonTab.addEventListener('keydown', handleTabKey)" in source
 
 
-def test_explorer_scope_validation_accepts_independent_canonical_choices() -> None:
-    assert run_core("core.validExplorerScope('loxone:read')") is True
-    assert run_core("core.validExplorerScope('loxone:read loxone:control loxberry:read')") is True
-    assert (
-        run_core("core.validExplorerScope('loxone:read loxone:history loxberry:operate')") is True
-    )
-    assert run_core("core.validExplorerScope('loxone:read loxberry:operate')") is False
-    assert run_core("core.validExplorerScope('loxone:read loxberry:read loxone:control')") is False
-
-
 def test_explorer_redacts_secret_shaped_arguments() -> None:
     schema = {
         "type": "object",
@@ -769,21 +606,15 @@ def test_explorer_ui_is_local_scoped_and_progressively_safe() -> None:
     assert "issuerUrl.origin !== resourceUrl.origin" in source
     assert "code_challenge_method: 'S256'" in source
     assert "width=680,height=900,resizable=yes,scrollbars=yes" in source
-    assert "core.rotateRefreshToken(" in source
+    assert "action: 'access'" in source
     assert "if (state.oauth) await revokeAndClear()" in source
     assert "core.toolIsMutating(state.selectedTool)" in source
     assert "state.history.length > core.MAX_CALL_HISTORY" in source
     assert "fetchWithTimeout('/plugins/mcpserver/mcp'" in source
     assert "}, 70000)" in source
-    assert "localStorage.setItem" not in source
-    assert "window.localStorage.removeItem(key)" in source
-    assert "core.validateClientRegistration" in source
-    assert "JSON.stringify(core.clientRegistration(clientId, Date.now()))" in source
-    assert "sessionStorage.setItem" in source
-    assert "core.validateResumableSession" in source
-    assert "readStoredSession(discovered.resourceMetadata.resource)" in source
-    assert "navigator.locks.request" in source
-    assert "ifAvailable: true" in source
+    assert "sessionStorage" not in source
+    assert "localStorage" not in source
+    assert "navigator.locks.request" not in source
     assert "await refreshAccessToken();" in source
     assert "window.addEventListener('pagehide'" not in source
     assert "navigator.sendBeacon" not in source
@@ -811,14 +642,12 @@ def test_explorer_ui_is_local_scoped_and_progressively_safe() -> None:
     assert 'id="explorer-origin-link"' in template
     assert "const canonicalUrl = core.canonicalExplorerUrl(" in source
     assert "showConnectionError(_error, label('error'))" in source
-    assert "if (canonicalOriginMismatch && stored) clearStoredSession()" in source
     assert 'id="explorer-session-expiry" hidden' in template
     assert "const scope = core.EXPLORER_SCOPE_ORDER.filter" in source
     assert "const registrationScope = scope" in source
     assert "supported.delete('loxberry:operate')" in source
     assert "state.selectedTool.name === 'loxberry_clear_statistics_cache'" in source
     assert "elements.historyArguments.hidden = !historySource" in source
-    assert "function clientStorageKey()" in source
     assert "Cache_Control => 'no-store'" in callback
     assert "frame-ancestors 'none'" in callback
     assert "window.history.replaceState" in callback
@@ -827,9 +656,7 @@ def test_explorer_ui_is_local_scoped_and_progressively_safe() -> None:
 def test_explorer_initial_discovery_has_no_pre_login_permission_choice() -> None:
     source = SCRIPT.read_text(encoding="utf-8")
     initial_discovery = source[
-        source.index("(async () => {", source.index("selectTab(false, false);")) : source.index(
-            "stored = readStoredSession"
-        )
+        source.index("(async () => {", source.index("selectTab(false, false);")) :
     ]
 
     assert "setScopeAvailability" not in initial_discovery

--- a/tests/test_loxone_store.py
+++ b/tests/test_loxone_store.py
@@ -4,7 +4,11 @@ from pathlib import Path
 
 import pytest
 
-from mcpserver.auth.loxone_store import EncryptedLoxoneTokenStore, LoxoneTokenStoreError
+from mcpserver.auth.loxone_store import (
+    EncryptedLoxoneTokenStore,
+    ExplorerSession,
+    LoxoneTokenStoreError,
+)
 from mcpserver.loxone.client import LoxoneToken
 
 
@@ -48,3 +52,26 @@ def test_wrong_installation_key_cannot_decrypt(tmp_path: Path) -> None:
 
     with pytest.raises(LoxoneTokenStoreError, match="cannot be decrypted"):
         reopened.get("family", "miniserver", "identity")
+
+
+def test_explorer_session_is_encrypted_and_removed_with_its_oauth_family(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    session = ExplorerSession(
+        "browser-session",
+        "family",
+        "client",
+        "https://example/mcp",
+        "loxone:read",
+        "access-secret",
+        2_000_000_000,
+        "refresh-secret",
+        2_000_010_000,
+    )
+
+    store.put_explorer_session(session)
+
+    assert "access-secret" not in store.path.read_text(encoding="utf-8")
+    assert "refresh-secret" not in store.path.read_text(encoding="utf-8")
+    assert store.get_explorer_session("browser-session") == session
+    store.delete_explorer_family("family")
+    assert store.get_explorer_session("browser-session") is None

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -18,6 +18,7 @@ from starlette.requests import Request
 from starlette.routing import Route
 from starlette.testclient import TestClient
 
+from mcpserver.auth.loxone_store import EncryptedLoxoneTokenStore
 from mcpserver.auth.provider import (
     CONTROL_SCOPE,
     EXPLORER_CLIENT_NAME,
@@ -556,12 +557,15 @@ async def test_expired_code_and_access_token_fail_closed(tmp_path: Path) -> None
     assert await provider.load_authorization_code(client, raw_code) is None
 
 
-def _web_app(provider: Phase0OAuthProvider) -> Starlette:
+def _web_app(
+    provider: Phase0OAuthProvider, explorer_store: EncryptedLoxoneTokenStore | None = None
+) -> Starlette:
     web = Phase0OAuthWeb(
         provider,
         endpoint=MiniserverEndpoint.parse_gen1("http://192.168.255.254"),
         issuer=ISSUER,
         resource=RESOURCE,
+        loxone_store=explorer_store,
     )
     return Starlette(
         routes=[
@@ -569,9 +573,75 @@ def _web_app(provider: Phase0OAuthProvider) -> Starlette:
             Route("/authorize", web.authorize, methods=["GET", "POST"]),
             Route("/token", web.token, methods=["POST"]),
             Route("/revoke", web.revoke, methods=["POST"]),
+            Route("/explorer-session", web.explorer_session, methods=["POST"]),
             Route("/metadata", web.authorization_metadata, methods=["GET"]),
         ]
     )
+
+
+def test_explorer_session_cookie_reuses_one_oauth_family_and_logout_revokes_it(
+    tmp_path: Path,
+) -> None:
+    provider = _provider(tmp_path)
+    client_info = _client_info(
+        "explorer-client", client_name=EXPLORER_CLIENT_NAME, redirect_uri=EXPLORER_REDIRECT
+    )
+    asyncio.run(provider.register_client(client_info))
+    code = provider.issue_authorization_code(
+        client_id="explorer-client",
+        redirect_uri=EXPLORER_REDIRECT,
+        code_challenge=CHALLENGE,
+        resource=RESOURCE,
+        identity_id="identity",
+        miniserver_id="miniserver",
+    )
+    key = tmp_path / "install.key"
+    key.write_bytes(b"k" * 32)
+    encrypted = EncryptedLoxoneTokenStore((tmp_path / "tokens.json").resolve(), key.resolve())
+    headers = {"Origin": "https://public.example"}
+    with TestClient(_web_app(provider, encrypted), base_url="https://public.example") as browser:
+        complete = browser.post(
+            "/explorer-session",
+            headers=headers,
+            json={
+                "action": "complete",
+                "client_id": "explorer-client",
+                "code": code,
+                "redirect_uri": EXPLORER_REDIRECT,
+                "code_verifier": VERIFIER,
+                "resource": RESOURCE,
+            },
+        )
+        session_headers = {**headers, "Cookie": complete.headers["set-cookie"].split(";", 1)[0]}
+        reused = browser.post(
+            "/explorer-session", headers=session_headers, json={"action": "access"}
+        )
+        logout = browser.post(
+            "/explorer-session", headers=session_headers, json={"action": "logout"}
+        )
+
+    assert complete.status_code == 200
+    assert "Secure" in complete.headers["set-cookie"]
+    assert "HttpOnly" in complete.headers["set-cookie"]
+    assert "SameSite=strict" in complete.headers["set-cookie"]
+    assert reused.status_code == 200
+    assert reused.json()["access_token"] == complete.json()["access_token"]
+    assert logout.status_code == 204
+    assert next(iter(provider.store.snapshot()["families"].values()))["revoked"] is True
+
+
+def test_explorer_session_rejects_cross_origin_requests(tmp_path: Path) -> None:
+    key = tmp_path / "install.key"
+    key.write_bytes(b"k" * 32)
+    encrypted = EncryptedLoxoneTokenStore((tmp_path / "tokens.json").resolve(), key.resolve())
+    with TestClient(_web_app(_provider(tmp_path), encrypted)) as browser:
+        response = browser.post(
+            "/explorer-session",
+            headers={"Origin": "https://attacker.example"},
+            json={"action": "access"},
+        )
+
+    assert response.status_code == 400
 
 
 def _registration_payload() -> dict[str, object]:

--- a/webfrontend/htmlauth/explorer.js
+++ b/webfrontend/htmlauth/explorer.js
@@ -1,4 +1,4 @@
-/* LoxBerry MCP Tool Explorer. Refresh credentials may resume only within the same tab. */
+/* LoxBerry MCP Tool Explorer. Refresh credentials remain in the server-side browser session. */
 (function (root, factory) {
   const api = factory();
   if (typeof module === 'object' && module.exports) module.exports = api;
@@ -9,12 +9,9 @@
   const PROTOCOL_VERSION = '2025-11-25';
   const MAX_CALL_HISTORY = 50;
   const MAX_TRANSCRIPT = 100;
-  const REVOCATION_TIMEOUT_MS = 5000;
   const EXPLORER_SESSION_MS = 8 * 60 * 60 * 1000;
-  const EXPLORER_CLIENT_REGISTRATION_MS = EXPLORER_SESSION_MS;
   const MCP_RESOURCE_PATH = '/plugins/mcpserver/mcp';
   const EXPLORER_PATH = '/admin/plugins/mcpserver/explorer.cgi';
-  const OPAQUE_VALUE = /^[A-Za-z0-9_-]{32,512}$/;
   const EXPLORER_SCOPE_ORDER = [
     'loxone:read', 'loxone:history', 'loxone:control', 'loxberry:read', 'loxberry:operate',
   ];
@@ -448,74 +445,6 @@
     return origin === expectedOrigin && data && data.type === 'mcp-explorer-oauth' && data.state === expectedState;
   }
 
-  function authorizationCodeTokenFields(clientId, code, redirectUri, verifier, resource) {
-    return {
-      grant_type: 'authorization_code', client_id: clientId, code,
-      redirect_uri: redirectUri, code_verifier: verifier, resource,
-    };
-  }
-
-  function refreshTokenFields(clientId, refreshToken, resource) {
-    return {
-      grant_type: 'refresh_token', client_id: clientId,
-      refresh_token: refreshToken, resource,
-    };
-  }
-
-  function resumableSession(oauth) {
-    return {
-      version: 1,
-      sessionId: oauth.sessionId,
-      clientId: oauth.clientId,
-      scope: oauth.scope,
-      refreshToken: oauth.refreshToken,
-      resource: oauth.resource,
-      resumeUntil: oauth.resumeUntil,
-    };
-  }
-
-  function validExplorerScope(value) {
-    if (typeof value !== 'string') return false;
-    const scopes = value.split(/\s+/).filter(Boolean);
-    if (!scopes.length || scopes.length !== new Set(scopes).size) return false;
-    if (scopes.join(' ') !== EXPLORER_SCOPE_ORDER.filter((scope) => scopes.includes(scope)).join(' ')) return false;
-    if (scopes[0] !== 'loxone:read') return false;
-    return !scopes.includes('loxberry:operate') || scopes.includes('loxone:history');
-  }
-
-  function validateResumableSession(value, expectedResource, now) {
-    if (!value || typeof value !== 'object' || Array.isArray(value) || value.version !== 1) return null;
-    if (!OPAQUE_VALUE.test(value.sessionId || '') || !OPAQUE_VALUE.test(value.clientId || '') ||
-      !OPAQUE_VALUE.test(value.refreshToken || '')) return null;
-    if (!validExplorerScope(value.scope) || value.resource !== expectedResource) return null;
-    if (!Number.isSafeInteger(value.resumeUntil) || value.resumeUntil <= now ||
-      value.resumeUntil > now + EXPLORER_SESSION_MS) return null;
-    return resumableSession(value);
-  }
-
-  function clientRegistration(clientId, registeredAt) {
-    return {version: 2, clientId, registeredAt};
-  }
-
-  function validateClientRegistration(value, now) {
-    if (!value || typeof value !== 'object' || Array.isArray(value) || value.version !== 2) return null;
-    if (!/^[A-Za-z0-9_-]{43}$/.test(value.clientId || '')) return null;
-    if (!Number.isSafeInteger(value.registeredAt) || value.registeredAt > now ||
-      value.registeredAt <= now - EXPLORER_CLIENT_REGISTRATION_MS) return null;
-    return clientRegistration(value.clientId, value.registeredAt);
-  }
-
-  async function rotateRefreshToken(oauth, exchange, clearResume, saveResume, now) {
-    if (oauth.resumeEnabled) clearResume();
-    const token = await exchange(refreshTokenFields(oauth.clientId, oauth.refreshToken, oauth.resource));
-    if (!token.access_token || !token.refresh_token) throw new Error('OAuth token response is incomplete');
-    oauth.accessToken = token.access_token;
-    oauth.refreshToken = token.refresh_token;
-    oauth.scope = token.scope || oauth.scope;
-    oauth.expiresAt = now + Math.max(0, Number(token.expires_in || 0) - 15) * 1000;
-    return !oauth.resumeEnabled || saveResume(oauth);
-  }
-
   function clearSensitiveState(state) {
     state.oauth = null;
     state.tools = [];
@@ -530,25 +459,6 @@
     state.transferPath = '';
     state.transferRecipe = null;
     state.drafts = {};
-  }
-
-  async function revokeThenClear(oauth, revoke, clear) {
-    try {
-      if (oauth && oauth.refreshToken) await revoke(oauth);
-    } catch (_error) {
-      // Server-side session management remains available if best-effort revocation fails.
-    } finally {
-      clear();
-    }
-  }
-
-  async function revokeOAuthGrant(fetcher, oauth, timeoutMs) {
-    return fetcher(oauth.metadata.revocation_endpoint, {
-      method: 'POST', cache: 'no-store',
-      headers: {'Content-Type': 'application/x-www-form-urlencoded'},
-      body: new URLSearchParams({token: oauth.refreshToken, token_type_hint: 'refresh_token', client_id: oauth.clientId}),
-      keepalive: true,
-    }, timeoutMs);
   }
 
   function fieldControlId(index) {
@@ -577,9 +487,7 @@
     PROTOCOL_VERSION,
     MAX_CALL_HISTORY,
     MAX_TRANSCRIPT,
-    REVOCATION_TIMEOUT_MS,
     EXPLORER_SESSION_MS,
-    EXPLORER_CLIENT_REGISTRATION_MS,
     EXPLORER_SCOPE_ORDER,
     clone,
     resolveRef,
@@ -605,17 +513,7 @@
     base64Url,
     toolIsMutating,
     acceptOAuthMessage,
-    authorizationCodeTokenFields,
-    refreshTokenFields,
-    resumableSession,
-    validExplorerScope,
-    validateResumableSession,
-    clientRegistration,
-    validateClientRegistration,
-    rotateRefreshToken,
     clearSensitiveState,
-    revokeThenClear,
-    revokeOAuthGrant,
     fieldControlId,
     canonicalExplorerUrl,
     httpsExplorerUrl,
@@ -691,8 +589,14 @@
     drafts: {},
     nextId: 1,
     busy: false,
-    sessionLockId: null,
-    releaseSessionLock: null,
+  };
+  const logoutChannel = typeof BroadcastChannel === 'function'
+    ? new BroadcastChannel('mcp-explorer-session') : null;
+  if (logoutChannel) logoutChannel.onmessage = (event) => {
+    if (event.data !== 'logout') return;
+    core.clearSensitiveState(state);
+    renderAll();
+    setStatus(label('disconnected'), '');
   };
 
   function setStatus(text, kind) {
@@ -763,104 +667,6 @@
     return body;
   }
 
-  function clientStorageKey() {
-    return `mcp-explorer-client:${window.location.origin}`;
-  }
-
-  function sessionStorageKey() {
-    return `mcp-explorer-session:${window.location.origin}`;
-  }
-
-  function clearStoredSession() {
-    try { window.sessionStorage.removeItem(sessionStorageKey()); } catch (_error) { /* optional */ }
-  }
-
-  function readStoredSession(expectedResource) {
-    try {
-      const serialized = window.sessionStorage.getItem(sessionStorageKey());
-      if (!serialized) return null;
-      const session = core.validateResumableSession(
-        JSON.parse(serialized),
-        expectedResource,
-        Date.now(),
-      );
-      if (!session) clearStoredSession();
-      return session;
-    } catch (_error) {
-      clearStoredSession();
-      return null;
-    }
-  }
-
-  function saveStoredSession(oauth) {
-    try {
-      window.sessionStorage.setItem(
-        sessionStorageKey(),
-        JSON.stringify(core.resumableSession(oauth)),
-      );
-      return true;
-    } catch (_error) {
-      // Never leave a rotated, replay-invalid refresh token behind.
-      clearStoredSession();
-      return false;
-    }
-  }
-
-  async function acquireSessionOwnership(sessionId) {
-    if (state.sessionLockId === sessionId) return true;
-    if (!navigator.locks || typeof navigator.locks.request !== 'function') return false;
-    return new Promise((resolve) => {
-      navigator.locks.request(
-        `mcp-explorer-session:${sessionId}`,
-        {mode: 'exclusive', ifAvailable: true},
-        (lock) => {
-          if (!lock) {
-            resolve(false);
-            return undefined;
-          }
-          state.sessionLockId = sessionId;
-          return new Promise((release) => {
-            state.releaseSessionLock = () => {
-              state.sessionLockId = null;
-              state.releaseSessionLock = null;
-              release();
-            };
-            resolve(true);
-          });
-        },
-      ).catch(() => resolve(false));
-    });
-  }
-
-  function releaseSessionOwnership() {
-    if (state.releaseSessionLock) state.releaseSessionLock();
-  }
-
-  function readClientId() {
-    const key = clientStorageKey();
-    // Older releases retained this identifier beyond the server-side DCR lifetime.
-    try { window.localStorage.removeItem(key); } catch (_error) { /* migration only */ }
-    try {
-      const serialized = window.sessionStorage.getItem(key);
-      if (!serialized) return null;
-      const registration = core.validateClientRegistration(JSON.parse(serialized), Date.now());
-      if (registration) return registration.clientId;
-      window.sessionStorage.removeItem(key);
-    } catch (_error) {
-      try { window.sessionStorage.removeItem(key); } catch (_ignored) { /* optional */ }
-    }
-    return null;
-  }
-
-  function saveClientId(clientId) {
-    try {
-      window.sessionStorage.setItem(
-        clientStorageKey(),
-        JSON.stringify(core.clientRegistration(clientId, Date.now())),
-      );
-    } catch (_error) { /* optional */ }
-  }
-
   async function discover() {
     if (window.location.protocol !== 'https:') {
       const error = new Error(label('originMismatch'));
@@ -904,8 +710,6 @@
   }
 
   async function registerClient(metadata, registrationScope, redirectUri) {
-    const cached = readClientId();
-    if (cached) return cached;
     const registration = await fetchJson(metadata.registration_endpoint, {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
@@ -920,7 +724,6 @@
       }),
     });
     if (!registration.client_id) throw new Error('OAuth client registration returned no client_id');
-    saveClientId(registration.client_id);
     return registration.client_id;
   }
 
@@ -950,13 +753,10 @@
     });
   }
 
-  async function exchangeToken(metadata, fields) {
-    const body = new URLSearchParams(fields);
-    return fetchJson(metadata.token_endpoint, {
-      method: 'POST',
-      headers: {'Content-Type': 'application/x-www-form-urlencoded'},
-      cache: 'no-store',
-      body,
+  async function explorerSession(metadata, body) {
+    return fetchJson(`${metadata.issuer}/explorer-session`, {
+      method: 'POST', cache: 'no-store', credentials: 'same-origin',
+      headers: {'Content-Type': 'application/json'}, body: JSON.stringify(body),
     });
   }
 
@@ -991,38 +791,29 @@
     popup.location.replace(authorizationUrl.href);
     const code = await waitForAuthorization(popup, oauthState);
     if (!code) throw new Error(label('authCancelled'));
-    const token = await exchangeToken(
-      discovered.authorizationMetadata,
-      core.authorizationCodeTokenFields(clientId, code, redirectUri, verifier, discovered.resourceMetadata.resource),
-    );
-    if (!token.access_token || !token.refresh_token) throw new Error('OAuth token response is incomplete');
+    const token = await explorerSession(discovered.authorizationMetadata, {
+      action: 'complete', client_id: clientId, code, redirect_uri: redirectUri,
+      code_verifier: verifier, resource: discovered.resourceMetadata.resource,
+    });
+    if (!token.access_token) throw new Error('Explorer session response is incomplete');
     return {
       metadata: discovered.authorizationMetadata,
       resource: discovered.resourceMetadata.resource,
-      sessionId: randomUrlSafe(32),
-      clientId,
       scope: token.scope || scope,
       accessToken: token.access_token,
-      refreshToken: token.refresh_token,
       expiresAt: Date.now() + Math.max(0, Number(token.expires_in || 0) - 15) * 1000,
-      resumeUntil,
-      resumeEnabled: false,
+      resumeUntil: Number(token.expires_at || resumeUntil) * 1000,
     };
   }
 
   async function refreshAccessToken() {
-    if (!state.oauth || !state.oauth.refreshToken) throw new Error(label('tokenExpired'));
-    const saved = await core.rotateRefreshToken(
-      state.oauth,
-      (fields) => exchangeToken(state.oauth.metadata, fields),
-      clearStoredSession,
-      saveStoredSession,
-      Date.now(),
-    );
-    if (!saved) {
-      state.oauth.resumeEnabled = false;
-      releaseSessionOwnership();
-    }
+    if (!state.oauth) throw new Error(label('tokenExpired'));
+    const token = await explorerSession(state.oauth.metadata, {action: 'access'});
+    if (!token.access_token) throw new Error('Explorer session response is incomplete');
+    state.oauth.accessToken = token.access_token;
+    state.oauth.scope = token.scope || state.oauth.scope;
+    state.oauth.expiresAt = Date.now() + Math.max(0, Number(token.expires_in || 0) - 15) * 1000;
+    state.oauth.resumeUntil = Number(token.expires_at || 0) * 1000;
   }
 
   async function accessToken() {
@@ -1119,23 +910,20 @@
 
   async function revokeAndClear() {
     const oauth = state.oauth;
-    await core.revokeThenClear(oauth, async (current) => {
-      await core.revokeOAuthGrant(fetchWithTimeout, current, core.REVOCATION_TIMEOUT_MS);
-    }, () => {
-      clearStoredSession();
-      releaseSessionOwnership();
-      core.clearSensitiveState(state);
-      elements.json.value = '{}';
-      elements.confirmTool.textContent = '';
-      elements.confirmArguments.textContent = '';
-      elements.transferSource.textContent = '';
-      elements.transferTool.replaceChildren();
-      elements.transferField.replaceChildren();
-      elements.transferEmpty.hidden = false;
-      elements.transferApply.disabled = true;
-      if (elements.transfer.open) elements.transfer.close();
-      renderAll();
-    });
+    try { if (oauth) await explorerSession(oauth.metadata, {action: 'logout'}); }
+    catch (_error) { /* Server-side expiry remains the fail-safe. */ }
+    core.clearSensitiveState(state);
+    elements.json.value = '{}';
+    elements.confirmTool.textContent = '';
+    elements.confirmArguments.textContent = '';
+    elements.transferSource.textContent = '';
+    elements.transferTool.replaceChildren();
+    elements.transferField.replaceChildren();
+    elements.transferEmpty.hidden = false;
+    elements.transferApply.disabled = true;
+    if (elements.transfer.open) elements.transfer.close();
+    renderAll();
+    if (logoutChannel) logoutChannel.postMessage('logout');
   }
 
   function renderConnection() {
@@ -1627,11 +1415,6 @@
     setStatus(label('working'), 'working');
     try {
       state.oauth = await authorize(authorizationPopup);
-      state.oauth.resumeEnabled = await acquireSessionOwnership(state.oauth.sessionId);
-      if (state.oauth.resumeEnabled && !saveStoredSession(state.oauth)) {
-        state.oauth.resumeEnabled = false;
-        releaseSessionOwnership();
-      }
       await initializeMcp();
       renderAll();
       if (state.tools.length) selectTool(state.tools[0].name);
@@ -1682,61 +1465,30 @@
   selectTab(false, false);
   renderAll();
   (async () => {
-    let stored = null;
-    let ownershipConflict = false;
-    let refreshed = false;
     try {
       const discovered = await discover();
-      stored = readStoredSession(discovered.resourceMetadata.resource);
-      if (stored) {
-        setBusy(true);
-        setStatus(label('restoringSession'), 'working');
-        if (!(await acquireSessionOwnership(stored.sessionId))) {
-          clearStoredSession();
-          stored = null;
-          ownershipConflict = true;
-        }
-      }
-      if (!stored) return;
+      setBusy(true);
+      setStatus(label('restoringSession'), 'working');
       state.oauth = {
-        ...stored,
         metadata: discovered.authorizationMetadata,
-        accessToken: '',
-        expiresAt: 0,
-        resumeEnabled: true,
+        resource: discovered.resourceMetadata.resource,
+        scope: 'loxone:read', accessToken: '', expiresAt: 0,
       };
       await refreshAccessToken();
-      refreshed = true;
       await initializeMcp();
       renderAll();
       if (state.tools.length) selectTool(state.tools[0].name);
       setStatus(label('connected'), 'success');
     } catch (_error) {
-      const refreshFailed = Boolean(state.oauth) && !refreshed;
       const canonicalOriginMismatch = _error instanceof Error
         && typeof _error.canonicalUrl === 'string';
-      if (refreshFailed) {
-        await revokeAndClear();
-      } else {
-        if (canonicalOriginMismatch && stored) clearStoredSession();
-        core.clearSensitiveState(state);
-        releaseSessionOwnership();
-      }
+      core.clearSensitiveState(state);
       renderAll();
       if (canonicalOriginMismatch) {
-        showConnectionError(_error, label('error'));
-      } else if (stored) {
-        showError(
-          new Error(refreshFailed ? label('tokenExpired') : label('restoreFailed')),
-          label('error'),
-        );
-      }
-      else {
         showConnectionError(_error, label('error'));
       }
     } finally {
       setBusy(false);
-      if (ownershipConflict) showError(new Error(label('sessionOtherTab')), label('error'));
     }
   })();
 })();


### PR DESCRIPTION
## Summary
- retain Explorer OAuth credentials only in an encrypted, server-side eight-hour browser session
- restore new tabs through a Secure, HttpOnly, SameSite=Strict cookie and serialize refresh rotation server-side
- make disconnect revoke the shared OAuth family, update tests and DE/EN documentation

## Validation
- C:\_Arbeit\LoxBerry-Plugin-MCP-Server\.venv\Scripts\python.exe -m pytest tests/test_loxone_store.py tests/test_oauth.py tests/test_explorer_ui.py --basetemp=.tmp\explorer-session-final2 -p no:cacheprovider (83 passed)
- uff format --check . and uff check . (passed)
- 
ode --check webfrontend/htmlauth/explorer.js and git diff --check (passed)
- full profile is delegated to CI: local environment has Python 3.12, project gate requires Python 3.13

## Acceptance scope
- targeted runtime file deployment to LoxBerry-Test passed; browser end-to-end acceptance requires an authenticated target browser session and is not claimed here.