### PR TITLE
Fix Explorer HTTPS alias sign-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,17 @@ extracted from the matching version heading.
 
 ## Unreleased
 
+## 0.4.0-alpha.11 - 2026-08-14
+
 - Add `loxberry_list_service_events`: a bounded, read-only MCP diagnostic feed
   exposing only allowlisted fields from server-authored records in the fixed
   plugin service log. Raw logs, arbitrary files, journal data, payloads and
   foreign services remain unavailable.
 - Record sanitized error classes for unexpected LoxBerry diagnostic failures and
   retain the returned trace ID for correlation.
+- Restore MCP Tool Explorer sign-in through approved HTTPS IP or hostname aliases:
+  proxy the exact internal Explorer-session endpoint, bind it to the current
+  validated Explorer origin, and retain its real error message for diagnosis.
 
 ## 0.4.0-alpha.10 - 2026-08-14
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ Für jeden Assistenten sollte ein eigener Loxone-Benutzer mit den minimal erford
 ## Projektstatus
 
 Phase 1 bis Phase 3 sind abgenommen. Der vorbereitete Phase-4-Pre-Release
-`0.4.0-alpha.10` ergänzt die verzögerungsfreie Admin-Ansicht und eine robuste,
-asynchrone Loxone-Token-Widerrufswiederholung. Es enthält außerdem die begrenzten
+`0.4.0-alpha.11` ergänzt die verzögerungsfreie Admin-Ansicht und eine robuste,
+asynchrone Loxone-Token-Widerrufswiederholung sowie eine reparierte MCP-Tool-
+Explorer-Anmeldung über freigegebene HTTPS-IP- und Host-Aliase. Es enthält außerdem die begrenzten
 LoxAPP3-Modelle für Klima, Lüftung, Status, Energie und globale Metadaten sowie
 nur dokumentierte temporäre Overrides. Die vorherige `0.4.0-alpha.8` blockiert die MCP-Tool-Explorer-Anmeldung auf HTTP mit einem
 Link zur gleichen IP-Adresse oder demselben Hostnamen über HTTPS sowie die versionsgeprüfte, begrenzte single-flight

--- a/config/apache/mcpserver.conf
+++ b/config/apache/mcpserver.conf
@@ -18,6 +18,9 @@ ProxyPassReverse "/plugins/mcpserver/mcp" "http://127.0.0.1:8765/mcp"
 <Location "/plugins/mcpserver/oauth/revoke">
     LimitRequestBody 16384
 </Location>
+<Location "/plugins/mcpserver/oauth/explorer-session">
+    LimitRequestBody 32768
+</Location>
 ProxyPassMatch "^/plugins/mcpserver/oauth/(authorize)$" "http://127.0.0.1:8765/$1" nocanon
 ProxyPassReverse "/plugins/mcpserver/oauth/authorize" "http://127.0.0.1:8765/authorize"
 ProxyPassMatch "^/plugins/mcpserver/oauth/(token)$" "http://127.0.0.1:8765/$1" nocanon
@@ -26,6 +29,8 @@ ProxyPassMatch "^/plugins/mcpserver/oauth/(register)$" "http://127.0.0.1:8765/$1
 ProxyPassReverse "/plugins/mcpserver/oauth/register" "http://127.0.0.1:8765/register"
 ProxyPassMatch "^/plugins/mcpserver/oauth/(revoke)$" "http://127.0.0.1:8765/$1" nocanon
 ProxyPassReverse "/plugins/mcpserver/oauth/revoke" "http://127.0.0.1:8765/revoke"
+ProxyPassMatch "^/plugins/mcpserver/oauth/(explorer-session)$" "http://127.0.0.1:8765/$1" nocanon
+ProxyPassReverse "/plugins/mcpserver/oauth/explorer-session" "http://127.0.0.1:8765/explorer-session"
 ProxyPassMatch "^(/.well-known/oauth-protected-resource/plugins/mcpserver/mcp)$" "http://127.0.0.1:8765$1" nocanon
 ProxyPassReverse "/.well-known/oauth-protected-resource/plugins/mcpserver/mcp" "http://127.0.0.1:8765/.well-known/oauth-protected-resource/plugins/mcpserver/mcp"
 ProxyPassMatch "^(/.well-known/oauth-authorization-server/plugins/mcpserver/oauth)$" "http://127.0.0.1:8765$1" nocanon

