### PR TITLE
Enable plugin automatic updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ extracted from the matching version heading.
 
 ## Unreleased
 
+- Enable LoxBerry Plugin Manager automatic update discovery for stable releases
+  and explicitly opted-in prereleases.
+
 ## 0.4.0-alpha.11 - 2026-08-14
 
 - Add `loxberry_list_service_events`: a bounded, read-only MCP diagnostic feed

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -41,6 +41,15 @@ Für die ChatGPT-/Codex-Desktop-App beschreibt die
 Hinzufügen per URL, die Browser-Authentifizierung und die angeforderten Lese-
 beziehungsweise Schreibrechte. Dafür wird keine lokale Node.js-Bridge benötigt.
 
+## Updates
+
+Der LoxBerry Plugin Manager darf neue Versionen dieses Plugins automatisch
+erkennen und installieren. Reguläre Updates stammen aus der stabilen
+Releasequelle; Vorabversionen werden nur angeboten, wenn sie im Plugin Manager
+ausdrücklich zugelassen sind. Vor einem Update einer Vorabversion sollte ein
+funktionsfähiger vorheriger Stand für den in [Rollback](#rollback) beschriebenen
+Rückweg verfügbar sein.
+
 Die Admin-Oberfläche zeigt die globale Funktionsfreigabe nach Zielsystem
 gruppiert. Die Checkboxen vergeben keine OAuth-Berechtigung, sondern erlauben
 die Funktion grundsätzlich. Der Client muss den angegebenen Scope zusätzlich

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -40,6 +40,14 @@ For the ChatGPT/Codex desktop app, the
 setup, browser authentication, and the requested read or write permissions. It
 does not require a local Node.js bridge.
 
+## Updates
+
+LoxBerry Plugin Manager may automatically discover and install new versions of
+this plugin. Regular updates use the stable release source; prereleases are
+offered only when they are explicitly enabled in Plugin Manager. Before updating
+a prerelease, keep a known-working earlier version available for the
+[rollback](#rollback) path.
+
 The administration UI groups global capability approval by target system. Its
 checkboxes do not grant OAuth permissions; they globally enable the capability.
 The client must additionally request the listed scope during sign-in and the

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -10,7 +10,7 @@ TITLE=LoxBerry MCP Server
 WEBSITE=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/blob/v0.4.0-alpha.11/README.md
 
 [AUTOUPDATE]
-AUTOMATIC_UPDATES=false
+AUTOMATIC_UPDATES=true
 RELEASECFG=https://raw.githubusercontent.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/master/release.cfg
 PRERELEASECFG=https://raw.githubusercontent.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/master/prerelease.cfg
 

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -138,6 +138,9 @@ def test_plugin_identity_and_platform_contract() -> None:
     assert parser["PLUGIN"]["FOLDER"] == "mcpserver"
     assert parser["PLUGIN"]["TITLE"] == "LoxBerry MCP Server"
     assert parser["PLUGIN"]["VERSION"] == "0.4.0-alpha.11"
+    assert parser["AUTOUPDATE"]["AUTOMATIC_UPDATES"] == "true"
+    assert parser["AUTOUPDATE"]["RELEASECFG"].startswith("https://")
+    assert parser["AUTOUPDATE"]["PRERELEASECFG"].startswith("https://")
     assert parser["SYSTEM"]["LB_MINIMUM"] == "4.0.0"
     assert parser["SYSTEM"]["INTERFACE"] == "2.0"
     for name in ("release.cfg", "prerelease.cfg"):


### PR DESCRIPTION
## Summary
- enable LoxBerry Plugin Manager automatic updates through the native metadata flag
- retain the stable and prerelease release configuration sources
- document update behavior in German and English and cover the metadata contract

## Validation
- git diff --check`n- targeted AUTOUPDATE configuration contract
- Full validation is delegated to the required Python 3.13 GitHub Actions gate; the local bundled Python is 3.12 and lacks pytest.