### PR TITLE
Retry remote Loxone token revocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable user-visible changes are recorded here. GitHub release notes are
 extracted from the matching version heading.
 
+## Unreleased
+
+- Retain encrypted Loxone tokens after a local session revocation until the
+  Miniserver confirms `killtoken`; unavailable Miniservers are retried by the
+  service without delaying the administrative UI.
+
 ## 0.4.0-alpha.9 - 2026-08-13
 
 - Add bounded LoxAPP3 climate, ventilation, safety/status, energy and global

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -392,8 +392,9 @@ Unterabschnitt **Plugin-Logs (LoxBerry LogManager)**.
 
 Der Diagnoseexport enthält nur Version,
 Dienststatus, Transportart und maskierte Zähler. Sitzungen können einzeln oder
-gemeinsam widerrufen werden; ein erreichbarer Miniserver erhält zusätzlich
-best effort `killtoken`.
+gemeinsam widerrufen werden. Der MCP-Server sperrt den Zugriff sofort; das
+verschlüsselte Loxone-Token bleibt bis zur Bestätigung durch einen erreichbaren
+Miniserver für den `killtoken`-Aufruf vorgemerkt.
 
 Die Statuskarte der Adminseite aktualisiert Zustand und PID automatisch. Bei
 inaktivem Dienst steht **Starten** bereit; bei aktivem Dienst stehen **Stoppen**

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -362,8 +362,9 @@ action. It is likewise limited to the active file and two 512 KiB backups. These
 settings are separated under **Plugin logs (LoxBerry Log Manager)**.
 
 Diagnostic export contains only the version, service state, transport kind and masked counts. Sessions can be
-revoked individually or together; an available Miniserver also receives a
-best-effort `killtoken`.
+revoked individually or together. The MCP server denies access immediately; the
+encrypted Loxone token remains queued until an available Miniserver confirms a
+`killtoken` request.
 
 The admin status card refreshes the service state and PID automatically. An
 inactive service offers **Start**; an active service offers **Stop** and

--- a/src/mcpserver/admin.py
+++ b/src/mcpserver/admin.py
@@ -799,11 +799,8 @@ def _revoke_many(
     timeout_seconds: float | None = None,
 ) -> int:
     from mcpserver.auth.loxone_store import LoxoneTokenStoreError
-    from mcpserver.loxone.client import LoxoneConnectionError, MiniserverEndpoint
-    from mcpserver.loxone.events import LoxoneProtocolError
 
     revoked: list[str] = []
