### PR TITLE
Verify MCP tool annotations accurately

### DIFF
--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -758,6 +758,8 @@ def test_mcp_client_probe_resolves_windows_application_aliases() -> None:
     assert "$startInfo.FileName = Resolve-ProcessCommand ([string]$server.command)" in script
     assert "'loxone_list_global_metadata'" in script
     assert "$optional = @(" in script
+    assert "$tool.annotations.idempotentHint -ne $false" in script
+    assert "$tool.name -eq 'loxberry_clear_statistics_cache'" in script
 
 
 def _write_claude_config(path: Path, *, configured: bool) -> None:

--- a/tools/test_mcp_client.ps1
+++ b/tools/test_mcp_client.ps1
@@ -226,8 +226,14 @@ try {
         if ($tool.name -eq 'loxone_operate_control') {
             if ($tool.annotations.readOnlyHint -ne $false -or
                 $tool.annotations.destructiveHint -ne $true -or
-                $tool.annotations.idempotentHint -ne $true) {
+                $tool.annotations.idempotentHint -ne $false) {
                 throw 'MCP control tool annotations violate the control contract.'
+            }
+        } elseif ($tool.name -eq 'loxberry_clear_statistics_cache') {
+            if ($tool.annotations.readOnlyHint -ne $false -or
+                $tool.annotations.destructiveHint -ne $true -or
+                $tool.annotations.idempotentHint -ne $true) {
+                throw 'MCP cache tool annotations violate the operate contract.'
             }
         } elseif ($tool.annotations.readOnlyHint -ne $true -or $tool.annotations.destructiveHint -ne $false) {
             throw 'MCP tool annotations violate the read-only contract.'


### PR DESCRIPTION
## Summary

- validate control actions as non-idempotent, matching the published MCP contract
- validate cache clearing as the distinct idempotent destructive operation
- retain read-only and unknown-tool contract checks

## Validation

- `tools/test.py --profile full` with Python 3.13: 527 passed
- `tools/test_mcp_client.ps1`: tool contract and skill delivery passed
