### PR TITLE
Prepare 0.4.0-alpha.10 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 All notable user-visible changes are recorded here. GitHub release notes are
 extracted from the matching version heading.
 
-## Unreleased
+## 0.4.0-alpha.10 - 2026-08-14
 
-- Retain encrypted Loxone tokens after a local session revocation until the
+- Load the administrative configuration before deferred status and session data,
+  so the management page remains responsive without weakening its consistency.
+- Retain encrypted Loxone tokens after local session revocation until the
   Miniserver confirms `killtoken`; unavailable Miniservers are retried by the
   service without delaying the administrative UI.
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ Für jeden Assistenten sollte ein eigener Loxone-Benutzer mit den minimal erford
 ## Projektstatus
 
 Phase 1 bis Phase 3 sind abgenommen. Der vorbereitete Phase-4-Pre-Release
-`0.4.0-alpha.9` ergänzt begrenzte LoxAPP3-Modelle für Klima, Lüftung, Status,
-Energie und globale Metadaten sowie nur dokumentierte temporäre Overrides. Die
-vorherige `0.4.0-alpha.8` blockiert die MCP-Tool-Explorer-Anmeldung auf HTTP mit einem
+`0.4.0-alpha.10` ergänzt die verzögerungsfreie Admin-Ansicht und eine robuste,
+asynchrone Loxone-Token-Widerrufswiederholung. Es enthält außerdem die begrenzten
+LoxAPP3-Modelle für Klima, Lüftung, Status, Energie und globale Metadaten sowie
+nur dokumentierte temporäre Overrides. Die vorherige `0.4.0-alpha.8` blockiert die MCP-Tool-Explorer-Anmeldung auf HTTP mit einem
 Link zur gleichen IP-Adresse oder demselben Hostnamen über HTTPS sowie die versionsgeprüfte, begrenzte single-flight
 LoxAPP3-Aktualisierung, einen kontrollierten Runtime-Shutdown und einen
 ausschließlich flüchtigen Statistik-Cache. Das Schreibwerkzeug unterstützt auf Gen.-1-Controls die Typen

--- a/docs/development/support-matrix.md
+++ b/docs/development/support-matrix.md
@@ -1,13 +1,13 @@
 # Support-Matrix
 
-- **Stand:** begrenzte LoxAPP3-Modellierung, 2026-08-13
-- **Vorbereiteter Pre-Release:** `0.4.0-alpha.9`
+- **Stand:** Alpha-10-Abnahmekandidat, 2026-08-14
+- **Vorbereiteter Pre-Release:** `0.4.0-alpha.10`
 - **Nächster Meilenstein:** gezielte reale Abnahme der noch unbestätigten
-  Phase-4-Aktionen und V1-Varianten
+  Phase-4-Aktionen und der Alpha-10-Admin-/Widerrufspfade
 
 Diese Matrix unterscheidet reale Nachweise von implementierten, aber noch nicht
 real bestätigten Kombinationen. Phase 1, Phase 2 und Phase 3 sind abgenommen;
-`0.4.0-alpha.9` bleibt wegen seines Vorabversionsstatus ein Pre-Release.
+`0.4.0-alpha.10` bleibt wegen seines Vorabversionsstatus ein Pre-Release.
 Phase 4 ist implementiert und für die lesenden Statistik-/Historienpfade, die
 eng begrenzte plugin-eigene Cache-Operation und ausgewählte, reversible
 Control-Aktionen auf Hardware abgenommen; siehe

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -1,4 +1,4 @@
-# LoxBerry MCP Server 0.4.0-alpha.9
+# LoxBerry MCP Server 0.4.0-alpha.10
 
 ## Voraussetzungen
 

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -1,4 +1,4 @@
-# LoxBerry MCP Server 0.4.0-alpha.9
+# LoxBerry MCP Server 0.4.0-alpha.10
 
 ## Requirements
 

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -3,11 +3,11 @@ NAME=Miraculix2050
 EMAIL=198097126+Miraculix2050@users.noreply.github.com
 
 [PLUGIN]
-VERSION=0.4.0-alpha.9
+VERSION=0.4.0-alpha.10
 NAME=mcpserver
 FOLDER=mcpserver
 TITLE=LoxBerry MCP Server
-WEBSITE=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/blob/v0.4.0-alpha.9/README.md
+WEBSITE=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/blob/v0.4.0-alpha.10/README.md
 
 [AUTOUPDATE]
 AUTOMATIC_UPDATES=false

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -52,7 +52,7 @@ fi
 
 python3.13 -m venv "$new_venv" || exit 2
 "$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" -r "$plugin_bin/runtime-arm64.lock" || exit 2