--- a/docs/development/support-matrix.md
+++ b/docs/development/support-matrix.md
@@ -1,13 +1,13 @@
 # Support-Matrix
 
 - **Stand:** Alpha 10 veröffentlicht, 2026-08-14
-- **Pre-Release:** `0.4.0-alpha.10`
+- **Pre-Release:** `0.4.0-alpha.11`
 - **Nächster Meilenstein:** gezielte reale Abnahme der verbleibenden
   Phase-4-Aktionen
 
 Diese Matrix unterscheidet reale Nachweise von implementierten, aber noch nicht
 real bestätigten Kombinationen. Phase 1, Phase 2 und Phase 3 sind abgenommen;
-`0.4.0-alpha.10` bleibt wegen seines Vorabversionsstatus ein Pre-Release.
+`0.4.0-alpha.11` bleibt wegen seines Vorabversionsstatus ein Pre-Release.
 Phase 4 ist implementiert und für die lesenden Statistik-/Historienpfade, die
 eng begrenzte plugin-eigene Cache-Operation und ausgewählte, reversible
 Control-Aktionen auf Hardware abgenommen; siehe

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -1,4 +1,4 @@
-# LoxBerry MCP Server 0.4.0-alpha.10
+# LoxBerry MCP Server 0.4.0-alpha.11
 
 ## Voraussetzungen
 

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -1,4 +1,4 @@
-# LoxBerry MCP Server 0.4.0-alpha.10
+# LoxBerry MCP Server 0.4.0-alpha.11
 
 ## Requirements
 

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -3,11 +3,11 @@ NAME=Miraculix2050
 EMAIL=198097126+Miraculix2050@users.noreply.github.com
 
 [PLUGIN]
-VERSION=0.4.0-alpha.10
+VERSION=0.4.0-alpha.11
 NAME=mcpserver
 FOLDER=mcpserver
 TITLE=LoxBerry MCP Server
-WEBSITE=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/blob/v0.4.0-alpha.10/README.md
+WEBSITE=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/blob/v0.4.0-alpha.11/README.md
 
 [AUTOUPDATE]
 AUTOMATIC_UPDATES=false

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -52,7 +52,7 @@ fi
 
 python3.13 -m venv "$new_venv" || exit 2
 "$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" -r "$plugin_bin/runtime-arm64.lock" || exit 2
-"$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" loxberry-mcpserver==0.4.0a10 || exit 2
+"$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" loxberry-mcpserver==0.4.0a11 || exit 2
 if [ -d "$venv" ]; then
     mv "$venv" "$old_venv" || exit 2
 fi

--- a/prerelease.cfg
+++ b/prerelease.cfg
@@ -1,4 +1,4 @@
 [AUTOUPDATE]
-VERSION=0.4.0-alpha.10
-ARCHIVEURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/download/v0.4.0-alpha.10/LoxBerry-MCP-Server-0.4.0-alpha.10.zip
-INFOURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/tag/v0.4.0-alpha.10
+VERSION=0.4.0-alpha.11
+ARCHIVEURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/download/v0.4.0-alpha.11/LoxBerry-MCP-Server-0.4.0-alpha.11.zip
+INFOURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/tag/v0.4.0-alpha.11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loxberry-mcpserver"
-version = "0.4.0-alpha.10"
+version = "0.4.0-alpha.11"
 description = "Local MCP server for LoxBerry and Loxone"
 requires-python = ">=3.13,<3.14"
 license = "Apache-2.0"

--- a/src/mcpserver/__init__.py
+++ b/src/mcpserver/__init__.py
@@ -5,6 +5,6 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("loxberry-mcpserver")
 except PackageNotFoundError:  # pragma: no cover - source tree without installation
