### PR TITLE
Add structured service diagnostic events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable user-visible changes are recorded here. GitHub release notes are
 extracted from the matching version heading.
 
+## Unreleased
+
+- Add `loxberry_list_service_events`: a bounded, read-only MCP diagnostic feed
+  exposing only allowlisted fields from server-authored records in the fixed
+  plugin service log. Raw logs, arbitrary files, journal data, payloads and
+  foreign services remain unavailable.
+- Record sanitized error classes for unexpected LoxBerry diagnostic failures and
+  retain the returned trace ID for correlation.
+
 ## 0.4.0-alpha.10 - 2026-08-14
 
 - Load the administrative configuration before deferred status and session data,

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ Das McpServer-Plugin betreibt einen [Model Context Protocol (MCP)](https://model
 Der Zugriff auf Loxone-Funktionen ist durch den Loxone-Login geschützt. Ein verbindender Assistent muss sich mit einem Loxone-Benutzerkonto anmelden und kann nur die Elemente lesen oder bedienen, für die dieses Konto berechtigt ist. Steuerzugriff benötigt zusätzlich die bewusste Aktivierung im Plugin und den separat bestätigten Scope `loxone:control`.
 
 Die optionale LoxBerry-Diagnose ist standardmäßig deaktiviert. Sie zeigt nur
-maskierte System-, Plugin- und Dienststatusdaten. `loxberry:read` benötigt eine
+maskierte System-, Plugin- und Dienststatusdaten sowie begrenzte,
+server-erzeugte Ereignisfelder aus dem festen plugin-eigenen Service-Log.
+`loxberry:read` benötigt eine
 lokale Administratorfreigabe für exakt Client, Loxone-Identität und Miniserver.
 Ein Client kann sie zusammen mit den Loxone-Scopes anfordern; bis zur Freigabe
 bleibt die Diagnose ausstehend. Sie erlaubt keine

--- a/docs/development/adr/0006-phase-3-loxberry-read-only-diagnostics.md
+++ b/docs/development/adr/0006-phase-3-loxberry-read-only-diagnostics.md
@@ -30,10 +30,15 @@ disable ends diagnostic-scoped families but retains approvals.
 
 The adapter reads only `Base.Version` from the bounded LoxBerry general config,
 fixed bounded `/proc` sources, `os.cpu_count`, `statvfs(LBHOMEDIR)`, and a
-fixed-property, three-second `/bin/systemctl show` for this service. It uses no
-shell, dynamic paths, foreign services, logs, PIDs, network data, environment
-values, or write operations. A stopped MCP service cannot report itself through
-MCP.
+fixed-property, three-second `/bin/systemctl show` for this service. The
+additional `loxberry_list_service_events` tool reads only the active,
+plugin-owned `service.log` at its fixed path. It parses server-authored,
+structured records and returns only timestamp, component, severity, trace ID,
+outcome, error code, and error type. It never returns raw lines, arbitrary
+files, backups, payloads, stack traces, identifiers, credentials, tokens,
+addresses, or foreign-service logs. It uses no shell, dynamic paths, PIDs,
+network data, environment values, or write operations. A stopped MCP service
+cannot report itself through MCP.
 
 ## Consequences
 

--- a/docs/development/implementation-guidelines.md
+++ b/docs/development/implementation-guidelines.md
@@ -199,6 +199,14 @@ Architekturentscheidung festgehalten.
 - Wiederholte identische Fehler werden begrenzt, damit ein Ausfall weder Datenträger
   noch LoxBerry-Logverwaltung überlastet.
 - Debug-Logging ist zeitlich oder explizit aktivierbar und standardmäßig aus.
+- Erwartete Fehler werden als stabiler MCP-Fehlercode zurückgegeben und als
+  sanitisierter strukturierter Eintrag mit Komponente, Schweregrad,
+  Korrelations-ID und Ergebnis geloggt. Unerwartete Fehler enthalten intern nur
+  die Fehlerklasse, niemals Rohdaten oder einen Stacktrace.
+- Ein über MCP lesbarer Diagnosefeed darf nur explizit erlaubte,
+  server-erzeugte Strukturfelder aus einer festen plugin-eigenen Quelle liefern.
+  Er akzeptiert keine Pfade und liefert keine Rohlogzeilen, Journal-, Prozess-
+  oder Fremdservice-Daten.
 - Ein Diagnoseexport maskiert Zugangsdaten, Tokens, Sessiondaten, interne
   Adressen und andere identifizierende Werte.
 - Telemetrie an einen Hersteller- oder Projektserver findet nicht statt.

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -65,9 +65,11 @@ und die ausstehende
 Diagnoseanfrage freigibt, enthält die Sitzung den bestätigten Scope, aber die
 Diagnosewerkzeuge antworten weiter mit `permission_denied`.
 Die Freigabe ist exakt an OAuth-Client, Loxone-Identität und Miniserver gebunden.
-Nach der Freigabe funktionieren sie in derselben Verbindung. Die drei Diagnosen sind nur lesend,
-starten oder reparieren nichts, zeigen keine Logs und lesen keine beliebigen
-Dateien. Der Entzug beendet passende Sitzungen.
+Nach der Freigabe funktionieren sie in derselben Verbindung. Die Diagnosen sind nur lesend
+und starten oder reparieren nichts. `loxberry_list_service_events` liefert nur
+begrenzte, server-erzeugte Ereignisfelder aus dem festen plugin-eigenen
+`service.log`; es zeigt keine Rohlogzeilen und liest keine beliebigen Dateien,
+Journaldaten oder fremden Dienste. Der Entzug beendet passende Sitzungen.
 
 **Loxone-Historie und Statistiken** ist ebenfalls standardmäßig deaktiviert.
 `loxone:history` darf bereits vorher angefordert und bestätigt werden; die

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -63,8 +63,10 @@ permissions. Until an administrator enables the feature globally and approves
 the pending diagnostics request,
 the client keeps its confirmed scope, but diagnostic tools continue to return
 `permission_denied`. The approval is bound to that exact OAuth client, Loxone identity
-and Miniserver. Once approved, diagnostics work in that same connection. The three diagnostics are read-only and never repair, restart, expose
-logs, or access arbitrary files. Revoking the approval ends matching sessions.
+and Miniserver. Once approved, diagnostics work in that same connection. They are read-only and never repair or restart. `loxberry_list_service_events` returns only bounded,
+server-authored event fields from the fixed plugin-owned `service.log`; it never
+exposes raw log lines, arbitrary files, journal data, or foreign services.
+Revoking the approval ends matching sessions.
 
 **Loxone history and statistics** is also disabled by default.
 `loxone:history` may be requested and confirmed beforehand; history tools return

--- a/src/mcpserver/loxberry/diagnostics.py
+++ b/src/mcpserver/loxberry/diagnostics.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import stat
 import subprocess
 from pathlib import Path
 from typing import Any, Final
@@ -51,7 +52,14 @@ class LoxBerryDiagnostics:
     @staticmethod
     def _read_limited(path: Path, maximum: int) -> bytes:
         try:
-            with path.open("rb") as handle:
+            # Diagnostic sources are fixed by code. Refuse indirection even if a
+            # plugin-owned log directory is writable by the service account.
+            metadata = path.lstat()
+            if not stat.S_ISREG(metadata.st_mode):
+                raise OSError("diagnostic source is not a regular file")
+            flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+            descriptor = os.open(path, flags)
+            with os.fdopen(descriptor, "rb") as handle:
                 result = handle.read(maximum + 1)
         except OSError as exc:
             raise DiagnosticsUnavailable("diagnostic source unavailable") from exc

--- a/src/mcpserver/loxberry/diagnostics.py
+++ b/src/mcpserver/loxberry/diagnostics.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 from pathlib import Path
 from typing import Any, Final
@@ -18,6 +19,25 @@ _PROC_MAX_BYTES: Final = 64 * 1024
 _SYSTEMCTL_MAX_BYTES: Final = 16 * 1024
 _SERVICE: Final = "loxberry-mcpserver.service"
 _SYSTEMCTL_PROPERTIES: Final = ("LoadState", "ActiveState", "SubState")
+_SERVICE_LOG_MAX_BYTES: Final = 512 * 1024
+_MAX_SERVICE_EVENTS: Final = 100
+_EVENT_LINE: Final = re.compile(
+    r"^(?P<timestamp>.{1,40}?) component=(?P<component>[a-z_.]{1,96}) "
+    r"severity=(?P<severity>DEBUG|INFO|WARNING|ERROR|CRITICAL)(?P<fields>.*)$"
+)
+_EVENT_FIELD: Final = re.compile(
+    r" (?P<name>trace_id|outcome|code|error_type)=(?P<value>[^ ]{1,128})"
+)
+_EVENT_COMPONENTS: Final = frozenset(
+    {
+        "mcpserver.tools",
+        "mcpserver.service",
+        "mcpserver.auth.provider",
+        "mcpserver.auth.remote_revocation",
+        "mcpserver.loxone.client",
+        "mcpserver.loxone.runtime",
+    }
+)
 
 
 class LoxBerryDiagnostics:
@@ -150,3 +170,30 @@ class LoxBerryDiagnostics:
             "sub_state": sub_state or "unknown",
             "healthy": installed and active_state == "active",
         }
