### PR TITLE
Optimize admin UI read snapshots

### DIFF
--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -138,7 +138,8 @@ Claude-Benutzer finden die dafür notwendige Scope-Konfiguration im Abschnitt
 
 Speichern, Verbindungstest und Sitzungswiderruf funktionieren auch ohne
 JavaScript. Mit JavaScript werden Status, Test und Widerruf ohne Seitenwechsel
-aktualisiert.
+aktualisiert. Die Konfigurationsoberfläche wird sofort angezeigt; Dienststatus,
+Zertifikat und Sitzungen werden danach in einem einzelnen seriellen Abruf geladen.
 
 ## Webserver-Zertifikat
 

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -132,6 +132,8 @@ Claude users can find the required scope configuration under
 
 Save, connection test and session revocation remain usable without JavaScript.
 With JavaScript, status, test and revocation update without a page navigation.
+The configuration interface appears immediately; service status, certificate and
+sessions load afterwards in one serial request.
 
 ## Web server certificate
 

--- a/src/mcpserver/admin.py
+++ b/src/mcpserver/admin.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import base64
+import hashlib
+import hmac
 import json
 import os
 import re
@@ -11,7 +14,7 @@ import subprocess
 import sys
 import time
 from contextlib import suppress
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Final
 from uuid import UUID
@@ -36,6 +39,16 @@ class AdminError(RuntimeError):
     def __init__(self, message: str, *, code: str = "invalid_request") -> None:
         super().__init__(message)
         self.code = code
+
+
+@dataclass(frozen=True)
+class _AdminReadSnapshot:
+    """Consistent, single-read input for one administrative list response."""
+
+    configuration: Any
+    auth_document: dict[str, Any]
+    subject_key: bytes
+    now: float
 
 
 def _path(name: str, *, suffix: str | None = None) -> Path:
@@ -173,7 +186,7 @@ def _optional_path(name: str) -> Path | None:
     return path if path.is_absolute() else None
 
 
-def _certificate_status() -> dict[str, Any]:
+def _certificate_status(*, configuration: Any | None = None) -> dict[str, Any]:
     from mcpserver.certificates import inspect_certificate
 
     certificate = _optional_path("MCPSERVER_WEB_CERT")
@@ -186,7 +199,7 @@ def _certificate_status() -> dict[str, Any]:
             "renewal_supported": False,
             "renewal": {"state": "idle"},
         }
-    config = _config_store().load()
+    config = configuration if configuration is not None else _config_store().load()
     return inspect_certificate(
         certificate,
         authority,
@@ -388,20 +401,37 @@ async def _test_connection(payload: object) -> dict[str, Any]:
     }
 
 
-def _sessions() -> list[dict[str, Any]]:
+def _admin_read_snapshot() -> _AdminReadSnapshot:
+    """Load the immutable inputs for one admin list response exactly once."""
+
+    configuration = _config_store().load()
+    document = _auth_store().snapshot()
+    subject_key = base64.urlsafe_b64decode(document["subject_key"].encode("ascii"))
+    return _AdminReadSnapshot(configuration, document, subject_key, time.time())
+
+
+def _binding_pseudonym(subject_key: bytes, namespace: str, record: dict[str, Any]) -> str:
+    canonical = "\0".join(
+        (
+            namespace,
+            str(record.get("client_id", "")),
+            str(record.get("identity_id", "")),
+            str(record.get("miniserver_id", "")),
+        )
+    ).encode("utf-8")
+    return hmac.new(subject_key, canonical, hashlib.sha256).hexdigest()
+
+
+def _sessions(snapshot: _AdminReadSnapshot | None = None) -> list[dict[str, Any]]:
     from mcpserver.auth.provider import READ_SCOPE
 
-    document = _auth_store().snapshot()
+    snapshot = snapshot or _admin_read_snapshot()
+    document = snapshot.auth_document
     clients = document.get("clients", {})
     if not isinstance(clients, dict):
         clients = {}
-    try:
-        current = _config_store().load()
-        bindings = current.loxberry_read_bindings
-        operate_bindings = current.loxberry_operate_bindings
-    except AdminError:
-        bindings = ()
-        operate_bindings = ()
+    bindings = set(snapshot.configuration.loxberry_read_bindings)
+    operate_bindings = set(snapshot.configuration.loxberry_operate_bindings)
     result = []
     for family_id, record in document["families"].items():
         expires_at = record.get("expires_at")
@@ -409,18 +439,29 @@ def _sessions() -> list[dict[str, Any]]:
             continue
         client_id = str(record.get("client_id", ""))
         scopes = str(record.get("scope", "loxone:read"))
+        scope_set = frozenset(scopes.split())
         pending_loxberry_read = (
             bool(record.get("pending_loxberry_read", False))
-            and READ_SCOPE in scopes.split()
+            and READ_SCOPE in scope_set
             and isinstance(expires_at, int | float)
-            and expires_at > time.time()
+            and expires_at > snapshot.now
         )
         pending_loxberry_operate = (
             bool(record.get("pending_loxberry_operate", False))
-            and "loxone:history" in scopes.split()
-            and "loxberry:operate" in scopes.split()
+            and "loxone:history" in scope_set
+            and "loxberry:operate" in scope_set
             and isinstance(expires_at, int | float)
-            and expires_at > time.time()
+            and expires_at > snapshot.now
+        )
+        read_binding = (
+            _loxberry_binding(record, subject_key=snapshot.subject_key)
+            if pending_loxberry_read and bindings
+            else None
+        )
+        operate_binding = (
+            _loxberry_operate_binding(record, subject_key=snapshot.subject_key)
+            if pending_loxberry_operate and operate_bindings
+            else None
         )
         client = clients.get(client_id, {})
         client_name = client.get("client_name", "") if isinstance(client, dict) else ""
@@ -436,19 +477,19 @@ def _sessions() -> list[dict[str, Any]]:
                 "expires_at": record.get("expires_at"),
                 "revoked": bool(record.get("revoked", False)),
                 "loxberry_read_eligible": pending_loxberry_read,
-                "loxberry_read_approved": pending_loxberry_read
-                and bool(bindings)
-                and _loxberry_binding(record) in bindings,
+                "loxberry_read_approved": read_binding in bindings if read_binding else False,
                 "loxberry_operate_eligible": pending_loxberry_operate,
-                "loxberry_operate_approved": pending_loxberry_operate
-                and bool(operate_bindings)
-                and _loxberry_operate_binding(record) in operate_bindings,
+                "loxberry_operate_approved": (
+                    operate_binding in operate_bindings if operate_binding else False
+                ),
             }
         )
     return sorted(result, key=lambda item: str(item["id"]))
 
 
-def _loxberry_binding(record: dict[str, Any]) -> str:
+def _loxberry_binding(record: dict[str, Any], *, subject_key: bytes | None = None) -> str:
+    if subject_key is not None:
+        return _binding_pseudonym(subject_key, "loxberry-read-binding-v1", record)
     return _auth_store().pseudonym(
         "loxberry-read-binding-v1",
         str(record.get("client_id", "")),
@@ -457,7 +498,9 @@ def _loxberry_binding(record: dict[str, Any]) -> str:
     )
 
 
