### PR TITLE
Complete documented temporary override transport handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ extracted from the matching version heading.
 - Retain encrypted Loxone tokens after local session revocation until the
   Miniserver confirms `killtoken`; unavailable Miniservers are retried by the
   service without delaying the administrative UI.
+- Correct the final transport allowlist for documented Daytimer, room-controller,
+  ventilation and HVAC temporary overrides; unsupported raw commands remain rejected.
 
 ## 0.4.0-alpha.9 - 2026-08-13
 

--- a/src/mcpserver/loxone/client.py
+++ b/src/mcpserver/loxone/client.py
@@ -48,7 +48,13 @@ _CONTROL_COMMAND = re.compile(
     rf"hsv\((?:360(?:\.0+)?|(?:[0-9]|[1-9][0-9]|[12][0-9][0-9]|3[0-5][0-9])(?:\.[0-9]+)?),{_PERCENT_COMMAND},{_PERCENT_COMMAND}\)|"
     rf"(?:temp|lumitech)\({_PERCENT_COMMAND},(?:[1-9][0-9]{{3,4}})\)|"
     rf"manualPosition/{_PERCENT_COMMAND}|manualLamelle/{_PERCENT_COMMAND}|"
-    rf"manualPosBlind/{_PERCENT_COMMAND}/{_PERCENT_COMMAND}|(?:0|[1-9][0-9]{{0,2}})|{_PERCENT_COMMAND})\Z"
+    rf"manualPosBlind/{_PERCENT_COMMAND}/{_PERCENT_COMMAND}|"
+    rf"startOverride/[01]/[1-9][0-9]{{0,4}}|stopOverride|"
+    rf"override/(?:0|[1-9][0-9]{{0,9}})/[1-9][0-9]{{0,9}}|"
+    rf"setTimer/(?:0|[1-9][0-9]{{0,4}}/100/(?:0|[1-9][0-9]{{0,9}})/-1)|"
+    rf"startVentilationTimer/(?:0|[1-9][0-9]{{0,9}})|"
+    rf"startmodetimer/[0-3]/(?:0|[1-9][0-9]{{0,9}})/0|"
+    rf"(?:0|[1-9][0-9]{{0,2}})|{_PERCENT_COMMAND})\Z"
 )
 _GEN1_IPV4_NETWORKS: Final = tuple(
     ipaddress.ip_network(value) for value in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")

--- a/src/mcpserver/loxone/runtime.py
+++ b/src/mcpserver/loxone/runtime.py
@@ -421,7 +421,20 @@ class LoxoneRuntime:
                         "control confirmation state is not current",
                     )
                 before = {name: record.observed_at for name, record in before_records.items()}
-                await command_session.operate_control(control.action_uuid, prepared.command)
+                try:
+                    await command_session.operate_control(control.action_uuid, prepared.command)
+                except ValueError as exc:
+                    _LOGGER.warning(
+                        "component=control outcome=transport_validation_failed "
+                        "control_type=%s action=%s error_type=%s",
+                        control.control_type,
+                        action,
+                        type(exc).__name__,
+                    )
+                    raise ControlOperationError(
+                        "unsupported_control",
+                        "control command is not supported by the transport",
+                    ) from exc
             except ControlOperationError:
                 raise
             except LoxoneCommandRejected as exc:

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -171,6 +171,46 @@ async def test_transport_failure_after_dispatch_has_unknown_outcome(
 
 
 @pytest.mark.asyncio
+async def test_transport_validation_failure_is_not_an_unknown_outcome(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    runtime = LoxoneRuntime(
+        MiniserverEndpoint.parse_gen1("http://192.168.1.10"),
+        _TokenStore(),  # type: ignore[arg-type]
+        control_enabled=True,
+    )
+    runtime.cache.begin_connection("family")
+    runtime.cache.apply("family", [StateEvent("state-1", 0.0)], allowed_uuids={"state-1"})
+
+    async def snapshot(_access: StoredAccessToken) -> RuntimeSnapshot:
+        return RuntimeSnapshot("family", _structure(), True)
+
+    class Session:
+        async def load_structure(self) -> LoxoneStructure:
+            return _structure()
+
+        async def operate_control(self, _action_uuid: str, _command: str) -> None:
+            raise ValueError("transport validation failed")
+
+        async def close(self) -> None:
+            return None
+
+    class Client:
+        async def open_session(self, _token: LoxoneToken) -> Session:
+            return Session()
+
+    monkeypatch.setattr(runtime, "snapshot", snapshot)
+    runtime.client = Client()  # type: ignore[assignment]
+
+    with pytest.raises(ControlOperationError) as captured:
+        await runtime.operate_control(_access(READ_SCOPE, CONTROL_SCOPE), "control-1", "on")
+
+    assert captured.value.code == "unsupported_control"
+    assert "outcome=transport_validation_failed control_type=Switch action=on" in caplog.text
+    assert "transport validation failed" not in caplog.text
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("control_type", "action", "kwargs", "command", "state_name", "state_value"),
     [

--- a/tests/test_loxone_client.py
+++ b/tests/test_loxone_client.py
@@ -88,8 +88,23 @@ async def test_control_operation_rejects_unprepared_command() -> None:
 
 
 @pytest.mark.asyncio
-async def test_control_operation_accepts_bounded_numeric_mood_id(
-    monkeypatch: pytest.MonkeyPatch,
+@pytest.mark.parametrize(
+    "operation",
+    (
+        "changeTo/314",
+        "startOverride/1/60",
+        "stopOverride",
+        "override/2/549000000",
+        "setTimer/60/100/2/-1",
+        "setTimer/0",
+        "startVentilationTimer/549000000",
+        "startVentilationTimer/0",
+        "startmodetimer/3/549000000/0",
+        "startmodetimer/0/0/0",
+    ),
+)
+async def test_control_operation_accepts_documented_bounded_commands(
+    monkeypatch: pytest.MonkeyPatch, operation: str
 ) -> None:
     session = LoxoneWebSocketSession(
         cast(Any, object()),
@@ -106,9 +121,9 @@ async def test_control_operation_accepts_bounded_numeric_mood_id(
 
     monkeypatch.setattr(session, "_command", command)
 
-    await session.operate_control("action-1", "changeTo/314")
+    await session.operate_control("action-1", operation)
 
-    assert commands == [("jdev/sps/io/action-1/changeTo/314", True)]
+    assert commands == [(f"jdev/sps/io/action-1/{operation}", True)]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed

- Allow the documented, bounded Daytimer, room-controller, ventilation, and HVAC temporary-override commands through the final WebSocket transport allowlist.
- Keep raw and unprepared commands rejected.
- Classify a transport validation failure as `unsupported_control`, rather than `outcome_unknown`, and log a masked diagnostic event containing only control type, action, and exception type.
- Preserve the fail-closed precondition: commands require current confirmation states before dispatch.

## Root cause

The domain model correctly built documented temporary override commands, but the final client-side transport allowlist omitted them. The client raised `ValueError` before dispatch; the runtime's broad fallback then incorrectly reported an unknown outcome.

## Validation

- Targeted control/client tests: 61 passed.
- Full deterministic suite: 538 passed (one pre-existing Starlette deprecation warning).
- Ruff format/check, mypy, and `git diff --check` passed.
- The full suite used a project-local pytest temporary directory because the Windows global pytest temp directory is not accessible in this session.