### PR TITLE
Fix concurrent local binding revocations

### DIFF
--- a/src/mcpserver/admin.py
+++ b/src/mcpserver/admin.py
@@ -662,17 +662,18 @@ def _allow_loxberry_read(payload: object) -> dict[str, Any]:
     ):
         raise AdminError("pending diagnostic session is unavailable")
     binding = _loxberry_binding(record)
-    store = _config_store()
-    previous = store.load()
-    if binding not in previous.loxberry_read_bindings:
+
+    def add_binding(previous: PluginConfig) -> PluginConfig:
+        if binding in previous.loxberry_read_bindings:
+            return previous
         if len(previous.loxberry_read_bindings) >= 64:
             raise AdminError("LoxBerry approval capacity reached")
-        store.save(
-            replace(
-                previous,
-                loxberry_read_bindings=(*previous.loxberry_read_bindings, binding),
-            )
+        return replace(
+            previous,
+            loxberry_read_bindings=(*previous.loxberry_read_bindings, binding),
         )
+
+    _config_store().mutate(add_binding)
     return {"loxberry_bindings": _loxberry_bindings(), "sessions": _sessions()}
 
 
@@ -680,12 +681,18 @@ def _revoke_loxberry_read(payload: object) -> dict[str, Any]:
     binding = payload.get("binding_id") if isinstance(payload, dict) else None
     if not isinstance(binding, str) or len(binding) != 64:
         raise AdminError("LoxBerry approval is invalid")
-    store = _config_store()
-    previous = store.load()
-    if binding not in previous.loxberry_read_bindings:
-        raise AdminError("LoxBerry approval is unavailable")
-    updated = tuple(item for item in previous.loxberry_read_bindings if item != binding)
-    store.save(replace(previous, loxberry_read_bindings=updated))
+
+    def remove_binding(previous: PluginConfig) -> PluginConfig:
+        if binding not in previous.loxberry_read_bindings:
+            raise AdminError("LoxBerry approval is unavailable")
+        return replace(
+            previous,
+            loxberry_read_bindings=tuple(
+                item for item in previous.loxberry_read_bindings if item != binding
+            ),
+        )
+
+    updated_config = _config_store().mutate(remove_binding)
     document = _auth_store().snapshot()
     families = [
         family_id
@@ -697,8 +704,8 @@ def _revoke_loxberry_read(payload: object) -> dict[str, Any]:
     if families:
         _revoke_many(
             families,
-            endpoint=previous.loxone_endpoint,
-            timeout_seconds=previous.connection_timeout,
+            endpoint=updated_config.loxone_endpoint,
+            timeout_seconds=updated_config.connection_timeout,
         )
     return {"loxberry_bindings": _loxberry_bindings(), "sessions": _sessions()}
 
@@ -723,17 +730,18 @@ def _allow_loxberry_operate(payload: object) -> dict[str, Any]:
     ):
         raise AdminError("pending operation session is unavailable")
     binding = _loxberry_operate_binding(record)
-    store = _config_store()
-    previous = store.load()
-    if binding not in previous.loxberry_operate_bindings:
+
+    def add_binding(previous: PluginConfig) -> PluginConfig:
+        if binding in previous.loxberry_operate_bindings:
+            return previous
         if len(previous.loxberry_operate_bindings) >= 64:
             raise AdminError("LoxBerry operation approval capacity reached")
-        store.save(
-            replace(
-                previous,
-                loxberry_operate_bindings=(*previous.loxberry_operate_bindings, binding),
-            )
+        return replace(
+            previous,
+            loxberry_operate_bindings=(*previous.loxberry_operate_bindings, binding),
         )
+
+    _config_store().mutate(add_binding)
     return {
         "sessions": _sessions(),
         "loxberry_operate_bindings": _loxberry_operate_bindings(),
@@ -746,18 +754,18 @@ def _revoke_loxberry_operate(payload: object) -> dict[str, Any]:
     binding = payload.get("binding_id") if isinstance(payload, dict) else None
     if not isinstance(binding, str) or len(binding) != 64:
         raise AdminError("LoxBerry operation approval is invalid")
-    store = _config_store()
-    previous = store.load()
-    if binding not in previous.loxberry_operate_bindings:
-        raise AdminError("LoxBerry operation approval is unavailable")
-    store.save(
-        replace(
+
+    def remove_binding(previous: PluginConfig) -> PluginConfig:
+        if binding not in previous.loxberry_operate_bindings:
+            raise AdminError("LoxBerry operation approval is unavailable")
+        return replace(
             previous,
             loxberry_operate_bindings=tuple(
                 item for item in previous.loxberry_operate_bindings if item != binding
             ),
         )
-    )
+
+    updated_config = _config_store().mutate(remove_binding)
     document = _auth_store().snapshot()
     families = [
         family_id
@@ -770,8 +778,8 @@ def _revoke_loxberry_operate(payload: object) -> dict[str, Any]:
     if families:
         _revoke_many(
             families,
-            endpoint=previous.loxone_endpoint,
-            timeout_seconds=previous.connection_timeout,
+            endpoint=updated_config.loxone_endpoint,
+            timeout_seconds=updated_config.connection_timeout,
         )
     return {
         "sessions": _sessions(),

--- a/src/mcpserver/config.py
+++ b/src/mcpserver/config.py
@@ -7,10 +7,13 @@ import json
 import os
 import secrets
 import stat
-from contextlib import suppress
+import sys
+import threading
+from collections.abc import Callable
+from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Final
+from typing import Any, BinaryIO, Final
 from urllib.parse import urlsplit
 
 import idna
@@ -40,6 +43,35 @@ SUPPORTED_LOG_LEVELS: Final = frozenset({"off", "error", "warning", "info", "deb
 
 class ConfigError(ValueError):
     """The plugin configuration is invalid or cannot be persisted safely."""
+
+
+def _lock_file(handle: BinaryIO) -> None:
+    if sys.platform == "win32":  # pragma: win32 cover
+        import msvcrt
+
+        handle.seek(0)
+        if os.fstat(handle.fileno()).st_size == 0:
+            handle.seek(0)
+            handle.write(b"0")
+            handle.flush()
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+    else:  # pragma: posix cover
+        import fcntl
+
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+
+
+def _unlock_file(handle: BinaryIO) -> None:
+    if sys.platform == "win32":  # pragma: win32 cover
+        import msvcrt
+
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+    else:  # pragma: posix cover
+        import fcntl
+
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
 
 def _mapping(value: object, *, name: str) -> dict[str, Any]:
@@ -384,8 +416,31 @@ class AtomicConfigStore:
         if not path.is_absolute() or path.suffix.lower() != ".json":
             raise ValueError("configuration path must be an absolute JSON file")
         self.path = path
+        self.lock_path = path.with_name(f".{path.name}.lock")
+        self._thread_lock = threading.RLock()
+
+    @contextmanager
+    def _locked(self):  # type: ignore[no-untyped-def]
+        with self._thread_lock:
+            try:
+                self.path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+                with self.lock_path.open("a+b") as handle:
+                    os.chmod(self.lock_path, 0o600)
+                    _lock_file(handle)
+                    try:
+                        yield
+                    finally:
+                        _unlock_file(handle)
+            except ConfigError:
+                raise
+            except OSError as exc:
+                raise ConfigError("configuration lock failed") from exc
 
     def load(self) -> PluginConfig:
+        with self._locked():
+            return self._load_unlocked()
+
+    def _load_unlocked(self) -> PluginConfig:
         if not self.path.exists():
             return PluginConfig.defaults()
         try:
@@ -399,6 +454,10 @@ class AtomicConfigStore:
             raise ConfigError("configuration is unreadable") from exc
 
     def save(self, config: PluginConfig) -> None:
+        with self._locked():
+            self._save_unlocked(config)
+
+    def _save_unlocked(self, config: PluginConfig) -> None:
         document = config.to_document()
         PluginConfig.from_document(document)
         temporary: Path | None = None
@@ -419,3 +478,12 @@ class AtomicConfigStore:
                 with suppress(OSError):
                     temporary.unlink(missing_ok=True)
             raise ConfigError("configuration update failed") from exc
+
+    def mutate(self, operation: Callable[[PluginConfig], PluginConfig]) -> PluginConfig:
+        """Apply one configuration update while holding the cross-process lock."""
+        with self._locked():
+            current = self._load_unlocked()
+            result = operation(current)
+            if result != current:
+                self._save_unlocked(result)
+            return result

--- a/templates/index.html
+++ b/templates/index.html
@@ -381,6 +381,9 @@
   let servicePollInFlight = false;
   let servicePollTimer = null;
   let sessionActionRunning = false;
+  let activeSessionActions = 0;
+  let sessionDataVersion = 0;
+  const pendingSessionActionButtons = new Set();
   let sessionPollInFlight = false;
   let sessionPollTimer = null;
   let lastService = null;
@@ -845,17 +848,27 @@
       sessionPollTimer = window.setTimeout(pollSessions, delay);
     }
   };
+  const releasePendingSessionActionButtons = () => {
+    for (const button of pendingSessionActionButtons) {
+      button.disabled = false;
+      button.removeAttribute('aria-busy');
+    }
+    pendingSessionActionButtons.clear();
+  };
   const pollSessions = async () => {
     if (document.hidden || !sessionsSection.open || sessionActionRunning || sessionPollInFlight) {
       scheduleSessionPoll();
       return;
     }
     sessionPollInFlight = true;
+    let expectedSessionDataVersion = -1;
     try {
       const body = new FormData();
       body.set('action', 'list_sessions');
       body.set('ajax', '1');
+      expectedSessionDataVersion = sessionDataVersion;
       const result = await postAjax(body, 7000);
+      if (expectedSessionDataVersion !== sessionDataVersion) return;
       if (Array.isArray(result.data.sessions)) updateSessions(result.data.sessions);
       if (Array.isArray(result.data.loxberry_bindings)) {
         updateLoxberryBindings(result.data.loxberry_bindings);
@@ -863,8 +876,12 @@
       if (Array.isArray(result.data.loxberry_operate_bindings)) {
         updateLoxberryOperateBindings(result.data.loxberry_operate_bindings);
       }
+      releasePendingSessionActionButtons();
     } catch {
       // Keep the last known table; the next visible and open-section poll retries.
+      if (expectedSessionDataVersion === sessionDataVersion) {
+        releasePendingSessionActionButtons();
+      }
     } finally {
       sessionPollInFlight = false;
       scheduleSessionPoll();
@@ -881,6 +898,10 @@
     service_action: 75000,
     service_status: 7000,
   })[action] || 15000;
+  const isSessionAction = (action) => [
+    'revoke_session', 'revoke_all', 'allow_loxberry_read', 'revoke_loxberry_read',
+    'allow_loxberry_operate', 'revoke_loxberry_operate',
+  ].includes(action);
   document.addEventListener('submit', async (event) => {
     const form = event.target.closest('form[data-ajax]');
     if (!form) return;
@@ -904,7 +925,9 @@
         servicePollTimer = null;
         renderService(lastService);
       }
-      if (['revoke_session', 'revoke_all', 'allow_loxberry_read', 'revoke_loxberry_read', 'allow_loxberry_operate', 'revoke_loxberry_operate'].includes(form.dataset.ajax)) {
+      if (isSessionAction(form.dataset.ajax)) {
+        activeSessionActions += 1;
+        sessionDataVersion += 1;
         sessionActionRunning = true;
         window.clearTimeout(sessionPollTimer);
         sessionPollTimer = null;
@@ -925,12 +948,18 @@
         status.textContent = '<TMPL_VAR AJAX.SUCCESS ESCAPE=JS>';
         hideSuccess(status);
         if (result.data.service) renderService(result.data.service);
-        if (Array.isArray(result.data.sessions)) updateSessions(result.data.sessions);
-        if (Array.isArray(result.data.loxberry_bindings)) {
-          updateLoxberryBindings(result.data.loxberry_bindings);
+        if (!isSessionAction(form.dataset.ajax)) {
+          if (Array.isArray(result.data.sessions)) updateSessions(result.data.sessions);
+          if (Array.isArray(result.data.loxberry_bindings)) {
+            updateLoxberryBindings(result.data.loxberry_bindings);
+          }
+          if (Array.isArray(result.data.loxberry_operate_bindings)) {
+            updateLoxberryOperateBindings(result.data.loxberry_operate_bindings);
+          }
         }
-        if (Array.isArray(result.data.loxberry_operate_bindings)) {
-          updateLoxberryOperateBindings(result.data.loxberry_operate_bindings);
+        if (isSessionAction(form.dataset.ajax)) {
+          keepButtonDisabled = true;
+          pendingSessionActionButtons.add(button);
         }
         if (result.data.certificate) updateCertificate(result.data.certificate);
         if (form.dataset.ajax === 'save_config') {
@@ -957,9 +986,10 @@
           renderService(lastService);
           scheduleServicePoll(0);
         }
-        if (['revoke_session', 'revoke_all', 'allow_loxberry_read', 'revoke_loxberry_read', 'allow_loxberry_operate', 'revoke_loxberry_operate'].includes(form.dataset.ajax)) {
-          sessionActionRunning = false;
-          scheduleSessionPoll();
+        if (isSessionAction(form.dataset.ajax)) {
+          activeSessionActions -= 1;
+          sessionActionRunning = activeSessionActions > 0;
+          if (!sessionActionRunning) scheduleSessionPoll(0);
         }
         if (!keepButtonDisabled) {
           button.disabled = false;

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -5,6 +5,7 @@ import hashlib
 import hmac
 import json
 import subprocess
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
 from pathlib import Path
 
@@ -20,6 +21,7 @@ from mcpserver.admin import (
     _renew_certificate,
     _revoke,
     _revoke_loxberry_operate,
+    _revoke_loxberry_read,
     _save,
     _service_status,
     _set_logging,
@@ -207,6 +209,48 @@ def test_revoking_loxberry_operate_keeps_other_bound_scope_families(
     _revoke_loxberry_operate({"binding_id": binding})
 
     assert revoked == ["operate-family"]
+
+
+def test_concurrent_loxberry_read_binding_revocations_remove_each_binding(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = (tmp_path / "config" / "mcpserver.json").resolve()
+    auth_path = (tmp_path / "data" / "auth" / "sessions.json").resolve()
+    auth_store = AtomicJsonAuthStore(auth_path)
+    families = {
+        f"family-{index}": {
+            "scope": f"{READ_SCOPE} {LOXBERRY_READ_SCOPE}",
+            "client_id": f"client-{index}",
+            "identity_id": f"identity-{index}",
+            "miniserver_id": f"miniserver-{index}",
+            "revoked": False,
+        }
+        for index in range(2)
+    }
+    bindings = tuple(
+        auth_store.pseudonym(
+            "loxberry-read-binding-v1",
+            f"client-{index}",
+            f"identity-{index}",
+            f"miniserver-{index}",
+        )
+        for index in range(len(families))
+    )
+    AtomicConfigStore(config_path).save(
+        PluginConfig.from_document(
+            {"schema_version": 1, "policies": {"loxberry_read_bindings": list(bindings)}}
+        )
+    )
+    auth_store.mutate(lambda document: document["families"].update(families))
+    monkeypatch.setenv("MCPSERVER_CONFIG", str(config_path))
+    monkeypatch.setenv("MCPSERVER_AUTH_STORE", str(auth_path))
+    monkeypatch.setattr("mcpserver.admin._token_store", lambda: None)
+
+    with ThreadPoolExecutor(max_workers=len(bindings)) as executor:
+        list(executor.map(lambda binding: _revoke_loxberry_read({"binding_id": binding}), bindings))
+
+    assert AtomicConfigStore(config_path).load().loxberry_read_bindings == ()
+    assert all(record["revoked"] for record in auth_store.snapshot()["families"].values())
 
 
 def test_loxberry_bindings_expose_related_active_client_without_raw_ids(

--- a/tests/test_admin_ui.py
+++ b/tests/test_admin_ui.py
@@ -101,6 +101,25 @@ def test_sessions_poll_only_while_visible_and_open_and_patch_changed_rows() -> N
     assert "sessionList.replaceChildren(fragment)" in template
 
 
+def test_parallel_session_actions_pause_polling_without_blocking_buttons() -> None:
+    template = (ROOT / "templates/index.html").read_text(encoding="utf-8")
+
+    assert "const isSessionAction = (action)" in template
+    assert "let activeSessionActions = 0;" in template
+    assert "let sessionDataVersion = 0;" in template
+    assert "const pendingSessionActionButtons = new Set();" in template
+    assert "activeSessionActions += 1;" in template
+    assert "sessionDataVersion += 1;" in template
+    assert "sessionActionRunning = activeSessionActions > 0;" in template
+    assert "if (!sessionActionRunning) scheduleSessionPoll(0);" in template
+    assert "if (isSessionAction(form.dataset.ajax) && sessionActionRunning) return;" not in template
+    assert "if (expectedSessionDataVersion !== sessionDataVersion) return;" in template
+    assert "if (!isSessionAction(form.dataset.ajax)) {" in template
+    assert "pendingSessionActionButtons.add(button);" in template
+    assert "releasePendingSessionActionButtons();" in template
+    assert template.count("if (isSessionAction(form.dataset.ajax)) {") == 3
+
+
 def test_read_only_ajax_polling_does_not_create_admin_log_files() -> None:
     cgi = (ROOT / "webfrontend/htmlauth/index.cgi").read_text(encoding="utf-8")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 import json
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
 from pathlib import Path
+from threading import Barrier
+from time import sleep
 
 import pytest
 
@@ -189,3 +193,27 @@ def test_failed_save_keeps_previous_valid_configuration(
         )
 
     assert store.load().to_document() == original.to_document()
+
+
+def test_concurrent_mutations_preserve_each_binding(tmp_path: Path) -> None:
+    path = (tmp_path / "config.json").resolve()
+    AtomicConfigStore(path).save(PluginConfig.defaults())
+    bindings = ("a" * 64, "b" * 64)
+    barrier = Barrier(len(bindings))
+
+    def add(binding: str) -> None:
+        barrier.wait()
+
+        def operation(config: PluginConfig) -> PluginConfig:
+            sleep(0.01)
+            return replace(
+                config,
+                loxberry_read_bindings=(*config.loxberry_read_bindings, binding),
+            )
+
+        AtomicConfigStore(path).mutate(operation)
+
+    with ThreadPoolExecutor(max_workers=len(bindings)) as executor:
+        list(executor.map(add, bindings))
+
+    assert set(AtomicConfigStore(path).load().loxberry_read_bindings) == set(bindings)


### PR DESCRIPTION
Fixes concurrent LoxBerry binding revocations and stale admin-session UI updates. Focused pytest and Ruff checks pass.