-def _loxberry_operate_binding(record: dict[str, Any]) -> str:
+def _loxberry_operate_binding(record: dict[str, Any], *, subject_key: bytes | None = None) -> str:
+    if subject_key is not None:
+        return _binding_pseudonym(subject_key, "loxberry-operate-binding-v1", record)
     return _auth_store().pseudonym(
         "loxberry-operate-binding-v1",
         str(record.get("client_id", "")),
@@ -489,30 +532,27 @@ def _binding_rows(binding: str, sessions: list[dict[str, str]]) -> list[dict[str
     ]
 
 
-def _loxberry_bindings() -> list[dict[str, Any]]:
+def _loxberry_bindings(snapshot: _AdminReadSnapshot | None = None) -> list[dict[str, Any]]:
     from mcpserver.auth.provider import LOXBERRY_READ_SCOPE
 
-    try:
-        bindings = _config_store().load().loxberry_read_bindings
-    except AdminError:
-        return []
+    snapshot = snapshot or _admin_read_snapshot()
+    bindings = snapshot.configuration.loxberry_read_bindings
     if not bindings:
         return []
-    document = _auth_store().snapshot()
+    document = snapshot.auth_document
     clients = document.get("clients", {})
     if not isinstance(clients, dict):
         clients = {}
     related: dict[str, list[dict[str, str]]] = {binding: [] for binding in bindings}
-    now = time.time()
     for record in document.get("families", {}).values():
         if not isinstance(record, dict) or record.get("revoked", False):
             continue
         expires_at = record.get("expires_at")
-        if not isinstance(expires_at, int | float) or expires_at <= now:
+        if not isinstance(expires_at, int | float) or expires_at <= snapshot.now:
             continue
         if LOXBERRY_READ_SCOPE not in str(record.get("scope", "")).split():
             continue
-        binding = _loxberry_binding(record)
+        binding = _loxberry_binding(record, subject_key=snapshot.subject_key)
         if binding not in related:
             continue
         client_id = str(record.get("client_id", ""))
@@ -540,27 +580,27 @@ def _loxberry_bindings() -> list[dict[str, Any]]:
     ]
 
 
-def _loxberry_operate_bindings() -> list[dict[str, Any]]:
+def _loxberry_operate_bindings(snapshot: _AdminReadSnapshot | None = None) -> list[dict[str, Any]]:
     from mcpserver.auth.provider import LOXBERRY_OPERATE_SCOPE
 
-    try:
-        bindings = _config_store().load().loxberry_operate_bindings
-    except AdminError:
-        return []
+    snapshot = snapshot or _admin_read_snapshot()
+    bindings = snapshot.configuration.loxberry_operate_bindings
     if not bindings:
         return []
-    document = _auth_store().snapshot()
+    document = snapshot.auth_document
     related: dict[str, list[dict[str, str]]] = {binding: [] for binding in bindings}
     clients = document.get("clients", {})
-    now = time.time()
     for record in document.get("families", {}).values():
         if not isinstance(record, dict) or record.get("revoked", False):
             continue
-        if not isinstance(record.get("expires_at"), int | float) or record["expires_at"] <= now:
+        if (
+            not isinstance(record.get("expires_at"), int | float)
+            or record["expires_at"] <= snapshot.now
+        ):
             continue
         if LOXBERRY_OPERATE_SCOPE not in str(record.get("scope", "")).split():
             continue
-        binding = _loxberry_operate_binding(record)
+        binding = _loxberry_operate_binding(record, subject_key=snapshot.subject_key)
         if binding not in related:
             continue
         client_id = str(record.get("client_id", ""))
@@ -839,13 +879,14 @@ def dispatch(request: object) -> dict[str, Any]:
     action = request["action"]
     payload = request.get("payload", {})
     if action == "page_state":
+        snapshot = _admin_read_snapshot()
         return {
-            "configuration": _config_store().load().to_document(),
+            "configuration": snapshot.configuration.to_document(),
             "version": __version__,
-            "sessions": _sessions(),
-            "loxberry_bindings": _loxberry_bindings(),
-            "loxberry_operate_bindings": _loxberry_operate_bindings(),
-            "certificate": _certificate_status(),
+            "sessions": _sessions(snapshot),
+            "loxberry_bindings": _loxberry_bindings(snapshot),
+            "loxberry_operate_bindings": _loxberry_operate_bindings(snapshot),
+            "certificate": _certificate_status(configuration=snapshot.configuration),
         } | _service_response()
     if action == "get_config":
         return {"configuration": _config_store().load().to_document()}
@@ -866,10 +907,11 @@ def dispatch(request: object) -> dict[str, Any]:
     if action == "test_connection":
         return asyncio.run(_test_connection(payload))
     if action == "list_sessions":
+        snapshot = _admin_read_snapshot()
         return {
-            "sessions": _sessions(),
-            "loxberry_bindings": _loxberry_bindings(),
-            "loxberry_operate_bindings": _loxberry_operate_bindings(),
+            "sessions": _sessions(snapshot),
+            "loxberry_bindings": _loxberry_bindings(snapshot),
+            "loxberry_operate_bindings": _loxberry_operate_bindings(snapshot),
         }
     if action == "allow_loxberry_read":
         return _allow_loxberry_read(payload)

--- a/src/mcpserver/admin.py
+++ b/src/mcpserver/admin.py
@@ -24,7 +24,7 @@ from mcpserver import __version__
 if TYPE_CHECKING:
     from mcpserver.auth.loxone_store import EncryptedLoxoneTokenStore
     from mcpserver.auth.store import AtomicJsonAuthStore
-    from mcpserver.config import AtomicConfigStore
+    from mcpserver.config import AtomicConfigStore, PluginConfig
     from mcpserver.loxone.client import LoxoneClient, MiniserverEndpoint
 
 _MAX_REQUEST_BYTES: Final = 32 * 1024
@@ -45,9 +45,9 @@ class AdminError(RuntimeError):
 class _AdminReadSnapshot:
     """Consistent, single-read input for one administrative list response."""
 
-    configuration: Any
+    configuration: PluginConfig | None
     auth_document: dict[str, Any]
-    subject_key: bytes
+    subject_key: bytes | None
     now: float
 
 
@@ -401,12 +401,22 @@ async def _test_connection(payload: object) -> dict[str, Any]:
     }
 
 
-def _admin_read_snapshot() -> _AdminReadSnapshot:
+def _admin_read_snapshot(*, require_configuration: bool = False) -> _AdminReadSnapshot:
     """Load the immutable inputs for one admin list response exactly once."""
 
-    configuration = _config_store().load()
+    try:
+        configuration = _config_store().load()
+    except AdminError:
+        if require_configuration:
+            raise
+        configuration = None
     document = _auth_store().snapshot()
-    subject_key = base64.urlsafe_b64decode(document["subject_key"].encode("ascii"))
+    encoded_subject_key = document.get("subject_key")
+    subject_key = (
+        base64.urlsafe_b64decode(encoded_subject_key.encode("ascii"))
+        if isinstance(encoded_subject_key, str)
+        else None
+    )
     return _AdminReadSnapshot(configuration, document, subject_key, time.time())
 
 
