### PR TITLE
Fix Explorer OAuth callback delivery

### DIFF
--- a/tests/test_explorer_ui.py
+++ b/tests/test_explorer_ui.py
@@ -452,22 +452,32 @@ def test_explorer_oauth_guards_and_resource_binding() -> None:
     assert (
         run_core(
             "core.acceptOAuthMessage('https://local','https://local',"
-            "{type:'mcp-explorer-oauth',state:'expected'},'expected')"
+            "{type:'mcp-explorer-oauth',state:'expected',code:'code'},'expected')"
         )
         is True
     )
     assert (
         run_core(
             "core.acceptOAuthMessage('https://other','https://local',"
-            "{type:'mcp-explorer-oauth',state:'expected'},'expected')"
+            "{type:'mcp-explorer-oauth',state:'expected',code:'code'},'expected')"
         )
         is False
     )
     assert (
         run_core(
             "core.acceptOAuthMessage('https://local','https://local',"
-            "{type:'mcp-explorer-oauth',state:'wrong'},'expected')"
+            "{type:'mcp-explorer-oauth',state:'wrong',code:'code'},'expected')"
         )
+        is False
+    )
+    assert (
+        run_core(
+            "core.acceptOAuthPayload({type:'mcp-explorer-oauth',state:'expected',code:'code'},'expected')"
+        )
+        is True
+    )
+    assert (
+        run_core("core.acceptOAuthPayload({type:'mcp-explorer-oauth',state:'expected'},'expected')")
         is False
     )
 
@@ -651,6 +661,10 @@ def test_explorer_ui_is_local_scoped_and_progressively_safe() -> None:
     assert "Cache_Control => 'no-store'" in callback
     assert "frame-ancestors 'none'" in callback
     assert "window.history.replaceState" in callback
+    assert "new BroadcastChannel('mcp-explorer-oauth')" in callback
+    assert "window.setTimeout(() => window.close(), 100)" in callback
+    assert "new BroadcastChannel('mcp-explorer-oauth')" in source
+    assert "authorizationChannel.onmessage = onChannelMessage" in source
 
 
 def test_explorer_initial_discovery_has_no_pre_login_permission_choice() -> None:

--- a/webfrontend/htmlauth/explorer.js
+++ b/webfrontend/htmlauth/explorer.js
@@ -441,8 +441,15 @@
     return !(annotations.readOnlyHint === true && annotations.destructiveHint === false);
   }
 
+  function acceptOAuthPayload(data, expectedState) {
+    return Boolean(
+      data && data.type === 'mcp-explorer-oauth' && data.state === expectedState &&
+      (typeof data.code === 'string' || typeof data.error === 'string'),
+    );
+  }
+
   function acceptOAuthMessage(origin, expectedOrigin, data, expectedState) {
-    return origin === expectedOrigin && data && data.type === 'mcp-explorer-oauth' && data.state === expectedState;
+    return origin === expectedOrigin && acceptOAuthPayload(data, expectedState);
   }
 
   function clearSensitiveState(state) {
@@ -512,6 +519,7 @@
     formatPath,
     base64Url,
     toolIsMutating,
+    acceptOAuthPayload,
     acceptOAuthMessage,
     clearSensitiveState,
     fieldControlId,
@@ -730,19 +738,28 @@
   function waitForAuthorization(popup, expectedState) {
     return new Promise((resolve, reject) => {
       let finished = false;
+      const authorizationChannel = typeof BroadcastChannel === 'function'
+        ? new BroadcastChannel('mcp-explorer-oauth')
+        : null;
       const finish = (callback) => {
         if (finished) return;
         finished = true;
         window.clearInterval(closedTimer);
         window.clearTimeout(timeout);
         window.removeEventListener('message', onMessage);
+        authorizationChannel?.close();
         callback();
       };
       const onMessage = (event) => {
         if (!core.acceptOAuthMessage(event.origin, window.location.origin, event.data, expectedState)) return;
         finish(() => event.data.error ? reject(new Error(event.data.errorDescription || event.data.error)) : resolve(event.data.code));
       };
+      const onChannelMessage = (event) => {
+        if (!core.acceptOAuthPayload(event.data, expectedState)) return;
+        finish(() => event.data.error ? reject(new Error(event.data.errorDescription || event.data.error)) : resolve(event.data.code));
+      };
       window.addEventListener('message', onMessage);
+      if (authorizationChannel) authorizationChannel.onmessage = onChannelMessage;
       const closedTimer = window.setInterval(() => {
         if (popup.closed) finish(() => reject(new Error(label('authCancelled'))));
       }, 500);

--- a/webfrontend/htmlauth/explorer_callback.cgi
+++ b/webfrontend/htmlauth/explorer_callback.cgi
@@ -29,9 +29,17 @@ print <<'HTML';
     errorDescription: parameters.get('error_description'),
   };
   window.history.replaceState(null, '', window.location.pathname);
+  // The direct opener message is the normal completion path. BroadcastChannel is
+  // a same-origin fallback for browsers that detach a popup's opener during the
+  // authentication navigation.
+  try {
+    const channel = new BroadcastChannel('mcp-explorer-oauth');
+    channel.postMessage(payload);
+    window.setTimeout(() => channel.close(), 100);
+  } catch (_error) { /* BroadcastChannel is optional. */ }
   if (window.opener && window.opener !== window) {
     window.opener.postMessage(payload, window.location.origin);
-    window.close();
+    window.setTimeout(() => window.close(), 100);
   } else {
     document.body.textContent = 'The authorization window can be closed. / Das Autorisierungsfenster kann geschlossen werden.';
   }


### PR DESCRIPTION
## Summary

Adds a same-origin callback fallback for the MCP Tool Explorer when a browser detaches the OAuth popup opener during authentication navigation.

## Root cause

The Explorer relied exclusively on `window.opener.postMessage`. If the opener relationship was lost, the callback closed without delivering the authorization code and the Explorer remained disconnected.

## Change

- retain the origin- and state-validated opener message as the primary path
- add a short-lived same-origin `BroadcastChannel` fallback
- delay closing the callback popup briefly so delivery can complete
- add regression coverage for payload validation and the fallback wiring

## Validation

- `79 passed` — `tests/test_explorer_ui.py tests/test_oauth.py` (project-local pytest temp directory)
- Ruff format and lint for the changed test
- JavaScript and Perl syntax checks
- `git diff --check`

Target deployment was attempted but safely stopped before writes because `Loxberry-Test` was unreachable.