-"$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" loxberry-mcpserver==0.4.0a9 || exit 2
+"$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" loxberry-mcpserver==0.4.0a10 || exit 2
 if [ -d "$venv" ]; then
     mv "$venv" "$old_venv" || exit 2
 fi

--- a/prerelease.cfg
+++ b/prerelease.cfg
@@ -1,4 +1,4 @@
 [AUTOUPDATE]
-VERSION=0.4.0-alpha.9
-ARCHIVEURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/download/v0.4.0-alpha.9/LoxBerry-MCP-Server-0.4.0-alpha.9.zip
-INFOURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/tag/v0.4.0-alpha.9
+VERSION=0.4.0-alpha.10
+ARCHIVEURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/download/v0.4.0-alpha.10/LoxBerry-MCP-Server-0.4.0-alpha.10.zip
+INFOURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/tag/v0.4.0-alpha.10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loxberry-mcpserver"
-version = "0.4.0-alpha.9"
+version = "0.4.0-alpha.10"
 description = "Local MCP server for LoxBerry and Loxone"
 requires-python = ">=3.13,<3.14"
 license = "Apache-2.0"

--- a/src/mcpserver/__init__.py
+++ b/src/mcpserver/__init__.py
@@ -5,6 +5,6 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("loxberry-mcpserver")
 except PackageNotFoundError:  # pragma: no cover - source tree without installation
-    __version__ = "0.4.0-alpha.9"
+    __version__ = "0.4.0-alpha.10"
 
 __all__ = ["__version__"]

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -120,7 +120,7 @@ def test_plugin_identity_and_platform_contract() -> None:
     assert parser["PLUGIN"]["NAME"] == "mcpserver"
     assert parser["PLUGIN"]["FOLDER"] == "mcpserver"
     assert parser["PLUGIN"]["TITLE"] == "LoxBerry MCP Server"
-    assert parser["PLUGIN"]["VERSION"] == "0.4.0-alpha.9"
+    assert parser["PLUGIN"]["VERSION"] == "0.4.0-alpha.10"
     assert parser["SYSTEM"]["LB_MINIMUM"] == "4.0.0"
     assert parser["SYSTEM"]["INTERFACE"] == "2.0"
     for name in ("release.cfg", "prerelease.cfg"):
@@ -455,7 +455,7 @@ def test_plugin_archive_verifier_accepts_builder_output(tmp_path: Path) -> None:
     for name, version in _locked_requirements(ROOT / "requirements" / "runtime-arm64.lock").items():
         wheel_name = name.replace("-", "_")
         (wheelhouse / f"{wheel_name}-{version}-py3-none-any.whl").write_bytes(b"wheel")
-    project_wheel = wheelhouse / "loxberry_mcpserver-0.4.0a9-py3-none-any.whl"
+    project_wheel = wheelhouse / "loxberry_mcpserver-0.4.0a10-py3-none-any.whl"
     _write_project_wheel(project_wheel)
     hash_lock = tmp_path / "runtime-arm64.sha256"
     hash_lock.write_text(
@@ -861,12 +861,12 @@ def test_plugin_archive_verifier_rejects_checksum_mismatch(tmp_path: Path) -> No
 
 
 def test_release_metadata_and_changelog_match_current_prerelease() -> None:
-    notes = validate_release_metadata(ROOT, "0.4.0-alpha.9", "prerelease")
+    notes = validate_release_metadata(ROOT, "0.4.0-alpha.10", "prerelease")
 
-    assert "Add bounded LoxAPP3 climate, ventilation" in notes
-    assert "documented temporary" in notes
+    assert "Load the administrative configuration" in notes
+    assert "Retain encrypted Loxone tokens" in notes
     with pytest.raises(ValueError, match="stable releases"):
-        validate_release_metadata(ROOT, "0.4.0-alpha.9", "stable")
+        validate_release_metadata(ROOT, "0.4.0-alpha.10", "stable")
     with pytest.raises(ValueError, match="versions do not match"):
         validate_release_metadata(ROOT, "0.3.0-alpha.2", "prerelease")
 


### PR DESCRIPTION
## Summary

- prepare `0.4.0-alpha.10` metadata, package installation pin, update feed, and release notes
- document the current Alpha-10 candidate status and the merged admin responsiveness and remote token-revocation retry behavior
- align package verification expectations with the new prerelease version

## Validation

- `tools/test.py --profile full` with Python 3.13: 526 passed
- `git diff --check`

## Follow-up

Native package, browser, and authorized MCP-Test acceptance will run from the merged prepared master before prerelease publication.