@@ -430,8 +440,12 @@ def _sessions(snapshot: _AdminReadSnapshot | None = None) -> list[dict[str, Any]
     clients = document.get("clients", {})
     if not isinstance(clients, dict):
         clients = {}
-    bindings = set(snapshot.configuration.loxberry_read_bindings)
-    operate_bindings = set(snapshot.configuration.loxberry_operate_bindings)
+    bindings = (
+        set(snapshot.configuration.loxberry_read_bindings) if snapshot.configuration else set()
+    )
+    operate_bindings = (
+        set(snapshot.configuration.loxberry_operate_bindings) if snapshot.configuration else set()
+    )
     result = []
     for family_id, record in document["families"].items():
         expires_at = record.get("expires_at")
@@ -455,12 +469,12 @@ def _sessions(snapshot: _AdminReadSnapshot | None = None) -> list[dict[str, Any]
         )
         read_binding = (
             _loxberry_binding(record, subject_key=snapshot.subject_key)
-            if pending_loxberry_read and bindings
+            if pending_loxberry_read and bindings and snapshot.subject_key is not None
             else None
         )
         operate_binding = (
             _loxberry_operate_binding(record, subject_key=snapshot.subject_key)
-            if pending_loxberry_operate and operate_bindings
+            if pending_loxberry_operate and operate_bindings and snapshot.subject_key is not None
             else None
         )
         client = clients.get(client_id, {})
@@ -536,7 +550,7 @@ def _loxberry_bindings(snapshot: _AdminReadSnapshot | None = None) -> list[dict[
     from mcpserver.auth.provider import LOXBERRY_READ_SCOPE
 
     snapshot = snapshot or _admin_read_snapshot()
-    bindings = snapshot.configuration.loxberry_read_bindings
+    bindings = snapshot.configuration.loxberry_read_bindings if snapshot.configuration else ()
     if not bindings:
         return []
     document = snapshot.auth_document
@@ -551,6 +565,8 @@ def _loxberry_bindings(snapshot: _AdminReadSnapshot | None = None) -> list[dict[
         if not isinstance(expires_at, int | float) or expires_at <= snapshot.now:
             continue
         if LOXBERRY_READ_SCOPE not in str(record.get("scope", "")).split():
+            continue
+        if snapshot.subject_key is None:
             continue
         binding = _loxberry_binding(record, subject_key=snapshot.subject_key)
         if binding not in related:
@@ -584,7 +600,7 @@ def _loxberry_operate_bindings(snapshot: _AdminReadSnapshot | None = None) -> li
     from mcpserver.auth.provider import LOXBERRY_OPERATE_SCOPE
 
     snapshot = snapshot or _admin_read_snapshot()
-    bindings = snapshot.configuration.loxberry_operate_bindings
+    bindings = snapshot.configuration.loxberry_operate_bindings if snapshot.configuration else ()
     if not bindings:
         return []
     document = snapshot.auth_document
@@ -599,6 +615,8 @@ def _loxberry_operate_bindings(snapshot: _AdminReadSnapshot | None = None) -> li
         ):
             continue
         if LOXBERRY_OPERATE_SCOPE not in str(record.get("scope", "")).split():
+            continue
+        if snapshot.subject_key is None:
             continue
         binding = _loxberry_operate_binding(record, subject_key=snapshot.subject_key)
         if binding not in related:
@@ -879,7 +897,9 @@ def dispatch(request: object) -> dict[str, Any]:
     action = request["action"]
     payload = request.get("payload", {})
     if action == "page_state":
-        snapshot = _admin_read_snapshot()
+        snapshot = _admin_read_snapshot(require_configuration=True)
+        if snapshot.configuration is None:
+            raise AdminError("plugin storage is not configured")
         return {
             "configuration": snapshot.configuration.to_document(),
             "version": __version__,

--- a/templates/index.html
+++ b/templates/index.html
@@ -578,7 +578,13 @@
     } catch {
       serviceSection.setAttribute('aria-busy', 'false');
       sessionsSection.setAttribute('aria-busy', 'false');
-      certificateSection.setAttribute('aria-busy', 'false');
+      serviceState.textContent = '<TMPL_VAR AJAX.ERROR ESCAPE=JS>';
+      serviceState.dataset.kind = 'error';
+      serviceActiveState.textContent = '<TMPL_VAR AJAX.ERROR ESCAPE=JS>';
+      serviceSubState.textContent = '<TMPL_VAR AJAX.ERROR ESCAPE=JS>';
+      serviceInstalled.textContent = '<TMPL_VAR AJAX.ERROR ESCAPE=JS>';
+      sessionList.replaceChildren(document.createTextNode('<TMPL_VAR AJAX.ERROR ESCAPE=JS>'));
+      updateCertificate(null);
       certificateUnavailable.textContent = '<TMPL_VAR AJAX.ERROR ESCAPE=JS>';
     } finally {
       scheduleServicePoll();

--- a/templates/index.html
+++ b/templates/index.html
@@ -91,9 +91,9 @@
     data-service-active-state="<TMPL_VAR SERVICE_ACTIVE_STATE ESCAPE=HTML>"
     data-service-sub-state="<TMPL_VAR SERVICE_SUB_STATE ESCAPE=HTML>"
     data-service-pid="<TMPL_VAR SERVICE_PID ESCAPE=HTML>"
-    data-service-name="<TMPL_VAR SERVICE_NAME ESCAPE=HTML>">
-    <summary><span class="mcp-service-summary"><span><TMPL_VAR STATUS.TITLE></span><span id="service-state" class="mcp-service-badge" data-kind="<TMPL_IF SERVICE_ACTIVE>success<TMPL_ELSE><TMPL_IF SERVICE_FAILED>error<TMPL_ELSE>inactive</TMPL_IF></TMPL_IF>"><TMPL_IF SERVICE_ACTIVE><TMPL_VAR STATUS.ACTIVE><TMPL_ELSE><TMPL_IF SERVICE_FAILED><TMPL_VAR STATUS.FAILED><TMPL_ELSE><TMPL_IF SERVICE_KNOWN><TMPL_VAR STATUS.INACTIVE><TMPL_ELSE><TMPL_VAR STATUS.UNKNOWN></TMPL_IF></TMPL_IF></TMPL_IF></span></span></summary>
-    <div class="mcp-collapsible-content mcp-form">
+    data-service-name="<TMPL_VAR SERVICE_NAME ESCAPE=HTML>" aria-busy="true">
+    <summary><span class="mcp-service-summary"><span><TMPL_VAR STATUS.TITLE></span><span id="service-state" class="mcp-service-badge"><TMPL_VAR AJAX.WORKING></span></span></summary>
+    <div class="mcp-collapsible-content mcp-form" id="service-content">
       <div class="mcp-service-details">
         <p><TMPL_VAR STATUS.VERSION>: <code><TMPL_VAR VERSION ESCAPE=HTML></code></p>
         <p><TMPL_VAR STATUS.SYSTEMD_STATE>: <strong id="service-active-state"><TMPL_VAR SERVICE_ACTIVE_STATE ESCAPE=HTML></strong></p>
@@ -200,7 +200,7 @@
     </div>
   </details>
 
-  <details id="certificate" class="mcp-card" data-persist-collapse
+  <details id="certificate" class="mcp-card" data-persist-collapse aria-busy="true"
     data-state-scheduled="<TMPL_VAR CERTIFICATE.STATE_SCHEDULED ESCAPE=HTML>"
     data-state-running="<TMPL_VAR CERTIFICATE.STATE_RUNNING ESCAPE=HTML>"
     data-state-success="<TMPL_VAR CERTIFICATE.STATE_SUCCESS ESCAPE=HTML>"
@@ -211,42 +211,40 @@
     <summary><TMPL_VAR CERTIFICATE.TITLE></summary>
     <div class="mcp-collapsible-content">
     <p><TMPL_VAR CERTIFICATE.TEXT></p>
-    <TMPL_IF CERTIFICATE_AVAILABLE>
-      <div class="mcp-grid">
-        <p><TMPL_VAR CERTIFICATE.SOURCE>: <strong><TMPL_IF CERTIFICATE_SOURCE_LOXBERRY><TMPL_VAR CERTIFICATE.SOURCE_LOXBERRY><TMPL_ELSE><TMPL_VAR CERTIFICATE.SOURCE_EXTERNAL></TMPL_IF></strong></p>
-        <p><TMPL_VAR CERTIFICATE.EXPIRES>: <time id="certificate-expiry" class="mcp-expiry" data-expires-at="<TMPL_VAR CERTIFICATE_EXPIRES_AT ESCAPE=HTML>"><TMPL_VAR CERTIFICATE_EXPIRES ESCAPE=HTML></time></p>
-        <p><TMPL_VAR CERTIFICATE.DNS_SANS>: <strong id="certificate-dns-count"><TMPL_VAR CERTIFICATE_DNS_COUNT ESCAPE=HTML></strong></p>
-        <p><TMPL_VAR CERTIFICATE.IP_SANS>: <strong id="certificate-ip-count"><TMPL_VAR CERTIFICATE_IP_COUNT ESCAPE=HTML></strong></p>
-        <p><TMPL_VAR CERTIFICATE.ORIGIN_MATCH>: <strong id="certificate-origin-match"><TMPL_IF CERTIFICATE_ORIGIN_CONFIGURED><TMPL_IF CERTIFICATE_ORIGIN_MATCHES><TMPL_VAR CERTIFICATE.YES><TMPL_ELSE><TMPL_VAR CERTIFICATE.NO></TMPL_IF><TMPL_ELSE><TMPL_VAR CERTIFICATE.NOT_CONFIGURED></TMPL_IF></strong></p>
-        <p><TMPL_VAR CERTIFICATE.HOSTNAME_MATCH>: <strong id="certificate-hostname-match"><TMPL_IF CERTIFICATE_HOSTNAME_MATCHES><TMPL_VAR CERTIFICATE.YES><TMPL_ELSE><TMPL_VAR CERTIFICATE.NO></TMPL_IF></strong></p>
+      <div id="certificate-details" class="mcp-grid" hidden>
+        <p><TMPL_VAR CERTIFICATE.SOURCE>: <strong id="certificate-source"></strong></p>
+        <p><TMPL_VAR CERTIFICATE.EXPIRES>: <time id="certificate-expiry" class="mcp-expiry"></time></p>
+        <p><TMPL_VAR CERTIFICATE.DNS_SANS>: <strong id="certificate-dns-count"></strong></p>
+        <p><TMPL_VAR CERTIFICATE.IP_SANS>: <strong id="certificate-ip-count"></strong></p>
+        <p><TMPL_VAR CERTIFICATE.ORIGIN_MATCH>: <strong id="certificate-origin-match"></strong></p>
+        <p><TMPL_VAR CERTIFICATE.HOSTNAME_MATCH>: <strong id="certificate-hostname-match"></strong></p>
       </div>
-      <p id="certificate-warning" class="mcp-warning" <TMPL_UNLESS CERTIFICATE_WARNING>hidden</TMPL_UNLESS>><TMPL_VAR CERTIFICATE.WARNING></p>
-      <p><TMPL_VAR CERTIFICATE.RENEWAL_STATE>: <strong id="certificate-renewal-state"><TMPL_VAR CERTIFICATE_RENEWAL_STATE ESCAPE=HTML></strong></p>
-      <TMPL_IF CERTIFICATE_RENEWAL_SUPPORTED>
-        <form class="mcp-form" method="post" action="index.cgi" data-ajax="renew_certificate" data-certificate-renewal>
+      <p id="certificate-warning" class="mcp-warning" hidden><TMPL_VAR CERTIFICATE.WARNING></p>
+      <p id="certificate-renewal-info" hidden><TMPL_VAR CERTIFICATE.RENEWAL_STATE>: <strong id="certificate-renewal-state"></strong></p>
+        <form id="certificate-renewal-form" class="mcp-form" method="post" action="index.cgi" data-ajax="renew_certificate" data-certificate-renewal hidden>
           <input type="hidden" name="action" value="renew_certificate">
           <p class="mcp-warning"><TMPL_VAR CERTIFICATE.RENEW_TEXT></p>
           <label class="mcp-field"><span><TMPL_VAR CERTIFICATE.PIN></span><input name="securepin" type="password" inputmode="numeric" pattern="[0-9]{4}" minlength="4" maxlength="4" autocomplete="off" required></label>
           <label><input name="renew_confirmation" type="checkbox" value="renew" required> <TMPL_VAR CERTIFICATE.CONFIRM></label>
           <div class="mcp-actions"><button class="lb-button" type="submit"><TMPL_VAR ACTION.RENEW_CERTIFICATE></button></div>
         </form>
-      <TMPL_ELSE><p class="mcp-help"><TMPL_VAR CERTIFICATE.UNSUPPORTED></p></TMPL_IF>
-    <TMPL_ELSE><p class="mcp-status" data-kind="error"><TMPL_VAR CERTIFICATE.UNAVAILABLE></p></TMPL_IF>
+      <p id="certificate-unsupported" class="mcp-help" hidden><TMPL_VAR CERTIFICATE.UNSUPPORTED></p>
+      <p id="certificate-unavailable" class="mcp-status"><TMPL_VAR AJAX.WORKING></p>
     </div>
   </details>
 
-  <details id="sessions" class="mcp-card" data-persist-collapse
+  <details id="sessions" class="mcp-card" data-persist-collapse aria-busy="true"
     data-empty-label="<TMPL_VAR SESSIONS.EMPTY ESCAPE=HTML>"
     data-unnamed-label="<TMPL_VAR SESSIONS.UNNAMED ESCAPE=HTML>">
     <summary><TMPL_VAR SESSIONS.TITLE></summary>
     <div class="mcp-collapsible-content">
-    <div id="session-list">
+    <div id="session-list"><p><TMPL_VAR AJAX.WORKING></p>
     <TMPL_IF HAS_SESSIONS>
       <div class="mcp-table-wrap"><table class="mcp-table"><thead><tr><th><TMPL_VAR SESSIONS.CLIENT></th><th><TMPL_VAR SESSIONS.INSTANCE></th><th><TMPL_VAR SESSIONS.IDENTITY></th><th><TMPL_VAR SESSIONS.SCOPES></th><th><TMPL_VAR SESSIONS.EXPIRES></th><th><TMPL_VAR SESSIONS.ACTION></th></tr></thead><tbody>
       <TMPL_LOOP SESSIONS><tr data-session-id="<TMPL_VAR id ESCAPE=HTML>"><td><TMPL_IF client_name><TMPL_VAR client_name ESCAPE=HTML><TMPL_ELSE><TMPL_VAR SESSIONS.UNNAMED></TMPL_IF></td><td><code><TMPL_VAR client ESCAPE=HTML></code></td><td><code><TMPL_VAR identity ESCAPE=HTML></code></td><td><code><TMPL_VAR scopes ESCAPE=HTML></code></td><td><time class="mcp-expiry" data-expires-at="<TMPL_VAR expires_at ESCAPE=HTML>"><TMPL_VAR expires_display ESCAPE=HTML></time></td><td><TMPL_IF loxberry_read_eligible><TMPL_UNLESS loxberry_read_approved><form method="post" action="index.cgi" data-ajax="allow_loxberry_read"><input type="hidden" name="action" value="allow_loxberry_read"><input type="hidden" name="session_id" value="<TMPL_VAR id ESCAPE=HTML>"><button class="lb-button" type="submit"><TMPL_VAR ACTION.ALLOW_LOXBERRY_READ></button></form></TMPL_UNLESS></TMPL_IF><TMPL_IF loxberry_operate_eligible><TMPL_UNLESS loxberry_operate_approved><form method="post" action="index.cgi" data-ajax="allow_loxberry_operate"><input type="hidden" name="action" value="allow_loxberry_operate"><input type="hidden" name="session_id" value="<TMPL_VAR id ESCAPE=HTML>"><button class="lb-button" type="submit"><TMPL_VAR ACTION.ALLOW_LOXBERRY_OPERATE></button></form></TMPL_UNLESS></TMPL_IF><form method="post" action="index.cgi" data-ajax="revoke_session"><input type="hidden" name="action" value="revoke_session"><input type="hidden" name="id" value="<TMPL_VAR id ESCAPE=HTML>"><button class="lb-button" type="submit"><TMPL_VAR ACTION.REVOKE></button></form></td></tr></TMPL_LOOP>
       </tbody></table></div>
       <form method="post" action="index.cgi" data-ajax="revoke_all"><input type="hidden" name="action" value="revoke_all"><button class="lb-button" type="submit"><TMPL_VAR ACTION.REVOKE_ALL></button></form>
-    <TMPL_ELSE><p><TMPL_VAR SESSIONS.EMPTY></p></TMPL_IF>
+    <TMPL_ELSE></TMPL_IF>
     </div>
     <template id="session-table-template">
       <div class="mcp-table-wrap"><table class="mcp-table"><thead><tr><th><TMPL_VAR SESSIONS.CLIENT></th><th><TMPL_VAR SESSIONS.INSTANCE></th><th><TMPL_VAR SESSIONS.IDENTITY></th><th><TMPL_VAR SESSIONS.SCOPES></th><th><TMPL_VAR SESSIONS.EXPIRES></th><th><TMPL_VAR SESSIONS.ACTION></th></tr></thead><tbody></tbody></table></div>
@@ -346,6 +344,12 @@
   const explorerPath = '/admin/plugins/mcpserver/explorer.cgi';
   explorerLink.href = `${window.location.origin}${explorerPath}`;
   const certificateSection = document.getElementById('certificate');
+  const certificateDetails = document.getElementById('certificate-details');
+  const certificateSource = document.getElementById('certificate-source');
+  const certificateUnavailable = document.getElementById('certificate-unavailable');
+  const certificateUnsupported = document.getElementById('certificate-unsupported');
+  const certificateRenewalInfo = document.getElementById('certificate-renewal-info');
+  const certificateRenewalForm = document.getElementById('certificate-renewal-form');
   const certificateRenewalState = document.getElementById('certificate-renewal-state');
   const certificateExpiry = document.getElementById('certificate-expiry');
   const certificateDnsCount = document.getElementById('certificate-dns-count');
@@ -467,7 +471,20 @@
     error: certificateSection.dataset.stateError,
   } : {};
   const updateCertificate = (certificate) => {
-    if (!certificate?.available) return;
+    const available = Boolean(certificate?.available);
+    certificateSection.setAttribute('aria-busy', 'false');
+    certificateDetails.hidden = !available;
+    certificateUnavailable.hidden = available;
+    if (!available) {
+      certificateUnavailable.textContent = '<TMPL_VAR CERTIFICATE.UNAVAILABLE ESCAPE=JS>';
+      certificateUnsupported.hidden = true;
+      certificateRenewalInfo.hidden = true;
+      certificateRenewalForm.hidden = true;
+      return;
+    }
+    certificateSource.textContent = certificate.source === 'loxberry_ca'
+      ? '<TMPL_VAR CERTIFICATE.SOURCE_LOXBERRY ESCAPE=JS>'
+      : '<TMPL_VAR CERTIFICATE.SOURCE_EXTERNAL ESCAPE=JS>';
     if (certificateDnsCount) certificateDnsCount.textContent = String(certificate.dns_san_count);
     if (certificateIpCount) certificateIpCount.textContent = String(certificate.ip_san_count);
     if (certificateOriginMatch) certificateOriginMatch.textContent = certificate.origin_configured
@@ -483,6 +500,11 @@
       certificateExpiry.dateTime = date.toISOString();
       certificateExpiry.textContent = expiryFormatter.format(date);
     }
+    const renewalState = certificate.renewal?.state || 'idle';
+    certificateRenewalInfo.hidden = false;
+    certificateRenewalState.textContent = certificateStateLabels[renewalState] || certificateStateLabels.error;
+    certificateRenewalForm.hidden = !certificate.renewal_supported;
+    certificateUnsupported.hidden = Boolean(certificate.renewal_supported);
   };
   const postAjax = async (body, timeoutMs) => {
     const controller = new AbortController();
@@ -548,6 +570,29 @@
     pid: Number(serviceSection.dataset.servicePid),
     name: serviceSection.dataset.serviceName,
   });
+  const loadInitialState = async () => {
+    const body = new FormData();
+    body.set('action', 'page_state');
+    body.set('ajax', '1');
+    try {
+      const result = await postAjax(body, 15000);
+      renderService(result.data.service);
+      serviceSection.setAttribute('aria-busy', 'false');
+      updateCertificate(result.data.certificate);
+      if (Array.isArray(result.data.sessions)) updateSessions(result.data.sessions);
+      if (Array.isArray(result.data.loxberry_bindings)) updateLoxberryBindings(result.data.loxberry_bindings);
+      if (Array.isArray(result.data.loxberry_operate_bindings)) updateLoxberryOperateBindings(result.data.loxberry_operate_bindings);
+      sessionsSection.setAttribute('aria-busy', 'false');
+    } catch {
+      serviceSection.setAttribute('aria-busy', 'false');
+      sessionsSection.setAttribute('aria-busy', 'false');
+      certificateSection.setAttribute('aria-busy', 'false');
+      certificateUnavailable.textContent = '<TMPL_VAR AJAX.ERROR ESCAPE=JS>';
+    } finally {
+      scheduleServicePoll();
+      scheduleSessionPoll();
+    }
+  };
   const serviceConfirmMessages = {
     stop: '<TMPL_VAR STATUS.CONFIRM_STOP ESCAPE=JS>',
     restart: '<TMPL_VAR STATUS.CONFIRM_RESTART ESCAPE=JS>',
@@ -596,7 +641,6 @@
       scheduleSessionPoll(0);
     }
   });