-    __version__ = "0.4.0-alpha.10"
+    __version__ = "0.4.0-alpha.11"
 
 __all__ = ["__version__"]

--- a/src/mcpserver/auth/web.py
+++ b/src/mcpserver/auth/web.py
@@ -289,7 +289,7 @@ class Phase0OAuthWeb:
         )
 
     async def _explorer_payload(self, request: Request) -> dict[str, str] | None:
-        if request.headers.get("origin") != self.explorer_origin:
+        if request.headers.get("origin") not in self.provider.explorer_origins:
             return None
         if (
             request.headers.get("content-type", "").split(";", 1)[0].strip().lower()

--- a/tests/test_apache_config.py
+++ b/tests/test_apache_config.py
@@ -26,6 +26,7 @@ def test_apache_exposes_only_exact_oauth_and_metadata_paths() -> None:
         "/plugins/mcpserver/oauth/token",
         "/plugins/mcpserver/oauth/register",
         "/plugins/mcpserver/oauth/revoke",
+        "/plugins/mcpserver/oauth/explorer-session",
         "/.well-known/oauth-protected-resource/plugins/mcpserver/mcp",
         "/.well-known/oauth-authorization-server/plugins/mcpserver/oauth",
     )
@@ -49,6 +50,7 @@ def test_apache_caps_oauth_request_bodies_on_exact_routes() -> None:
         "/plugins/mcpserver/oauth/token": 16384,
         "/plugins/mcpserver/oauth/register": 32768,
         "/plugins/mcpserver/oauth/revoke": 16384,
+        "/plugins/mcpserver/oauth/explorer-session": 32768,
     }
 
     for path, limit in expected_limits.items():

--- a/tests/test_explorer_ui.py
+++ b/tests/test_explorer_ui.py
@@ -117,6 +117,7 @@ def test_explorer_uses_current_https_origin_for_validated_oauth_endpoints() -> N
         "token_endpoint": "https://loxberry-test/plugins/mcpserver/oauth/token",
         "registration_endpoint": "https://loxberry-test/plugins/mcpserver/oauth/register",
         "revocation_endpoint": "https://loxberry-test/plugins/mcpserver/oauth/revoke",
+        "explorer_session_endpoint": "https://loxberry-test/plugins/mcpserver/oauth/explorer-session",
     }
     tampered = dict(metadata)
     tampered["token_endpoint"] = "https://other.example/token"
@@ -656,6 +657,7 @@ def test_explorer_ui_is_local_scoped_and_progressively_safe() -> None:
     assert "const scope = core.EXPLORER_SCOPE_ORDER.filter" in source
     assert "const registrationScope = scope" in source
     assert "supported.delete('loxberry:operate')" in source
+    assert "return fetchJson(metadata.explorer_session_endpoint" in source
     assert "state.selectedTool.name === 'loxberry_clear_statistics_cache'" in source
     assert "elements.historyArguments.hidden = !historySource" in source
     assert "Cache_Control => 'no-store'" in callback
@@ -675,6 +677,24 @@ def test_explorer_initial_discovery_has_no_pre_login_permission_choice() -> None
 
     assert "setScopeAvailability" not in initial_discovery
     assert "scopeHistory" not in initial_discovery
+
+
+def test_explorer_login_failure_remains_visible_after_connection_render() -> None:
+    source = SCRIPT.read_text(encoding="utf-8")
+    login_handler = source[
+        source.index("elements.connect.addEventListener('click'") : source.index(
+            "elements.disconnect.addEventListener('click'"
+        )
+    ]
+    failure_handler = login_handler[
+        login_handler.index("} catch (error) {") : login_handler.index(
+            "} finally { setBusy(false); }"
+        )
+    ]
+
+    assert failure_handler.index("renderAll();") < failure_handler.index(
+        "showConnectionError(error, label('error'));"
+    )
 
 
 def test_session_refresh_preserves_pending_loxberry_approval_action() -> None:

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -644,6 +644,22 @@ def test_explorer_session_rejects_cross_origin_requests(tmp_path: Path) -> None:
     assert response.status_code == 400
 
 