+
+    def service_events(self, *, limit: int) -> list[dict[str, str]]:
+        """Return only allowlisted fields from this plugin's bounded service log."""
+        if not 1 <= limit <= _MAX_SERVICE_EVENTS:
+            raise ValueError("event limit is invalid")
+        # This is a fixed plugin-owned path, deliberately not an MCP argument.
+        raw = self._read_limited(
+            self._home / "log/plugins/mcpserver/service.log", _SERVICE_LOG_MAX_BYTES
+        )
+        try:
+            text = raw.decode("utf-8", "strict")
+        except UnicodeError as exc:
+            raise DiagnosticsUnavailable("diagnostic source unavailable") from exc
+        events: list[dict[str, str]] = []
+        for line in text.splitlines():
+            match = _EVENT_LINE.fullmatch(line)
+            if match is None or match["component"] not in _EVENT_COMPONENTS:
+                continue
+            event = {
+                "timestamp": match["timestamp"],
+                "component": match["component"],
+                "severity": match["severity"].lower(),
+            }
+            for field in _EVENT_FIELD.finditer(match["fields"]):
+                event[field["name"]] = field["value"]
+            events.append(event)
+        return events[-limit:]

--- a/src/mcpserver/skill_delivery.py
+++ b/src/mcpserver/skill_delivery.py
@@ -8,7 +8,7 @@ from typing import Final
 from mcp.server.fastmcp import FastMCP
 
 SKILL_NAME: Final = "using-loxberry-mcp"