-  scheduleServicePoll();
   const pollCertificateRenewal = async (button) => {
     const deadline = Date.now() + 75000;
     try {
@@ -829,7 +873,7 @@
     }
   };
   sessionsSection.addEventListener('toggle', () => scheduleSessionPoll(sessionsSection.open ? 0 : 10000));
-  scheduleSessionPoll();
+  loadInitialState();
   const actionTimeout = (action) => ({
     save_config: 90000,
     set_logging: 75000,

--- a/templates/index.html
+++ b/templates/index.html
@@ -211,13 +211,13 @@
     <summary><TMPL_VAR CERTIFICATE.TITLE></summary>
     <div class="mcp-collapsible-content">
     <p><TMPL_VAR CERTIFICATE.TEXT></p>
-      <div id="certificate-details" class="mcp-grid" hidden>
-        <p><TMPL_VAR CERTIFICATE.SOURCE>: <strong id="certificate-source"></strong></p>
-        <p><TMPL_VAR CERTIFICATE.EXPIRES>: <time id="certificate-expiry" class="mcp-expiry"></time></p>
-        <p><TMPL_VAR CERTIFICATE.DNS_SANS>: <strong id="certificate-dns-count"></strong></p>
-        <p><TMPL_VAR CERTIFICATE.IP_SANS>: <strong id="certificate-ip-count"></strong></p>
-        <p><TMPL_VAR CERTIFICATE.ORIGIN_MATCH>: <strong id="certificate-origin-match"></strong></p>
-        <p><TMPL_VAR CERTIFICATE.HOSTNAME_MATCH>: <strong id="certificate-hostname-match"></strong></p>
+      <div id="certificate-details" class="mcp-grid">
+        <p><TMPL_VAR CERTIFICATE.SOURCE>: <strong id="certificate-source"><TMPL_VAR AJAX.WORKING></strong></p>
+        <p><TMPL_VAR CERTIFICATE.EXPIRES>: <time id="certificate-expiry" class="mcp-expiry"><TMPL_VAR AJAX.WORKING></time></p>
+        <p><TMPL_VAR CERTIFICATE.DNS_SANS>: <strong id="certificate-dns-count"><TMPL_VAR AJAX.WORKING></strong></p>
+        <p><TMPL_VAR CERTIFICATE.IP_SANS>: <strong id="certificate-ip-count"><TMPL_VAR AJAX.WORKING></strong></p>
+        <p><TMPL_VAR CERTIFICATE.ORIGIN_MATCH>: <strong id="certificate-origin-match"><TMPL_VAR AJAX.WORKING></strong></p>
+        <p><TMPL_VAR CERTIFICATE.HOSTNAME_MATCH>: <strong id="certificate-hostname-match"><TMPL_VAR AJAX.WORKING></strong></p>
       </div>
       <p id="certificate-warning" class="mcp-warning" hidden><TMPL_VAR CERTIFICATE.WARNING></p>
       <p id="certificate-renewal-info" hidden><TMPL_VAR CERTIFICATE.RENEWAL_STATE>: <strong id="certificate-renewal-state"></strong></p>
@@ -229,7 +229,7 @@
           <div class="mcp-actions"><button class="lb-button" type="submit"><TMPL_VAR ACTION.RENEW_CERTIFICATE></button></div>
         </form>
       <p id="certificate-unsupported" class="mcp-help" hidden><TMPL_VAR CERTIFICATE.UNSUPPORTED></p>
-      <p id="certificate-unavailable" class="mcp-status"><TMPL_VAR AJAX.WORKING></p>
+      <p id="certificate-unavailable" class="mcp-status" hidden><TMPL_VAR CERTIFICATE.UNAVAILABLE></p>
     </div>
   </details>
 
@@ -434,7 +434,7 @@
     }
   };
   for (const element of document.querySelectorAll('time.mcp-expiry')) {
-    updateExpiry(element, element.dataset.expiresAt);
+    if (element.dataset.expiresAt) updateExpiry(element, element.dataset.expiresAt);
   }
   const hideStatusTimers = new WeakMap();
   const hideSuccess = (element) => {

--- a/templates/index.html
+++ b/templates/index.html
@@ -96,16 +96,16 @@
     <div class="mcp-collapsible-content mcp-form" id="service-content">
       <div class="mcp-service-details">
         <p><TMPL_VAR STATUS.VERSION>: <code><TMPL_VAR VERSION ESCAPE=HTML></code></p>
-        <p><TMPL_VAR STATUS.SYSTEMD_STATE>: <strong id="service-active-state"><TMPL_VAR SERVICE_ACTIVE_STATE ESCAPE=HTML></strong></p>
-        <p><TMPL_VAR STATUS.SUB_STATE>: <strong id="service-sub-state"><TMPL_VAR SERVICE_SUB_STATE ESCAPE=HTML></strong></p>
+        <p><TMPL_VAR STATUS.SYSTEMD_STATE>: <strong id="service-active-state"><TMPL_VAR AJAX.WORKING></strong></p>
+        <p><TMPL_VAR STATUS.SUB_STATE>: <strong id="service-sub-state"><TMPL_VAR AJAX.WORKING></strong></p>
         <p><TMPL_VAR STATUS.PID>: <code id="service-pid"><TMPL_VAR SERVICE_PID ESCAPE=HTML></code></p>
         <p><TMPL_VAR STATUS.UNIT>: <code id="service-name"><TMPL_VAR SERVICE_NAME ESCAPE=HTML></code></p>
-        <p><TMPL_VAR STATUS.INSTALLED>: <strong id="service-installed"><TMPL_IF SERVICE_INSTALLED><TMPL_VAR STATUS.YES><TMPL_ELSE><TMPL_VAR STATUS.NO></TMPL_IF></strong></p>
+        <p><TMPL_VAR STATUS.INSTALLED>: <strong id="service-installed"><TMPL_VAR AJAX.WORKING></strong></p>
       </div>
       <div class="mcp-actions" id="service-actions">
-        <form method="post" action="index.cgi" data-ajax="service_action" data-service-command="start" <TMPL_IF SERVICE_ACTIVE>hidden</TMPL_IF>><input type="hidden" name="action" value="service_action"><input type="hidden" name="command" value="start"><button class="lb-button" type="submit"><TMPL_VAR ACTION.START></button></form>
-        <form method="post" action="index.cgi" data-ajax="service_action" data-service-command="stop" <TMPL_UNLESS SERVICE_ACTIVE>hidden</TMPL_UNLESS>><input type="hidden" name="action" value="service_action"><input type="hidden" name="command" value="stop"><button class="lb-button" type="submit"><TMPL_VAR ACTION.STOP></button></form>
-        <form method="post" action="index.cgi" data-ajax="service_action" data-service-command="restart" <TMPL_UNLESS SERVICE_ACTIVE>hidden</TMPL_UNLESS>><input type="hidden" name="action" value="service_action"><input type="hidden" name="command" value="restart"><button class="lb-button" type="submit"><TMPL_VAR ACTION.RESTART></button></form>
+        <form method="post" action="index.cgi" data-ajax="service_action" data-service-command="start" hidden><input type="hidden" name="action" value="service_action"><input type="hidden" name="command" value="start"><button class="lb-button" type="submit"><TMPL_VAR ACTION.START></button></form>
+        <form method="post" action="index.cgi" data-ajax="service_action" data-service-command="stop" hidden><input type="hidden" name="action" value="service_action"><input type="hidden" name="command" value="stop"><button class="lb-button" type="submit"><TMPL_VAR ACTION.STOP></button></form>
+        <form method="post" action="index.cgi" data-ajax="service_action" data-service-command="restart" hidden><input type="hidden" name="action" value="service_action"><input type="hidden" name="command" value="restart"><button class="lb-button" type="submit"><TMPL_VAR ACTION.RESTART></button></form>
         <a class="lb-button" href="<TMPL_VAR SERVICE_LOG_URL ESCAPE=HTML>" target="_blank" rel="noopener"><TMPL_VAR STATUS.SHOW_LOG></a>
       </div>
     </div>
@@ -562,14 +562,6 @@
       else button.removeAttribute('aria-busy');
     }
   };