+def test_explorer_session_accepts_configured_origin_alias(tmp_path: Path) -> None:
+    key = tmp_path / "install.key"
+    key.write_bytes(b"k" * 32)
+    encrypted = EncryptedLoxoneTokenStore((tmp_path / "tokens.json").resolve(), key.resolve())
+    provider = _provider(tmp_path, explorer_origins=("https://loxberry-alias",))
+    with TestClient(_web_app(provider, encrypted), base_url="https://loxberry-alias") as browser:
+        response = browser.post(
+            "/explorer-session",
+            headers={"Origin": "https://loxberry-alias"},
+            json={"action": "access"},
+        )
+
+    assert response.status_code == 401
+    assert response.json() == {"error": "invalid_session"}
+
+
 def _registration_payload() -> dict[str, object]:
     return {
         "redirect_uris": [REDIRECT],

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -113,6 +113,23 @@ def test_project_wheel_source_set_must_match_exactly(tmp_path: Path, variant: st
         verify_project_wheel_archive(wheel.read_bytes(), ROOT / "src")
 
 
+def test_project_wheel_source_verification_ignores_line_endings(tmp_path: Path) -> None:
+    source_root = tmp_path / "src"
+    source = source_root / "mcpserver" / "module.py"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b'"""Module."""\r\n')
+    wheel = tmp_path / "project.whl"
+    with zipfile.ZipFile(wheel, "w") as archive:
+        archive.writestr("mcpserver/module.py", b'"""Module."""\n')
+        archive.writestr("mcpserver/skills/using-loxberry-mcp/SKILL.md", b"skill\n")
+        archive.writestr(
+            "mcpserver/skills/using-loxberry-mcp/agents/openai.yaml", b"interface: {}\n"
+        )
+
+    verify_project_wheel_input(wheel, source_root)
+    verify_project_wheel_archive(wheel.read_bytes(), source_root)
+
+
 def test_plugin_identity_and_platform_contract() -> None:
     parser = configparser.ConfigParser()
     parser.read(ROOT / "plugin.cfg", encoding="utf-8")
@@ -120,7 +137,7 @@ def test_plugin_identity_and_platform_contract() -> None:
     assert parser["PLUGIN"]["NAME"] == "mcpserver"
     assert parser["PLUGIN"]["FOLDER"] == "mcpserver"
     assert parser["PLUGIN"]["TITLE"] == "LoxBerry MCP Server"
-    assert parser["PLUGIN"]["VERSION"] == "0.4.0-alpha.10"
+    assert parser["PLUGIN"]["VERSION"] == "0.4.0-alpha.11"
     assert parser["SYSTEM"]["LB_MINIMUM"] == "4.0.0"
     assert parser["SYSTEM"]["INTERFACE"] == "2.0"
     for name in ("release.cfg", "prerelease.cfg"):
@@ -455,7 +472,7 @@ def test_plugin_archive_verifier_accepts_builder_output(tmp_path: Path) -> None:
     for name, version in _locked_requirements(ROOT / "requirements" / "runtime-arm64.lock").items():
         wheel_name = name.replace("-", "_")
         (wheelhouse / f"{wheel_name}-{version}-py3-none-any.whl").write_bytes(b"wheel")
-    project_wheel = wheelhouse / "loxberry_mcpserver-0.4.0a10-py3-none-any.whl"
+    project_wheel = wheelhouse / "loxberry_mcpserver-0.4.0a11-py3-none-any.whl"
     _write_project_wheel(project_wheel)
     hash_lock = tmp_path / "runtime-arm64.sha256"
     hash_lock.write_text(
@@ -873,12 +890,11 @@ def test_plugin_archive_verifier_rejects_checksum_mismatch(tmp_path: Path) -> No
 
 
 def test_release_metadata_and_changelog_match_current_prerelease() -> None:
-    notes = validate_release_metadata(ROOT, "0.4.0-alpha.10", "prerelease")
+    notes = validate_release_metadata(ROOT, "0.4.0-alpha.11", "prerelease")
 
-    assert "Load the administrative configuration" in notes
-    assert "Retain encrypted Loxone tokens" in notes
+    assert "Restore MCP Tool Explorer sign-in" in notes
     with pytest.raises(ValueError, match="stable releases"):
-        validate_release_metadata(ROOT, "0.4.0-alpha.10", "stable")
+        validate_release_metadata(ROOT, "0.4.0-alpha.11", "stable")
     with pytest.raises(ValueError, match="versions do not match"):
         validate_release_metadata(ROOT, "0.3.0-alpha.2", "prerelease")
 

--- a/tools/build_plugin.py
+++ b/tools/build_plugin.py
@@ -159,7 +159,7 @@ def _verify_project_wheel(project_wheel: Path, source_root: Path) -> None:
                 packaged = wheel.read(name)
             except KeyError as exc:
                 raise SystemExit(f"project wheel is missing current source: {name}") from exc
-            if packaged != source.read_bytes().replace(b"\r\n", b"\n"):
+            if packaged.replace(b"\r\n", b"\n") != source.read_bytes().replace(b"\r\n", b"\n"):
                 raise SystemExit(f"project wheel contains stale source: {name}")
 
 

--- a/tools/verify_plugin.py
+++ b/tools/verify_plugin.py
@@ -137,7 +137,7 @@ def _verify_project_wheel(content: bytes, source_root: Path) -> None:
                 raise PackageVerificationError(
                     f"project wheel is missing current source: {name}"
                 ) from exc
-            if packaged != source.read_bytes().replace(b"\r\n", b"\n"):
+            if packaged.replace(b"\r\n", b"\n") != source.read_bytes().replace(b"\r\n", b"\n"):
                 raise PackageVerificationError(f"project wheel contains stale source: {name}")
         missing = _REQUIRED_PROJECT_WHEEL_ENTRIES - set(wheel.namelist())
         if missing:

--- a/webfrontend/htmlauth/explorer.js
+++ b/webfrontend/htmlauth/explorer.js
@@ -165,7 +165,10 @@
       if (metadata[name] !== `${issuer.origin}${path}`) return null;
     }
     return Object.fromEntries(
-      Object.entries(endpoints).map(([name, path]) => [name, `${local.origin}${path}`]),
+      [
+        ...Object.entries(endpoints),
+        ['explorer_session_endpoint', '/plugins/mcpserver/oauth/explorer-session'],
+      ].map(([name, path]) => [name, `${local.origin}${path}`]),
     );
   }
 