-    bindings: list[tuple[str, str, str]] = []
 
     def mutate(document: dict[str, Any]) -> None:
         targets = (
@@ -817,13 +814,6 @@ def _revoke_many(
                 continue
             family["revoked"] = True
             revoked.append(target)
-            bindings.append(
-                (
-                    target,
-                    str(family.get("miniserver_id", "")),
-                    str(family.get("identity_id", "")),
-                )
-            )
             for collection in ("codes", "access_tokens", "refresh_tokens"):
                 for record in document[collection].values():
                     if record.get("family_id") == target:
@@ -834,43 +824,10 @@ def _revoke_many(
         token_store = _token_store()
     except LoxoneTokenStoreError:
         token_store = None
-    config = _config_store().load()
-    selected_endpoint = endpoint if endpoint is not None else config.loxone_endpoint
-    selected_timeout = timeout_seconds if timeout_seconds is not None else config.connection_timeout
-    if selected_endpoint and token_store is not None:
-        client = _loxone_client(
-            MiniserverEndpoint.parse(selected_endpoint),
-            client_uuid=_CLIENT_UUID,
-            timeout_seconds=selected_timeout,
-        )
-
-        async def kill_token(binding: tuple[str, str, str]) -> None:
-            target, miniserver_id, identity_id = binding
-            try:
-                token = token_store.get(target, miniserver_id, identity_id)
-            except LoxoneTokenStoreError:
-                token = None
-            if token is not None:
-                with suppress(
-                    TimeoutError,
-                    LoxoneConnectionError,
-                    LoxoneProtocolError,
-                ):
-                    await asyncio.wait_for(
-                        client.kill_token(token),
-                        timeout=selected_timeout + 5,
-                    )
-
-        async def kill_tokens() -> None:
-            async with asyncio.TaskGroup() as group:
-                for binding in bindings:
-                    group.create_task(kill_token(binding))
-
-        asyncio.run(kill_tokens())
     if token_store is not None:
         for target in revoked:
             with suppress(LoxoneTokenStoreError):
-                token_store.delete(target)
+                token_store.schedule_remote_revoke(target)
     return len(revoked)
 
 

--- a/src/mcpserver/auth/loxone_store.py
+++ b/src/mcpserver/auth/loxone_store.py
@@ -69,6 +69,16 @@ class ExplorerSession:
     expires_at: int
 
 
+@dataclass(frozen=True)
+class RemoteRevocation:
+    """A still-encrypted Loxone token awaiting confirmed remote revocation."""
+
+    family_id: str
+    miniserver_id: str
+    identity_id: str
+    token: LoxoneToken
+
+
 def _encoded(value: bytes) -> str:
     return base64.urlsafe_b64encode(value).decode("ascii")
 
@@ -270,6 +280,57 @@ class EncryptedLoxoneTokenStore:
             document = self._read()
             if document["tokens"].pop(family_id, None) is not None:
                 self._write(document)
+
+    def schedule_remote_revoke(self, family_id: str) -> bool:
+        """Retain a token until a worker confirms its Miniserver revocation."""
+        with self._locked():
+            document = self._read()
+            record = document["tokens"].get(family_id)
+            if not isinstance(record, dict):
+                return False
+            record["remote_revoke_pending"] = True
+            record.setdefault("remote_revoke_attempts", 0)
+            record.setdefault("remote_revoke_after", 0)
+            self._write(document)
+            return True
+
+    def pending_remote_revocations(self, now: int) -> tuple[RemoteRevocation, ...]:
+        with self._locked():
+            records = [
+                (family_id, record.copy())
+                for family_id, record in self._read()["tokens"].items()
+                if isinstance(record, dict)
+                and record.get("remote_revoke_pending") is True
+                and isinstance(record.get("remote_revoke_after"), int)
+                and record["remote_revoke_after"] <= now
+            ]
+        pending = []
+        for family_id, record in records:
+            miniserver_id, identity_id = record.get("miniserver_id"), record.get("identity_id")
+            if not isinstance(miniserver_id, str) or not isinstance(identity_id, str):
+                raise LoxoneTokenStoreError("encrypted token binding is invalid")
+            token = self.get(family_id, miniserver_id, identity_id)
+            if token is not None:
+                pending.append(RemoteRevocation(family_id, miniserver_id, identity_id, token))
+        return tuple(pending)
+
+    def defer_remote_revoke(self, family_id: str, now: int) -> None:
+        with self._locked():
+            document = self._read()
+            record = document["tokens"].get(family_id)
+            if not isinstance(record, dict) or record.get("remote_revoke_pending") is not True:
+                return
+            attempts = record.get("remote_revoke_attempts", 0)
+            if not isinstance(attempts, int) or attempts < 0:
+                attempts = 0
+            attempts += 1
+            record["remote_revoke_attempts"] = attempts
+            record["remote_revoke_after"] = now + min(300, 2 ** min(attempts, 8))
+            self._write(document)
+
+    def complete_remote_revoke(self, family_id: str) -> None:
+        """Delete only after the Miniserver accepted killtoken."""
+        self.delete(family_id)
 
     @staticmethod
     def _explorer_aad(session_id: str, family_id: str, client_id: str) -> bytes:

--- a/src/mcpserver/auth/remote_revocation.py
+++ b/src/mcpserver/auth/remote_revocation.py
@@ -1,0 +1,69 @@
+"""Durable best-effort cleanup of Loxone tokens after local OAuth revocation."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from contextlib import suppress
+from typing import Final
+from uuid import UUID
+
+from mcpserver.auth.loxone_store import (
+    EncryptedLoxoneTokenStore,
+    LoxoneTokenStoreError,
+    RemoteRevocation,
+)
+from mcpserver.loxone.client import LoxoneClient, LoxoneConnectionError, MiniserverEndpoint
+from mcpserver.loxone.events import LoxoneProtocolError
+
+_LOGGER = logging.getLogger("mcpserver.auth.remote_revocation")
+_POLL_SECONDS: Final = 5
+_CLIENT_UUID: Final = UUID("3f52f6fe-3af0-4d30-a8bb-f429b9da4465")
+
+
+async def process_remote_revocations(
+    endpoint: MiniserverEndpoint,
+    store: EncryptedLoxoneTokenStore,
+    timeout_seconds: float,
+) -> None:
+    """Delete only tokens whose remote killtoken operation succeeded."""
+    try:
+        pending = store.pending_remote_revocations(int(time.time()))
+    except LoxoneTokenStoreError as exc:
+        _LOGGER.warning(
+            "component=remote_revocation outcome=queue_unavailable error_type=%s",
+            type(exc).__name__,
+        )
+        return
+    if not pending:
+        return
+    client = LoxoneClient(endpoint, client_uuid=_CLIENT_UUID, timeout_seconds=timeout_seconds)
+
+    async def process(item: RemoteRevocation) -> None:
+        # Keep identifiers and tokens out of logs.
+        try:
+            await asyncio.wait_for(client.kill_token(item.token), timeout=timeout_seconds + 5)
+        except (TimeoutError, LoxoneConnectionError, LoxoneProtocolError):
+            with suppress(LoxoneTokenStoreError):
+                store.defer_remote_revoke(item.family_id, int(time.time()))
+            _LOGGER.warning("component=remote_revocation outcome=deferred")
+        else:
+            with suppress(LoxoneTokenStoreError):
+                store.complete_remote_revoke(item.family_id)
+            _LOGGER.info("component=remote_revocation outcome=completed")
+
+    async with asyncio.TaskGroup() as group:
+        for item in pending:
+            group.create_task(process(item))
+
+
+async def run_remote_revocation_worker(
+    endpoint: MiniserverEndpoint,
+    store: EncryptedLoxoneTokenStore,
+    timeout_seconds: float,
+) -> None:
+    """Continue deferred cleanup across CGI requests and service restarts."""
+    while True:
+        await process_remote_revocations(endpoint, store, timeout_seconds)
+        await asyncio.sleep(_POLL_SECONDS)

--- a/src/mcpserver/loxone/runtime.py
+++ b/src/mcpserver/loxone/runtime.py
@@ -896,7 +896,6 @@ class LoxoneRuntime:
 
     async def revoke(self, family_id: str) -> None:
         await self.disconnect(family_id)
-        self.token_store.delete(family_id)
 
     async def close(self) -> None:
         for family_id in tuple(self._records):

--- a/src/mcpserver/server.py
+++ b/src/mcpserver/server.py
@@ -33,10 +33,12 @@ from mcpserver.auth.provider import (
     READ_SCOPE,
     Phase0OAuthProvider,
 )
+from mcpserver.auth.remote_revocation import run_remote_revocation_worker
 from mcpserver.auth.store import AtomicJsonAuthStore
 from mcpserver.auth.web import Phase0OAuthWeb
 from mcpserver.config import DEFAULT_LOG_LEVEL, AtomicConfigStore
 from mcpserver.loxberry.diagnostics import LoxBerryDiagnostics
+from mcpserver.loxone.client import MiniserverEndpoint
 from mcpserver.loxone.runtime import LoxoneRuntime
 from mcpserver.loxone.statistics import StatisticsCache
 from mcpserver.settings import ServerSettings
@@ -270,11 +272,23 @@ class _Phase0TokenVerifier(TokenVerifier):
 
 
 @asynccontextmanager
-async def _runtime_lifespan(runtime: LoxoneRuntime | None) -> AsyncIterator[None]:
+async def _runtime_lifespan(
+    runtime: LoxoneRuntime | None,
+    remote_revocation: tuple[MiniserverEndpoint, EncryptedLoxoneTokenStore, float] | None = None,
+) -> AsyncIterator[None]:
     """Close all live Miniserver sessions when the HTTP application stops."""
+    worker = (
+        asyncio.create_task(run_remote_revocation_worker(*remote_revocation))
+        if remote_revocation is not None
+        else None
+    )
     try:
         yield
     finally:
+        if worker is not None:
+            worker.cancel()
+            with suppress(asyncio.CancelledError):
+                await worker
         if runtime is not None:
             await runtime.close()
 
@@ -341,7 +355,7 @@ def create_server(settings: ServerSettings) -> FastMCP:
 
         def on_family_revoked(family_id: str) -> None:
             if loxone_store is not None:
-                loxone_store.delete(family_id)
+                loxone_store.schedule_remote_revoke(family_id)
                 loxone_store.delete_explorer_family(family_id)
             runtime_value = runtime_ref.get("runtime")
             if runtime_value is None:
@@ -448,7 +462,16 @@ def create_server(settings: ServerSettings) -> FastMCP:
         stateless_http=True,
         auth=oauth_auth,
         transport_security=transport_security,
-        lifespan=lambda _server: _runtime_lifespan(runtime),
+        lifespan=lambda _server: _runtime_lifespan(
+            runtime,
+            (
+                settings.phase0_auth.loxone_endpoint,
+                loxone_store,
+                config.connection_timeout if config is not None else 10.0,
+            )
+            if settings.phase0_auth is not None and loxone_store is not None
+            else None,
+        ),
     )
     server.forwarded_allowed_hosts = settings.allowed_hosts
     server.transport_guard = transport_guard

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import base64
 import hashlib
 import hmac
@@ -936,10 +935,7 @@ def test_revoke_survives_unreadable_encrypted_token(
     store.mutate(add_family)
 
     class BrokenTokenStore:
-        def get(self, family_id: str, miniserver_id: str, identity_id: str) -> None:
-            raise LoxoneTokenStoreError("cannot decrypt")
-
-        def delete(self, family_id: str) -> None:
+        def schedule_remote_revoke(self, family_id: str) -> None:
             raise LoxoneTokenStoreError("cannot read store")
 
     monkeypatch.setenv("MCPSERVER_AUTH_STORE", str(auth_path))
@@ -999,7 +995,7 @@ def test_revoke_survives_corrupt_encrypted_token_store_constructor(
     assert store.snapshot()["families"]["family"]["revoked"] is True
 
 
-def test_revoke_deletes_local_token_after_remote_protocol_error(
+def test_revoke_queues_local_token_after_remote_protocol_error(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     auth_path = (tmp_path / "data" / "auth" / "sessions.json").resolve()
@@ -1017,14 +1013,11 @@ def test_revoke_deletes_local_token_after_remote_protocol_error(
         }
 
     store.mutate(add_family)
-    deleted: list[str] = []
+    queued: list[str] = []
 
     class TrackingTokenStore:
-        def get(self, family_id: str, miniserver_id: str, identity_id: str) -> LoxoneToken:
-            return LoxoneToken("jwt", "user", "key", "SHA256", 1)
-
-        def delete(self, family_id: str) -> None:
-            deleted.append(family_id)
+        def schedule_remote_revoke(self, family_id: str) -> None:
+            queued.append(family_id)
 
     class ProtocolFailingClient:
         def __init__(self, *args: object, **kwargs: object) -> None:
@@ -1053,11 +1046,11 @@ def test_revoke_deletes_local_token_after_remote_protocol_error(
     )
 
     assert _revoke("family") == 1
-    assert deleted == ["family"]
+    assert queued == ["family"]
     assert store.snapshot()["families"]["family"]["revoked"] is True
 
 
-def test_revoke_kills_remote_tokens_concurrently(
+def test_revoke_queues_remote_tokens_without_waiting_for_miniserver(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     auth_path = (tmp_path / "data" / "auth" / "sessions.json").resolve()
@@ -1075,31 +1068,14 @@ def test_revoke_kills_remote_tokens_concurrently(
             }
 
     store.mutate(add_families)
-    active = 0
-    maximum_active = 0
-    deleted: list[str] = []
+    queued: list[str] = []
 
     class TokenStore:
-        def get(self, family_id: str, miniserver_id: str, identity_id: str) -> LoxoneToken:
-            return LoxoneToken(family_id, identity_id, "key", "SHA256", 1)
-
-        def delete(self, family_id: str) -> None:
-            deleted.append(family_id)
-
-    class ConcurrentClient:
-        def __init__(self, *args: object, **kwargs: object) -> None:
-            pass
-
-        async def kill_token(self, token: LoxoneToken) -> None:
-            nonlocal active, maximum_active
-            active += 1
-            maximum_active = max(maximum_active, active)
-            await asyncio.sleep(0)
-            active -= 1
+        def schedule_remote_revoke(self, family_id: str) -> None:
+            queued.append(family_id)
 
     monkeypatch.setenv("MCPSERVER_AUTH_STORE", str(auth_path))
     monkeypatch.setattr("mcpserver.admin._token_store", lambda: TokenStore())
-    monkeypatch.setattr("mcpserver.admin._loxone_client", ConcurrentClient)
     monkeypatch.setattr(
         "mcpserver.admin._config_store",
         lambda: type(
@@ -1117,5 +1093,4 @@ def test_revoke_kills_remote_tokens_concurrently(
     )
 
     assert _revoke(None) == 2
-    assert maximum_active == 2
-    assert sorted(deleted) == ["family-0", "family-1"]
+    assert sorted(queued) == ["family-0", "family-1"]

--- a/tests/test_loxone_store.py
+++ b/tests/test_loxone_store.py
@@ -75,3 +75,17 @@ def test_explorer_session_is_encrypted_and_removed_with_its_oauth_family(tmp_pat
     assert store.get_explorer_session("browser-session") == session
     store.delete_explorer_family("family")
     assert store.get_explorer_session("browser-session") is None
+
+
+def test_remote_revocation_keeps_token_until_confirmed(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    token = LoxoneToken("token-secret", "user", "key", "SHA256", 2_000_000_000)
+    store.put("family", "miniserver", "identity", token)
+
+    assert store.schedule_remote_revoke("family") is True
+    assert store.pending_remote_revocations(0)[0].token == token
+    store.defer_remote_revoke("family", 0)
+    assert store.pending_remote_revocations(1) == ()
+    assert store.pending_remote_revocations(2)[0].family_id == "family"
+    store.complete_remote_revoke("family")
+    assert store.get("family", "miniserver", "identity") is None

--- a/tests/test_remote_revocation.py
+++ b/tests/test_remote_revocation.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from mcpserver.auth.loxone_store import EncryptedLoxoneTokenStore
+from mcpserver.auth.remote_revocation import process_remote_revocations
+from mcpserver.loxone.client import LoxoneToken, MiniserverEndpoint
+from mcpserver.loxone.events import LoxoneProtocolError
+
+
+def _store(tmp_path: Path) -> EncryptedLoxoneTokenStore:
+    key = tmp_path / "install.key"
+    key.write_bytes(b"k" * 32)
+    return EncryptedLoxoneTokenStore((tmp_path / "tokens.json").resolve(), key.resolve())
+
+
+def test_remote_revoke_keeps_token_after_failure_and_removes_it_after_success(
+    tmp_path: Path, monkeypatch
+) -> None:
+    store = _store(tmp_path)
+    store.put("family", "miniserver", "identity", LoxoneToken("jwt", "user", "key", "SHA256", 1))
+    store.schedule_remote_revoke("family")
+
+    class FailingClient:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        async def kill_token(self, _token: LoxoneToken) -> None:
+            raise LoxoneProtocolError("failed")
+
+    monkeypatch.setattr("mcpserver.auth.remote_revocation.LoxoneClient", FailingClient)
+    endpoint = MiniserverEndpoint.parse_gen1("http://192.168.10.20")
+    asyncio.run(process_remote_revocations(endpoint, store, 0.1))
+    assert store.get("family", "miniserver", "identity") is not None
+
+    class SuccessfulClient(FailingClient):
+        async def kill_token(self, _token: LoxoneToken) -> None:
+            pass
+
+    monkeypatch.setattr("mcpserver.auth.remote_revocation.LoxoneClient", SuccessfulClient)
+    store.defer_remote_revoke("family", -10)
+    asyncio.run(process_remote_revocations(endpoint, store, 0.1))
+    assert store.get("family", "miniserver", "identity") is None


### PR DESCRIPTION
## Summary
- revoke MCP OAuth access locally and immediately, but retain the encrypted Loxone token until killtoken succeeds
- persist deferred remote revocations in the encrypted token store and process them from the service with bounded exponential backoff
- update regression coverage and DE/EN user documentation

## Validation
- targeted tests: 73 passed
- Ruff format/check, mypy, JavaScript syntax and diff check passed
- full Python 3.13 gate delegated to CI

## Native evidence
- focused Loxberry-Test deployment was attempted through the approved script but the target command returned exit code 1; native acceptance remains incomplete.