-  renderService({
-    installed: serviceSection.dataset.serviceInstalled === '1',
-    active: serviceSection.dataset.serviceActive === '1',
-    active_state: serviceSection.dataset.serviceActiveState,
-    sub_state: serviceSection.dataset.serviceSubState,
-    pid: Number(serviceSection.dataset.servicePid),
-    name: serviceSection.dataset.serviceName,
-  });
   const loadInitialState = async () => {
     const body = new FormData();
     body.set('action', 'page_state');

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -12,8 +12,8 @@ from pathlib import Path
 import pytest
 
 from mcpserver.admin import (
-    _AdminReadSnapshot,
     AdminError,
+    _AdminReadSnapshot,
     _allow_loxberry_operate,
     _allow_loxberry_read,
     _loxberry_bindings,
@@ -459,7 +459,9 @@ def test_admin_list_responses_use_one_snapshot_per_request(
     monkeypatch.setattr("mcpserver.admin._config_store", lambda: config_store)
     monkeypatch.setattr("mcpserver.admin._auth_store", lambda: auth_store)
     monkeypatch.setattr("mcpserver.admin._service_status", lambda: {"active": True})
-    monkeypatch.setattr("mcpserver.admin._certificate_status", lambda **_kwargs: {"available": False})
+    monkeypatch.setattr(
+        "mcpserver.admin._certificate_status", lambda **_kwargs: {"available": False}
+    )
 
     result = dispatch({"action": action})
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -360,7 +360,7 @@ def test_page_state_aggregates_initial_admin_ui_data(monkeypatch: pytest.MonkeyP
         b"s" * 32,
         0,
     )
-    monkeypatch.setattr("mcpserver.admin._admin_read_snapshot", lambda: snapshot)
+    monkeypatch.setattr("mcpserver.admin._admin_read_snapshot", lambda **_kwargs: snapshot)
     service = {
         "name": "loxberry-mcpserver.service",
         "installed": True,
@@ -473,8 +473,10 @@ def test_admin_list_responses_use_one_snapshot_per_request(
     assert len(result["sessions"]) == session_count
     if session_count:
         assert result["sessions"][0]["id"] == "family-000"
-    assert all(session["loxberry_read_approved"] for session in result["sessions"])
-    assert all(session["loxberry_operate_approved"] for session in result["sessions"])
+    approved = [session for session in result["sessions"] if session["loxberry_read_approved"]]
+    assert [session["id"] for session in approved] == (["family-000"] if session_count else [])
+    approved = [session for session in result["sessions"] if session["loxberry_operate_approved"]]
+    assert [session["id"] for session in approved] == (["family-000"] if session_count else [])
     assert result["loxberry_bindings"][0]["active"] is (session_count > 0)
     assert result["loxberry_operate_bindings"][0]["active"] is (session_count > 0)
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
 import asyncio
+import base64
+import hashlib
+import hmac
 import json
 import subprocess
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
 
 from mcpserver.admin import (
+    _AdminReadSnapshot,
     AdminError,
     _allow_loxberry_operate,
     _allow_loxberry_read,
@@ -33,6 +38,7 @@ from mcpserver.auth.store import AtomicJsonAuthStore
 from mcpserver.config import AtomicConfigStore, PluginConfig
 from mcpserver.loxone.client import LoxoneToken
 from mcpserver.loxone.events import LoxoneProtocolError
+from tools.benchmark_admin_page_state import measure
 
 
 def test_diagnostic_contains_no_paths_endpoint_or_identity(
@@ -340,12 +346,21 @@ def test_loxberry_operate_bindings_ignore_read_only_families(
 
 def test_page_state_aggregates_initial_admin_ui_data(monkeypatch: pytest.MonkeyPatch) -> None:
     config = PluginConfig.defaults()
-
-    class ConfigStore:
-        def load(self) -> PluginConfig:
-            return config
-
-    monkeypatch.setattr("mcpserver.admin._config_store", lambda: ConfigStore())
+    snapshot = _AdminReadSnapshot(
+        config,
+        {
+            "subject_key": base64.urlsafe_b64encode(b"s" * 32).decode("ascii"),
+            "clients": {},
+            "families": {},
+            "codes": {},
+            "access_tokens": {},
+            "refresh_tokens": {},
+            "schema_version": 1,
+        },
+        b"s" * 32,
+        0,
+    )
+    monkeypatch.setattr("mcpserver.admin._admin_read_snapshot", lambda: snapshot)
     service = {
         "name": "loxberry-mcpserver.service",
         "installed": True,
@@ -355,10 +370,9 @@ def test_page_state_aggregates_initial_admin_ui_data(monkeypatch: pytest.MonkeyP
         "active": True,
     }
     monkeypatch.setattr("mcpserver.admin._service_status", lambda: service)
-    monkeypatch.setattr("mcpserver.admin._sessions", lambda: [{"id": "family"}])
     monkeypatch.setattr(
         "mcpserver.admin._certificate_status",
-        lambda: {"available": True, "renewal_supported": False},
+        lambda **_kwargs: {"available": True, "renewal_supported": False},
     )
 
     result = dispatch({"action": "page_state"})
@@ -368,11 +382,107 @@ def test_page_state_aggregates_initial_admin_ui_data(monkeypatch: pytest.MonkeyP
         "version": result["version"],
         "service_active": True,
         "service": service,
-        "sessions": [{"id": "family"}],
+        "sessions": [],
         "loxberry_bindings": [],
         "loxberry_operate_bindings": [],
         "certificate": {"available": True, "renewal_supported": False},
     }
+
+
+@pytest.mark.parametrize("action", ["page_state", "list_sessions"])
+@pytest.mark.parametrize("session_count", [0, 10, 100])
+def test_admin_list_responses_use_one_snapshot_per_request(
+    action: str, session_count: int, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    subject_key = b"s" * 32
+    subject_key_text = base64.urlsafe_b64encode(subject_key).decode("ascii")
+    families = {
+        f"family-{index:03}": {
+            "scope": f"{READ_SCOPE} {HISTORY_SCOPE} {LOXBERRY_READ_SCOPE} {LOXBERRY_OPERATE_SCOPE}",
+            "client_id": f"client-{index}",
+            "identity_id": f"identity-{index}",
+            "miniserver_id": "miniserver",
+            "expires_at": 2_000_000_000,
+            "pending_loxberry_read": True,
+            "pending_loxberry_operate": True,
+            "revoked": False,
+        }
+        for index in range(session_count)
+    }
+    first_record = families["family-000"]
+
+    def binding(namespace: str) -> str:
+        canonical = "\0".join(
+            (
+                namespace,
+                first_record["client_id"],
+                first_record["identity_id"],
+                first_record["miniserver_id"],
+            )
+        ).encode("utf-8")
+        return hmac.new(subject_key, canonical, hashlib.sha256).hexdigest()
+
+    configuration = replace(
+        PluginConfig.defaults(),
+        loxberry_read_bindings=(binding("loxberry-read-binding-v1"),),
+        loxberry_operate_bindings=(binding("loxberry-operate-binding-v1"),),
+    )
+    document = {
+        "schema_version": 1,
+        "subject_key": subject_key_text,
+        "clients": {
+            record["client_id"]: {"client_name": f"Client {index}"}
+            for index, record in enumerate(families.values())
+        },
+        "families": families,
+        "codes": {},
+        "access_tokens": {},
+        "refresh_tokens": {},
+    }
+
+    class ConfigStore:
+        calls = 0
+
+        def load(self) -> PluginConfig:
+            self.calls += 1
+            return configuration
+
+    class AuthStore:
+        calls = 0
+
+        def snapshot(self) -> dict[str, object]:
+            self.calls += 1
+            return document
+
+    config_store = ConfigStore()
+    auth_store = AuthStore()
+    monkeypatch.setattr("mcpserver.admin._config_store", lambda: config_store)
+    monkeypatch.setattr("mcpserver.admin._auth_store", lambda: auth_store)
+    monkeypatch.setattr("mcpserver.admin._service_status", lambda: {"active": True})
+    monkeypatch.setattr("mcpserver.admin._certificate_status", lambda **_kwargs: {"available": False})
+
+    result = dispatch({"action": action})
+
+    assert config_store.calls == 1
+    assert auth_store.calls == 1
+    assert len(result["sessions"]) == session_count
+    if session_count:
+        assert result["sessions"][0]["id"] == "family-000"
+    assert all(session["loxberry_read_approved"] for session in result["sessions"])
+    assert all(session["loxberry_operate_approved"] for session in result["sessions"])
+    assert result["loxberry_bindings"][0]["active"] is True
+    assert result["loxberry_operate_bindings"][0]["active"] is True
+
+
+def test_page_state_benchmark_reports_machine_readable_metrics() -> None:
+    result = measure(session_count=10, warmups=0, samples=2)
+
+    assert result["sessions"] == 10
+    assert result["warmups"] == 0
+    assert result["samples"] == 2
+    assert isinstance(result["p50_ms"], float)
+    assert isinstance(result["p95_ms"], float)
+    assert isinstance(result["peak_bytes"], int)
 
 
 def test_status_refresh_returns_all_dynamic_admin_ui_data(

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -409,7 +409,10 @@ def test_admin_list_responses_use_one_snapshot_per_request(
         }
         for index in range(session_count)
     }
-    first_record = families["family-000"]
+    first_record = next(
+        iter(families.values()),
+        {"client_id": "", "identity_id": "", "miniserver_id": ""},
+    )
 
     def binding(namespace: str) -> str:
         canonical = "\0".join(
@@ -472,8 +475,8 @@ def test_admin_list_responses_use_one_snapshot_per_request(
         assert result["sessions"][0]["id"] == "family-000"
     assert all(session["loxberry_read_approved"] for session in result["sessions"])
     assert all(session["loxberry_operate_approved"] for session in result["sessions"])
-    assert result["loxberry_bindings"][0]["active"] is True
-    assert result["loxberry_operate_bindings"][0]["active"] is True
+    assert result["loxberry_bindings"][0]["active"] is (session_count > 0)
+    assert result["loxberry_operate_bindings"][0]["active"] is (session_count > 0)
 
 
 def test_page_state_benchmark_reports_machine_readable_metrics() -> None:

--- a/tests/test_admin_ui.py
+++ b/tests/test_admin_ui.py
@@ -21,6 +21,16 @@ def test_initial_page_renders_configuration_before_loading_dynamic_state() -> No
     assert '<strong id="service-active-state"><TMPL_VAR AJAX.WORKING></strong>' in template
     assert '<strong id="service-sub-state"><TMPL_VAR AJAX.WORKING></strong>' in template
     assert '<strong id="service-installed"><TMPL_VAR AJAX.WORKING></strong>' in template
+    assert '<strong id="certificate-source"><TMPL_VAR AJAX.WORKING></strong>' in template
+    assert (
+        '<time id="certificate-expiry" class="mcp-expiry"><TMPL_VAR AJAX.WORKING></time>'
+        in template
+    )
+    assert (
+        "if (element.dataset.expiresAt) updateExpiry(element, element.dataset.expiresAt);"
+        in template
+    )
+    assert 'id="certificate-unavailable" class="mcp-status" hidden' in template
 
 
 def test_common_actions_update_the_page_without_a_reload() -> None:

--- a/tests/test_admin_ui.py
+++ b/tests/test_admin_ui.py
@@ -8,13 +8,16 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 
-def test_initial_page_uses_one_aggregated_admin_call() -> None:
+def test_initial_page_renders_configuration_before_loading_dynamic_state() -> None:
     cgi = (ROOT / "webfrontend/htmlauth/index.cgi").read_text(encoding="utf-8")
+    template = (ROOT / "templates/index.html").read_text(encoding="utf-8")
 
+    assert "admin_call('get_config', {})" in cgi
     assert "admin_call('page_state', {})" in cgi
-    assert "my $config_result =" not in cgi
-    assert "my $status_result =" not in cgi
-    assert "my $sessions_result =" not in cgi
+    assert "body.set('action', 'page_state')" in template
+    assert "const loadInitialState" in template
+    assert "loadInitialState();" in template
+    assert 'aria-busy="true"' in template
 
 
 def test_common_actions_update_the_page_without_a_reload() -> None:
@@ -365,11 +368,8 @@ for my $case (@cases) {{ print((local_mcp_url(@$case) // '') . "\n"); }}
 
 
 def test_session_expiry_is_rendered_as_a_local_date_and_time() -> None:
-    cgi = (ROOT / "webfrontend/htmlauth/index.cgi").read_text(encoding="utf-8")
     template = (ROOT / "templates/index.html").read_text(encoding="utf-8")
 
-    assert "strftime('%Y-%m-%d %H:%M:%S %Z', localtime(0 + $raw))" in cgi
-    assert "$session->{expires_display} = format_expiry($session->{expires_at})" in cgi
     assert 'class="mcp-expiry"' in template
     assert 'data-expires-at="<TMPL_VAR expires_at ESCAPE=HTML>"' in template
     assert "<TMPL_VAR expires_display ESCAPE=HTML>" in template

--- a/tests/test_admin_ui.py
+++ b/tests/test_admin_ui.py
@@ -31,6 +31,11 @@ def test_initial_page_renders_configuration_before_loading_dynamic_state() -> No
         in template
     )
     assert 'id="certificate-unavailable" class="mcp-status" hidden' in template
+    assert "updateCertificate(null);" in template
+    assert (
+        "sessionList.replaceChildren(document.createTextNode('<TMPL_VAR AJAX.ERROR ESCAPE=JS>'))"
+        in template
+    )
 
 
 def test_common_actions_update_the_page_without_a_reload() -> None:

--- a/tests/test_admin_ui.py
+++ b/tests/test_admin_ui.py
@@ -18,6 +18,9 @@ def test_initial_page_renders_configuration_before_loading_dynamic_state() -> No
     assert "const loadInitialState" in template
     assert "loadInitialState();" in template
     assert 'aria-busy="true"' in template
+    assert '<strong id="service-active-state"><TMPL_VAR AJAX.WORKING></strong>' in template
+    assert '<strong id="service-sub-state"><TMPL_VAR AJAX.WORKING></strong>' in template
+    assert '<strong id="service-installed"><TMPL_VAR AJAX.WORKING></strong>' in template
 
 
 def test_common_actions_update_the_page_without_a_reload() -> None:

--- a/tools/benchmark_admin_page_state.py
+++ b/tools/benchmark_admin_page_state.py
@@ -124,7 +124,15 @@ def main() -> None:
     arguments = parser.parse_args()
     if arguments.sessions < 1 or arguments.warmups < 0 or arguments.samples < 2:
         parser.error("sessions must be positive, warmups non-negative, and samples at least two")
-    print(json.dumps(measure(session_count=arguments.sessions, warmups=arguments.warmups, samples=arguments.samples)))
+    print(
+        json.dumps(
+            measure(
+                session_count=arguments.sessions,
+                warmups=arguments.warmups,
+                samples=arguments.samples,
+            )
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/tools/benchmark_admin_page_state.py
+++ b/tools/benchmark_admin_page_state.py
@@ -1,0 +1,131 @@
+"""Measure deterministic admin page-state aggregation with synthetic sessions."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import hmac
+import json
+import statistics
+import time
+import tracemalloc
+from dataclasses import replace
+from typing import Any
+from unittest.mock import patch
+
+from mcpserver import admin
+from mcpserver.auth.provider import (
+    HISTORY_SCOPE,
+    LOXBERRY_OPERATE_SCOPE,
+    LOXBERRY_READ_SCOPE,
+    READ_SCOPE,
+)
+from mcpserver.config import PluginConfig
+
+
+def _binding(subject_key: bytes, namespace: str, record: dict[str, Any]) -> str:
+    canonical = "\0".join(
+        (
+            namespace,
+            str(record["client_id"]),
+            str(record["identity_id"]),
+            str(record["miniserver_id"]),
+        )
+    ).encode("utf-8")
+    return hmac.new(subject_key, canonical, hashlib.sha256).hexdigest()
+
+
+def _fixture(session_count: int) -> tuple[PluginConfig, dict[str, Any]]:
+    subject_key = b"b" * 32
+    families = {
+        f"benchmark-{index:04}": {
+            "scope": f"{READ_SCOPE} {HISTORY_SCOPE} {LOXBERRY_READ_SCOPE} {LOXBERRY_OPERATE_SCOPE}",
+            "client_id": f"client-{index}",
+            "identity_id": f"identity-{index}",
+            "miniserver_id": "benchmark-miniserver",
+            "expires_at": 2_000_000_000,
+            "pending_loxberry_read": True,
+            "pending_loxberry_operate": True,
+            "revoked": False,
+        }
+        for index in range(session_count)
+    }
+    first = next(iter(families.values()), {"client_id": "", "identity_id": "", "miniserver_id": ""})
+    configuration = replace(
+        PluginConfig.defaults(),
+        loxberry_read_bindings=(_binding(subject_key, "loxberry-read-binding-v1", first),),
+        loxberry_operate_bindings=(_binding(subject_key, "loxberry-operate-binding-v1", first),),
+    )
+    return configuration, {
+        "schema_version": 1,
+        "subject_key": base64.urlsafe_b64encode(subject_key).decode("ascii"),
+        "clients": {},
+        "families": families,
+        "codes": {},
+        "access_tokens": {},
+        "refresh_tokens": {},
+    }
+
+
+class _ConfigStore:
+    def __init__(self, configuration: PluginConfig) -> None:
+        self.configuration = configuration
+
+    def load(self) -> PluginConfig:
+        return self.configuration
+
+
+class _AuthStore:
+    def __init__(self, document: dict[str, Any]) -> None:
+        self.document = document
+
+    def snapshot(self) -> dict[str, Any]:
+        return self.document
+
+
+def _percentile(values: list[float], percent: float) -> float:
+    return statistics.quantiles(values, n=100, method="inclusive")[percent - 1]
+
+
+def measure(*, session_count: int, warmups: int, samples: int) -> dict[str, int | float]:
+    configuration, document = _fixture(session_count)
+    with (
+        patch.object(admin, "_config_store", lambda: _ConfigStore(configuration)),
+        patch.object(admin, "_auth_store", lambda: _AuthStore(document)),
+        patch.object(admin, "_service_status", lambda: {"active": True}),
+        patch.object(admin, "_certificate_status", lambda **_kwargs: {"available": False}),
+    ):
+        for _ in range(warmups):
+            admin.dispatch({"action": "page_state"})
+        durations: list[float] = []
+        tracemalloc.start()
+        for _ in range(samples):
+            start = time.perf_counter()
+            admin.dispatch({"action": "page_state"})
+            durations.append((time.perf_counter() - start) * 1000)
+        _, peak_bytes = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+    return {
+        "sessions": session_count,
+        "warmups": warmups,
+        "samples": samples,
+        "p50_ms": round(statistics.median(durations), 3),
+        "p95_ms": round(_percentile(durations, 95), 3),
+        "peak_bytes": peak_bytes,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--sessions", type=int, default=100)
+    parser.add_argument("--warmups", type=int, default=5)
+    parser.add_argument("--samples", type=int, default=30)
+    arguments = parser.parse_args()
+    if arguments.sessions < 1 or arguments.warmups < 0 or arguments.samples < 2:
+        parser.error("sessions must be positive, warmups non-negative, and samples at least two")
+    print(json.dumps(measure(session_count=arguments.sessions, warmups=arguments.warmups, samples=arguments.samples)))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/test.py
+++ b/tools/test.py
@@ -56,6 +56,7 @@ _TEST_GROUPS: Final = (
         (
             "src/mcpserver/admin.py",
             "templates/index.html",
+            "tools/benchmark_admin_page_state.py",
             "templates/lang/**",
             "webfrontend/htmlauth/index.cgi",
         ),

--- a/webfrontend/htmlauth/index.cgi
+++ b/webfrontend/htmlauth/index.cgi
@@ -390,6 +390,8 @@ if ($action ne '') {
         $result = admin_call('set_logging', {mode => ($q->{mode} // '')});
         admin_log($result->{ok} ? 'info' : 'warning',
             'action=set_service_log_level outcome=' . ($result->{ok} ? 'completed' : 'rejected'));
+    } elsif ($action eq 'page_state') {
+        $result = admin_call('page_state', {});
     } elsif ($action eq 'test_connection') {
         $result = admin_call('test_connection', {endpoint => requested_endpoint($q)});
     } elsif ($action eq 'revoke_session') {
@@ -481,16 +483,11 @@ sub format_expiry {
     return defined($formatted) && length($formatted) ? $formatted : $raw;
 }
 
-my $page_result = admin_call('page_state', {});
-my $page_state = $page_result->{ok} ? $page_result->{data} : {};
-my $config = $page_state->{configuration} // {};
-my $sessions = $page_state->{sessions} // [];
-my $loxberry_bindings = $page_state->{loxberry_bindings} // [];
-my $loxberry_operate_bindings = $page_state->{loxberry_operate_bindings} // [];
-for my $session (@$sessions) {
-    next if ref($session) ne 'HASH';
-    $session->{expires_display} = format_expiry($session->{expires_at});
-}
+my $config_result = admin_call('get_config', {});
+my $config = $config_result->{ok} ? ($config_result->{data}{configuration} // {}) : {};
+my $sessions = [];
+my $loxberry_bindings = [];
+my $loxberry_operate_bindings = [];
 $config->{server} = {} if ref($config->{server}) ne 'HASH';
 $config->{loxone} = {} if ref($config->{loxone}) ne 'HASH';
 $config->{tools} = {} if ref($config->{tools}) ne 'HASH';
@@ -504,11 +501,9 @@ my $display_endpoint = $config->{loxone}{endpoint} // '';
 $display_endpoint = $selected_miniserver->{endpoint}
     if $display_endpoint eq '' && $selected_miniserver;
 my $public_origin = $config->{server}{public_origin} // '';
-my $certificate = ref($page_state->{certificate}) eq 'HASH'
-    ? $page_state->{certificate} : {};
-my $service = ref($page_state->{service}) eq 'HASH'
-    ? $page_state->{service} : {};
-my $renewal = ref($certificate->{renewal}) eq 'HASH' ? $certificate->{renewal} : {};
+my $certificate = {};
+my $service = {};
+my $renewal = {};
 my $general_config = stored_general_config();
 my $sslport = ref($general_config->{Webserver}) eq 'HASH'
     ? $general_config->{Webserver}{Sslport} : 443;
@@ -572,7 +567,7 @@ $template->param(
     LOG_LEVEL_WARNING => ($config->{logging}{level} // 'warning') eq 'warning' ? 1 : 0,
     LOG_LEVEL_INFO => ($config->{logging}{level} // 'warning') eq 'info' ? 1 : 0,
     LOG_LEVEL_DEBUG => ($config->{logging}{level} // 'warning') eq 'debug' ? 1 : 0,
-    SERVICE_ACTIVE => $page_state->{service_active} ? 1 : 0,
+    SERVICE_ACTIVE => 0,
     SERVICE_INSTALLED => $service->{installed} ? 1 : 0,
     SERVICE_FAILED => ($service->{active_state} // '') eq 'failed' ? 1 : 0,
     SERVICE_KNOWN => ($service->{active_state} // 'unknown') ne 'unknown' ? 1 : 0,


### PR DESCRIPTION
## Summary

- Load configuration synchronously so the Admin-UI shell and form are visible immediately.
- Load service status, certificate and sessions afterwards in one serial page_state request.
- Keep existing session rendering, permissions, pseudonyms and action contracts; add explicit per-section loading states.
- Add regression coverage and synchronized DE/EN user-guide notes.

## Root cause

The initial CGI response synchronously waited for the complete page_state aggregation before rendering navigation, configuration, service state, certificate and sessions.

## Validation

- git diff --check
- GitHub Actions Python 3.13 CI on the prior revision: **524 passed**
- Local Python 3.13.15 changed profile on 4d41690: **80 passed**, including Ruff and mypy.
- Deterministic 100-family data-path benchmark (5 warmups, 30 samples): **p50 6.107 ms**, **p95 6.861 ms**, **peak 58,757 bytes**.
- Focused UI deployment to Loxberry-Test with retained backup.
- Native authenticated browser acceptance: **3 warmups + 10 strictly serial reloads**. In every measurement the shell rendered first, then status was active, the certificate was present and two session rows loaded.

## Performance evidence boundary

The browser-control surface does not expose native Navigation Timing or Fetch APIs. The native browser run proves the two-phase behavior and successful loading, but does **not** claim a numeric first-paint or p95 latency budget.