@@ -771,7 +774,7 @@
   }
 
   async function explorerSession(metadata, body) {
-    return fetchJson(`${metadata.issuer}/explorer-session`, {
+    return fetchJson(metadata.explorer_session_endpoint, {
       method: 'POST', cache: 'no-store', credentials: 'same-origin',
       headers: {'Content-Type': 'application/json'}, body: JSON.stringify(body),
     });
@@ -1440,8 +1443,10 @@
       try { authorizationPopup?.close(); } catch (_closeError) { /* already gone */ }
       if (state.oauth) await revokeAndClear();
       else core.clearSensitiveState(state);
-      showConnectionError(error, label('error'));
       renderAll();
+      // renderAll() resets the connection status. Render first so the actual
+      // OAuth failure remains visible instead of being replaced by "disconnected".
+      showConnectionError(error, label('error'));
     } finally { setBusy(false); }
   });
   elements.disconnect.addEventListener('click', async () => {


### PR DESCRIPTION
## Summary

- proxy the exact Explorer session endpoint and retain its visible connection error
- use the validated current Explorer origin for approved HTTPS IP/hostname aliases
- release 0.4.0-alpha.11 with a cross-platform package source comparison

## Validation

- Python 3.13 full profile: 543 passed
- local release candidate and plugin archive verification passed
- Chrome on Loxberry-Test: sign-in succeeds and the Explorer session survives reload