-SKILL_REVISION: Final = 14
+SKILL_REVISION: Final = 15
 SKILL_MIME_TYPE: Final = "text/markdown"
 SKILL_RESOURCE_URI: Final = f"skill://{SKILL_NAME}/SKILL.md"
 SERVER_INSTRUCTIONS: Final = (

--- a/src/mcpserver/skills/using-loxberry-mcp/SKILL.md
+++ b/src/mcpserver/skills/using-loxberry-mcp/SKILL.md
@@ -59,6 +59,12 @@ required approval; do not recommend repair, restart, or a permission bypass.
 The MCP service can report its own health only while it is reachable. A fully
 stopped MCP service cannot diagnose itself through MCP.
 
+`loxberry_list_service_events` is a read-only, bounded aid for correlating a
+tool response's `trace_id` with recent server-authored diagnostic events. It
+does not expose raw logs, arbitrary files, journal output, credentials, or
+foreign services. If the service is stopped, use the local LoxBerry log viewer
+or an explicitly authorized host diagnosis instead.
+
 Optional scopes may already be present while their administrator policy gate is
 disabled. In that case the relevant tool returns `permission_denied`; explain
 which global or local approval is missing and retry only after the administrator

--- a/src/mcpserver/tools.py
+++ b/src/mcpserver/tools.py
@@ -565,7 +565,11 @@ def _result[EnvelopeT: ToolEnvelope](
 
 
 def _error[EnvelopeT: ToolEnvelope](
-    envelope_type: type[EnvelopeT], code: str, message: str, *, trace_id: str | None = None
+    envelope_type: type[EnvelopeT],
+    code: str,
+    message: str,
+    *,
+    trace_id: str | None = None,
 ) -> EnvelopeT:
     trace_id = trace_id or str(uuid4())
     if code == "temporarily_unavailable":
@@ -1438,7 +1442,9 @@ def register_loxberry_read_tools(server: FastMCP, runtime: LoxBerryReadRuntime) 
         trace_id = str(uuid4())
         try:
             return _result(
-                LoxBerrySystemStatusEnvelope, await runtime.system_status(_access()), trace_id=trace_id
+                LoxBerrySystemStatusEnvelope,
+                await runtime.system_status(_access()),
+                trace_id=trace_id,
             )
         except PermissionError:
             return _error(
@@ -1456,12 +1462,16 @@ def register_loxberry_read_tools(server: FastMCP, runtime: LoxBerryReadRuntime) 
             )
         except Exception as exc:
             _LOGGER.error(
-                "component=tools trace_id=%s outcome=internal_error tool=loxberry_get_system_status error_type=%s",
+                "component=tools trace_id=%s outcome=internal_error "
+                "tool=loxberry_get_system_status error_type=%s",
                 trace_id,
                 type(exc).__name__,
             )
             return _error(
-                LoxBerrySystemStatusEnvelope, "internal_error", "Internal error", trace_id=trace_id
+                LoxBerrySystemStatusEnvelope,
+                "internal_error",
+                "Internal error",
+                trace_id=trace_id,
             )
 
     @server.tool(
@@ -1474,7 +1484,9 @@ def register_loxberry_read_tools(server: FastMCP, runtime: LoxBerryReadRuntime) 
         trace_id = str(uuid4())
         try:
             return _result(
-                LoxBerryPluginStatusEnvelope, await runtime.plugin_status(_access()), trace_id=trace_id
+                LoxBerryPluginStatusEnvelope,
+                await runtime.plugin_status(_access()),
+                trace_id=trace_id,
             )
         except PermissionError:
             return _error(
@@ -1492,12 +1504,16 @@ def register_loxberry_read_tools(server: FastMCP, runtime: LoxBerryReadRuntime) 
             )
         except Exception as exc:
             _LOGGER.error(
-                "component=tools trace_id=%s outcome=internal_error tool=loxberry_get_plugin_status error_type=%s",
+                "component=tools trace_id=%s outcome=internal_error "
+                "tool=loxberry_get_plugin_status error_type=%s",
                 trace_id,
                 type(exc).__name__,
             )
             return _error(
-                LoxBerryPluginStatusEnvelope, "internal_error", "Internal error", trace_id=trace_id
+                LoxBerryPluginStatusEnvelope,
+                "internal_error",
+                "Internal error",
+                trace_id=trace_id,
             )
 
     @server.tool(
@@ -1510,7 +1526,9 @@ def register_loxberry_read_tools(server: FastMCP, runtime: LoxBerryReadRuntime) 
         trace_id = str(uuid4())
         try:
             return _result(
-                LoxBerryServiceHealthEnvelope, await runtime.service_health(_access()), trace_id=trace_id
+                LoxBerryServiceHealthEnvelope,
+                await runtime.service_health(_access()),
+                trace_id=trace_id,
             )
         except PermissionError:
             return _error(
@@ -1528,19 +1546,24 @@ def register_loxberry_read_tools(server: FastMCP, runtime: LoxBerryReadRuntime) 
             )
         except Exception as exc:
             _LOGGER.error(
-                "component=tools trace_id=%s outcome=internal_error tool=loxberry_get_service_health error_type=%s",
+                "component=tools trace_id=%s outcome=internal_error "
+                "tool=loxberry_get_service_health error_type=%s",
                 trace_id,
                 type(exc).__name__,
             )
             return _error(
-                LoxBerryServiceHealthEnvelope, "internal_error", "Internal error", trace_id=trace_id
+                LoxBerryServiceHealthEnvelope,
+                "internal_error",
+                "Internal error",
+                trace_id=trace_id,
             )
 
     @server.tool(
         name="loxberry_list_service_events",
         description=(
             "List recent sanitized diagnostic events from this plugin's fixed service log. "
-            "It never returns raw log lines, arbitrary files, payloads, credentials, or other services."
+            "It never returns raw log lines, arbitrary files, payloads, credentials, "
+            "or other services."
         ),
         annotations=annotations,
         structured_output=True,
@@ -1558,7 +1581,12 @@ def register_loxberry_read_tools(server: FastMCP, runtime: LoxBerryReadRuntime) 
                 trace_id=trace_id,
             )
         except ValueError as exc:
-            return _error(LoxBerryServiceEventsEnvelope, "invalid_input", str(exc), trace_id=trace_id)
+            return _error(
+                LoxBerryServiceEventsEnvelope,
+                "invalid_input",
+                str(exc),
+                trace_id=trace_id,
+            )
         except PermissionError:
             return _error(
                 LoxBerryServiceEventsEnvelope,
@@ -1575,12 +1603,16 @@ def register_loxberry_read_tools(server: FastMCP, runtime: LoxBerryReadRuntime) 
             )
         except Exception as exc:
             _LOGGER.error(
-                "component=tools trace_id=%s outcome=internal_error tool=loxberry_list_service_events error_type=%s",
+                "component=tools trace_id=%s outcome=internal_error "
+                "tool=loxberry_list_service_events error_type=%s",
                 trace_id,
                 type(exc).__name__,
             )
             return _error(
-                LoxBerryServiceEventsEnvelope, "internal_error", "Internal error", trace_id=trace_id
+                LoxBerryServiceEventsEnvelope,
+                "internal_error",
+                "Internal error",
+                trace_id=trace_id,
             )
 
 

--- a/src/mcpserver/tools.py
+++ b/src/mcpserver/tools.py
@@ -498,6 +498,24 @@ class LoxBerryServiceHealthData(BaseModel):
     healthy: bool
 
 
+class LoxBerryServiceEventData(BaseModel):
+    """Sanitized, server-authored diagnostic event; never a raw log line."""
+
+    model_config = ConfigDict(extra="forbid")
+    timestamp: str
+    component: str
+    severity: Literal["debug", "info", "warning", "error", "critical"]
+    trace_id: str | None = None
+    outcome: str | None = None
+    code: str | None = None
+    error_type: str | None = None
+
+
+class LoxBerryServiceEventsData(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    events: list[LoxBerryServiceEventData]
+
+
 class LoxBerryErrorData(ErrorData):
     model_config = ConfigDict(extra="forbid")
 
@@ -517,6 +535,11 @@ class LoxBerryServiceHealthEnvelope(ToolEnvelope):
     data: LoxBerryServiceHealthData | LoxBerryErrorData
 
 
+class LoxBerryServiceEventsEnvelope(ToolEnvelope):
+    model_config = ConfigDict(extra="forbid")
+    data: LoxBerryServiceEventsData | LoxBerryErrorData
+
+
 def _now() -> str:
     return datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
@@ -527,8 +550,9 @@ def _result[EnvelopeT: ToolEnvelope](
     *,
     stale: bool = False,
     warnings: list[str] | None = None,
+    trace_id: str | None = None,
 ) -> EnvelopeT:
-    trace_id = str(uuid4())
+    trace_id = trace_id or str(uuid4())
     _LOGGER.debug("component=tools severity=DEBUG trace_id=%s outcome=ok", trace_id)
     return envelope_type(
         ok=True,
@@ -541,9 +565,9 @@ def _result[EnvelopeT: ToolEnvelope](
 
 
 def _error[EnvelopeT: ToolEnvelope](
-    envelope_type: type[EnvelopeT], code: str, message: str
+    envelope_type: type[EnvelopeT], code: str, message: str, *, trace_id: str | None = None
 ) -> EnvelopeT:
-    trace_id = str(uuid4())
+    trace_id = trace_id or str(uuid4())
     if code == "temporarily_unavailable":
         now = time.monotonic()
         previous = _ERROR_LAST.get(code)
@@ -757,6 +781,12 @@ class LoxBerryReadRuntime:
         import asyncio
 
         return await asyncio.to_thread(self._diagnostics.service_health)
+
+    async def service_events(self, access: StoredAccessToken, limit: int) -> dict[str, Any]:
+        self._allowed(access)
+        import asyncio
+
+        return {"events": await asyncio.to_thread(self._diagnostics.service_events, limit=limit)}
 
 
 class LoxBerryOperateRuntime:
@@ -1405,22 +1435,34 @@ def register_loxberry_read_tools(server: FastMCP, runtime: LoxBerryReadRuntime) 
         structured_output=True,
     )
     async def get_loxberry_system_status() -> LoxBerrySystemStatusEnvelope:
+        trace_id = str(uuid4())
         try:
-            return _result(LoxBerrySystemStatusEnvelope, await runtime.system_status(_access()))
+            return _result(
+                LoxBerrySystemStatusEnvelope, await runtime.system_status(_access()), trace_id=trace_id
+            )
         except PermissionError:
             return _error(
                 LoxBerrySystemStatusEnvelope,
                 "permission_denied",
                 "LoxBerry diagnostics require loxberry:read and local approval",
+                trace_id=trace_id,
             )
         except DiagnosticsUnavailable:
             return _error(
                 LoxBerrySystemStatusEnvelope,
                 "temporarily_unavailable",
                 "LoxBerry diagnostics are temporarily unavailable",
+                trace_id=trace_id,
             )
-        except Exception:
-            return _error(LoxBerrySystemStatusEnvelope, "internal_error", "Internal error")
+        except Exception as exc:
+            _LOGGER.error(
+                "component=tools trace_id=%s outcome=internal_error tool=loxberry_get_system_status error_type=%s",
+                trace_id,
+                type(exc).__name__,
+            )
+            return _error(
+                LoxBerrySystemStatusEnvelope, "internal_error", "Internal error", trace_id=trace_id
+            )
 
     @server.tool(
         name="loxberry_get_plugin_status",
@@ -1429,22 +1471,34 @@ def register_loxberry_read_tools(server: FastMCP, runtime: LoxBerryReadRuntime) 
         structured_output=True,
     )
     async def get_loxberry_plugin_status() -> LoxBerryPluginStatusEnvelope:
+        trace_id = str(uuid4())
         try:
-            return _result(LoxBerryPluginStatusEnvelope, await runtime.plugin_status(_access()))
+            return _result(
+                LoxBerryPluginStatusEnvelope, await runtime.plugin_status(_access()), trace_id=trace_id
+            )
         except PermissionError:
             return _error(
                 LoxBerryPluginStatusEnvelope,
                 "permission_denied",
                 "LoxBerry diagnostics require loxberry:read and local approval",
+                trace_id=trace_id,
             )
         except DiagnosticsUnavailable:
             return _error(
                 LoxBerryPluginStatusEnvelope,
                 "temporarily_unavailable",
                 "LoxBerry diagnostics are temporarily unavailable",
+                trace_id=trace_id,
             )
-        except Exception:
-            return _error(LoxBerryPluginStatusEnvelope, "internal_error", "Internal error")
+        except Exception as exc:
+            _LOGGER.error(
+                "component=tools trace_id=%s outcome=internal_error tool=loxberry_get_plugin_status error_type=%s",
+                trace_id,
+                type(exc).__name__,
+            )
+            return _error(
+                LoxBerryPluginStatusEnvelope, "internal_error", "Internal error", trace_id=trace_id
+            )
 
     @server.tool(
         name="loxberry_get_service_health",
@@ -1453,22 +1507,81 @@ def register_loxberry_read_tools(server: FastMCP, runtime: LoxBerryReadRuntime) 
         structured_output=True,
     )
     async def get_loxberry_service_health() -> LoxBerryServiceHealthEnvelope:
+        trace_id = str(uuid4())
         try:
-            return _result(LoxBerryServiceHealthEnvelope, await runtime.service_health(_access()))
+            return _result(
+                LoxBerryServiceHealthEnvelope, await runtime.service_health(_access()), trace_id=trace_id
+            )
         except PermissionError:
             return _error(
                 LoxBerryServiceHealthEnvelope,
                 "permission_denied",
                 "LoxBerry diagnostics require loxberry:read and local approval",
+                trace_id=trace_id,
             )
         except DiagnosticsUnavailable:
             return _error(
                 LoxBerryServiceHealthEnvelope,
                 "temporarily_unavailable",
                 "LoxBerry diagnostics are temporarily unavailable",
+                trace_id=trace_id,
             )
-        except Exception:
-            return _error(LoxBerryServiceHealthEnvelope, "internal_error", "Internal error")
+        except Exception as exc:
+            _LOGGER.error(
+                "component=tools trace_id=%s outcome=internal_error tool=loxberry_get_service_health error_type=%s",
+                trace_id,
+                type(exc).__name__,
+            )
+            return _error(
+                LoxBerryServiceHealthEnvelope, "internal_error", "Internal error", trace_id=trace_id
+            )
+
+    @server.tool(
+        name="loxberry_list_service_events",
+        description=(
+            "List recent sanitized diagnostic events from this plugin's fixed service log. "
+            "It never returns raw log lines, arbitrary files, payloads, credentials, or other services."
+        ),
+        annotations=annotations,
+        structured_output=True,
+    )
+    async def list_loxberry_service_events(
+        limit: Annotated[
+            int, Field(description="Recent events to return, from 1 to 100.", ge=1, le=100)
+        ] = 50,
+    ) -> LoxBerryServiceEventsEnvelope:
+        trace_id = str(uuid4())
+        try:
+            return _result(
+                LoxBerryServiceEventsEnvelope,
+                await runtime.service_events(_access(), limit),
+                trace_id=trace_id,
+            )
+        except ValueError as exc:
+            return _error(LoxBerryServiceEventsEnvelope, "invalid_input", str(exc), trace_id=trace_id)
+        except PermissionError:
+            return _error(
+                LoxBerryServiceEventsEnvelope,
+                "permission_denied",
+                "LoxBerry diagnostics require loxberry:read and local approval",
+                trace_id=trace_id,
+            )
+        except DiagnosticsUnavailable:
+            return _error(
+                LoxBerryServiceEventsEnvelope,
+                "temporarily_unavailable",
+                "LoxBerry diagnostic events are temporarily unavailable",
+                trace_id=trace_id,
+            )
+        except Exception as exc:
+            _LOGGER.error(
+                "component=tools trace_id=%s outcome=internal_error tool=loxberry_list_service_events error_type=%s",
+                trace_id,
+                type(exc).__name__,
+            )
+            return _error(
+                LoxBerryServiceEventsEnvelope, "internal_error", "Internal error", trace_id=trace_id
+            )
 
 
 def _rfc3339(value: str) -> datetime:

--- a/tests/test_loxberry_diagnostics.py
+++ b/tests/test_loxberry_diagnostics.py
@@ -89,3 +89,16 @@ def test_service_events_reject_invalid_limit_and_oversized_log(tmp_path: Path) -
     target.write_bytes(b"x" * (512 * 1024 + 1))
     with pytest.raises(DiagnosticsUnavailable):
         diagnostics.service_events(limit=1)
+
+
+def test_diagnostic_source_rejects_a_symlink(tmp_path: Path) -> None:
+    target = tmp_path / "target.log"
+    target.write_text("safe", encoding="utf-8")
+    source = tmp_path / "source.log"
+    try:
+        source.symlink_to(target)
+    except OSError as exc:
+        pytest.skip(f"symlinks are unavailable: {exc}")
+
+    with pytest.raises(DiagnosticsUnavailable):
+        LoxBerryDiagnostics._read_limited(source, 64)

--- a/tests/test_loxberry_diagnostics.py
+++ b/tests/test_loxberry_diagnostics.py
@@ -55,3 +55,37 @@ def test_service_health_uses_fixed_command_and_masks_missing_unit(
         "sub_state": "running",
         "healthy": True,
     }
+
+
+def test_service_events_return_only_allowlisted_fields_from_fixed_log(tmp_path: Path) -> None:
+    log = tmp_path / "log" / "plugins" / "mcpserver"
+    log.mkdir(parents=True)
+    (log / "service.log").write_text(
+        "2026-08-14 10:00:00,000 component=mcpserver.tools severity=ERROR "
+        "component=tools outcome=internal_error tool=secret error_type=ValueError\n"
+        "not an event and definitely not returned\n",
+        encoding="utf-8",
+    )
+
+    assert LoxBerryDiagnostics(tmp_path.resolve()).service_events(limit=100) == [
+        {
+            "timestamp": "2026-08-14 10:00:00,000",
+            "component": "mcpserver.tools",
+            "severity": "error",
+            "outcome": "internal_error",
+            "error_type": "ValueError",
+        }
+    ]
+
+
+def test_service_events_reject_invalid_limit_and_oversized_log(tmp_path: Path) -> None:
+    log = tmp_path / "log" / "plugins" / "mcpserver"
+    log.mkdir(parents=True)
+    target = log / "service.log"
+    target.write_text("", encoding="utf-8")
+    diagnostics = LoxBerryDiagnostics(tmp_path.resolve())
+    with pytest.raises(ValueError):
+        diagnostics.service_events(limit=0)
+    target.write_bytes(b"x" * (512 * 1024 + 1))
+    with pytest.raises(DiagnosticsUnavailable):
+        diagnostics.service_events(limit=1)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -120,9 +120,12 @@ def test_loxberry_tool_contracts_have_closed_output_schemas() -> None:
         "loxberry_get_system_status",
         "loxberry_get_plugin_status",
         "loxberry_get_service_health",
+        "loxberry_list_service_events",
     }
-    for tool in published.values():
-        assert tool.parameters["properties"] == {}
+    for name, tool in published.items():
+        assert set(tool.parameters["properties"]) == (
+            {"limit"} if name == "loxberry_list_service_events" else set()
+        )
         assert tool.annotations is not None
         assert tool.annotations.readOnlyHint is True
         assert tool.annotations.destructiveHint is False
@@ -472,7 +475,7 @@ def test_skill_guide_tool_is_read_only_and_matches_resource_content() -> None:
     assert tool.annotations.destructiveHint is False
     assert tool.annotations.openWorldHint is False
     assert result.data.name == "using-loxberry-mcp"  # type: ignore[union-attr]
-    assert result.data.revision == 14  # type: ignore[union-attr]
+    assert result.data.revision == 15  # type: ignore[union-attr]
     assert result.data.media_type == "text/markdown"  # type: ignore[union-attr]
     assert result.data.content == read_skill_markdown()  # type: ignore[union-attr]
     assert "For a `StatusMonitor`, use its `inputStates` state UUID." in result.data.content  # type: ignore[union-attr]

--- a/tools/test_mcp_client.ps1
+++ b/tools/test_mcp_client.ps1
@@ -246,7 +246,7 @@ try {
     $script:nextId = 4
     $skillGuide = Invoke-ReadTool (Get-NextId) 'loxone_get_skill_guide' @{}
     if ($skillGuide.data.name -ne 'using-loxberry-mcp' -or
-        $skillGuide.data.revision -ne 14 -or
+        $skillGuide.data.revision -ne 15 -or
         $skillGuide.data.media_type -ne 'text/markdown' -or
         $skillGuide.data.content -ne $skillMarkdown) {
         throw 'MCP skill guide tool differs from the canonical resource.'


### PR DESCRIPTION
## Summary

- add a bounded MCP feed for allowlisted service diagnostic event fields
- retain trace IDs for LoxBerry diagnostic error correlation
- document the closed log-access boundary and regression coverage

## Validation

- git diff --check
- local Python 3.13 test runner unavailable; CI is required for deterministic test evidence