### PR TITLE
Use local pytest temp directory

### DIFF
--- a/tests/test_test_runner.py
+++ b/tests/test_test_runner.py
@@ -8,11 +8,14 @@ import pytest
 from tools.test import TestPlan as RunnerPlan
 from tools.test import create_plan, discover_changed_files, main
 
+_PYTEST_BASETEMP = ("--basetemp", "tmp/pytest")
+
 
 def _pytest_targets(plan: RunnerPlan) -> set[str]:
     for command in plan.commands:
         if command[1:4] == ("-m", "pytest", "-q"):
-            return set(command[4:])
+            assert command[4:6] == _PYTEST_BASETEMP
+            return set(command[6:])
     return set()
 
 
@@ -99,7 +102,7 @@ def test_changed_explicit_plan_cli_does_not_run_commands(
 def test_full_profile_keeps_ci_commands_quiet() -> None:
     plan = create_plan("full")
 
-    assert plan.commands[-1][1:] == ("-m", "pytest", "-q")
+    assert plan.commands[-1][1:] == ("-m", "pytest", "-q", *_PYTEST_BASETEMP)
     assert plan.commands[0] == ("git", "diff", "--check")
 
 

--- a/tests/test_test_runner.py
+++ b/tests/test_test_runner.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
 
+from tools import test as test_runner
 from tools.test import TestPlan as RunnerPlan
 from tools.test import create_plan, discover_changed_files, main
 
@@ -104,6 +106,26 @@ def test_full_profile_keeps_ci_commands_quiet() -> None:
 
     assert plan.commands[-1][1:] == ("-m", "pytest", "-q", *_PYTEST_BASETEMP)
     assert plan.commands[0] == ("git", "diff", "--check")
+
+
+def test_runner_creates_pytest_basetemp_parent_before_running(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    plan = RunnerPlan(
+        "changed",
+        "changed",
+        (),
+        ((sys.executable, "-m", "pytest", "-q", *_PYTEST_BASETEMP),),
+    )
+    monkeypatch.setattr(test_runner, "ROOT", tmp_path)
+
+    def run(command: tuple[str, ...], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        assert (tmp_path / "tmp").is_dir()
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(test_runner.subprocess, "run", run)
+
+    assert test_runner._run(plan) == 0
 
 
 def test_invalid_explicit_base_ref_fails(

--- a/tests/test_test_runner.py
+++ b/tests/test_test_runner.py
@@ -10,14 +10,13 @@ from tools import test as test_runner
 from tools.test import TestPlan as RunnerPlan
 from tools.test import create_plan, discover_changed_files, main
 
-_PYTEST_BASETEMP = ("--basetemp", "tmp/pytest")
+_PYTEST_BASETEMP = "--basetemp=tmp/pytest"
 
 
 def _pytest_targets(plan: RunnerPlan) -> set[str]:
     for command in plan.commands:
         if command[1:4] == ("-m", "pytest", "-q"):
-            assert command[4:6] == _PYTEST_BASETEMP
-            return set(command[6:])
+            return set(command[4:])
     return set()
 
 
@@ -104,7 +103,7 @@ def test_changed_explicit_plan_cli_does_not_run_commands(
 def test_full_profile_keeps_ci_commands_quiet() -> None:
     plan = create_plan("full")
 
-    assert plan.commands[-1][1:] == ("-m", "pytest", "-q", *_PYTEST_BASETEMP)
+    assert plan.commands[-1][1:] == ("-m", "pytest", "-q")
     assert plan.commands[0] == ("git", "diff", "--check")
 
 
@@ -115,12 +114,37 @@ def test_runner_creates_pytest_basetemp_parent_before_running(
         "changed",
         "changed",
         (),
-        ((sys.executable, "-m", "pytest", "-q", *_PYTEST_BASETEMP),),
+        ((sys.executable, "-m", "pytest", "-q"),),
     )
     monkeypatch.setattr(test_runner, "ROOT", tmp_path)
+    monkeypatch.delenv("PYTEST_ADDOPTS", raising=False)
 
-    def run(command: tuple[str, ...], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+    def run(command: tuple[str, ...], **kwargs: object) -> subprocess.CompletedProcess[str]:
         assert (tmp_path / "tmp").is_dir()
+        environment = kwargs["env"]
+        assert isinstance(environment, dict)
+        assert environment["PYTHONPATH"] == str(tmp_path / "src")
+        assert environment["PYTEST_ADDOPTS"] == _PYTEST_BASETEMP
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(test_runner.subprocess, "run", run)
+
+    assert test_runner._run(plan) == 0
+
+
+def test_runner_preserves_existing_pytest_basetemp(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    plan = RunnerPlan("changed", "changed", (), ((sys.executable, "-m", "pytest", "-q"),))
+    monkeypatch.setattr(test_runner, "ROOT", tmp_path)
+    monkeypatch.setenv("PYTEST_ADDOPTS", "--basetemp=/managed/pytest -p no:cacheprovider")
+
+    def run(command: tuple[str, ...], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        assert not (tmp_path / "tmp").exists()
+        environment = kwargs["env"]
+        assert isinstance(environment, dict)
+        assert environment["PYTHONPATH"] == str(tmp_path / "src")
+        assert environment["PYTEST_ADDOPTS"] == "--basetemp=/managed/pytest -p no:cacheprovider"
         return subprocess.CompletedProcess(command, 0)
 
     monkeypatch.setattr(test_runner.subprocess, "run", run)

--- a/tools/test.py
+++ b/tools/test.py
@@ -189,6 +189,10 @@ def _pytest_command(*tests: str) -> Command:
     )
 
 
+def _is_pytest_command(command: Command) -> bool:
+    return command[1:4] == ("-m", "pytest", "-q")
+
+
 def create_plan(profile: str, files: tuple[str, ...] = ()) -> TestPlan:
     normalized = tuple(sorted({_normalize_file(path) for path in files}))
     if profile == "full":
@@ -322,6 +326,8 @@ def _run(plan: TestPlan) -> int:
 
     environment = {**os.environ, "PYTHONPATH": str(ROOT / "src")}
     for command in plan.commands:
+        if _is_pytest_command(command):
+            (ROOT / _PYTEST_BASETEMP).parent.mkdir(parents=True, exist_ok=True)
         completed = subprocess.run(command, check=False, cwd=ROOT, env=environment)
         if completed.returncode:
             return completed.returncode

--- a/tools/test.py
+++ b/tools/test.py
@@ -173,19 +173,7 @@ def _full_commands() -> tuple[Command, ...]:
         (sys.executable, "-m", "ruff", "format", "--check", "."),
         (sys.executable, "-m", "ruff", "check", "."),
         (sys.executable, "-m", "mypy"),
-        _pytest_command(),
-    )
-
-
-def _pytest_command(*tests: str) -> Command:
-    return (
-        sys.executable,
-        "-m",
-        "pytest",
-        "-q",
-        "--basetemp",
-        _PYTEST_BASETEMP,
-        *tests,
+        (sys.executable, "-m", "pytest", "-q"),
     )
 
 
@@ -243,7 +231,7 @@ def create_plan(profile: str, files: tuple[str, ...] = ()) -> TestPlan:
     if needs_mypy:
         commands.append((sys.executable, "-m", "mypy"))
     if selected_tests:
-        commands.append(_pytest_command(*tuple(sorted(selected_tests))))
+        commands.append((sys.executable, "-m", "pytest", "-q", *tuple(sorted(selected_tests))))
     return TestPlan("changed", "changed", normalized, tuple(commands))
 
 
@@ -325,8 +313,14 @@ def _run(plan: TestPlan) -> int:
             return 2
 
     environment = {**os.environ, "PYTHONPATH": str(ROOT / "src")}
+    existing_pytest_options = environment.get("PYTEST_ADDOPTS", "")
+    uses_default_pytest_basetemp = "--basetemp" not in existing_pytest_options
+    if uses_default_pytest_basetemp:
+        environment["PYTEST_ADDOPTS"] = (
+            f"{existing_pytest_options} --basetemp={_PYTEST_BASETEMP}"
+        ).strip()
     for command in plan.commands:
-        if _is_pytest_command(command):
+        if _is_pytest_command(command) and uses_default_pytest_basetemp:
             (ROOT / _PYTEST_BASETEMP).parent.mkdir(parents=True, exist_ok=True)
         completed = subprocess.run(command, check=False, cwd=ROOT, env=environment)
         if completed.returncode:

--- a/tools/test.py
+++ b/tools/test.py
@@ -14,6 +14,7 @@ from typing import Final, cast
 
 ROOT: Final = Path(__file__).resolve().parents[1]
 Command = tuple[str, ...]
+_PYTEST_BASETEMP: Final = "tmp/pytest"
 
 _DOCUMENTATION_PATTERNS: Final = (
     "AGENTS.md",
@@ -172,7 +173,19 @@ def _full_commands() -> tuple[Command, ...]:
         (sys.executable, "-m", "ruff", "format", "--check", "."),
         (sys.executable, "-m", "ruff", "check", "."),
         (sys.executable, "-m", "mypy"),
-        (sys.executable, "-m", "pytest", "-q"),
+        _pytest_command(),
+    )
+
+
+def _pytest_command(*tests: str) -> Command:
+    return (
+        sys.executable,
+        "-m",
+        "pytest",
+        "-q",
+        "--basetemp",
+        _PYTEST_BASETEMP,
+        *tests,
     )
 
 
@@ -226,7 +239,7 @@ def create_plan(profile: str, files: tuple[str, ...] = ()) -> TestPlan:
     if needs_mypy:
         commands.append((sys.executable, "-m", "mypy"))
     if selected_tests:
-        commands.append((sys.executable, "-m", "pytest", "-q", *tuple(sorted(selected_tests))))
+        commands.append(_pytest_command(*tuple(sorted(selected_tests))))
     return TestPlan("changed", "changed", normalized, tuple(commands))
 
 


### PR DESCRIPTION
## What changed

The local test runner now passes `--basetemp tmp/pytest` to every Pytest invocation.

## Why

Pytest otherwise uses the global Windows user temp directory, which can be inaccessible in isolated execution environments and causes false-negative test failures.

## Impact

Temporary test data remains inside the ignored `tmp/` directory. The runner tests now assert the explicit Pytest arguments.

## Validation

- `py -3.13 tools/test.py --profile changed --files tools/test.py tests/test_test_runner.py`
  - 10 passed
