### PR TITLE
Restore Gen 1 Loxone runtime stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ extracted from the matching version heading.
 
 ## Unreleased
 
+- Keep a failed Loxone binary-state stream fail-closed while recording only its
+  sanitized exception class; the stream task is now consumed after that record
+  so its error cannot be raised a second time during session cleanup.
 - Restore Gen. 1 Loxone token authentication by using the firmware-supported
   JWT credential inside RSA/AES Command Encryption instead of the rejected
   token-hash variant; the independent Gen. 2 hash path remains unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ extracted from the matching version heading.
 
 ## Unreleased
 
+- Restore Gen. 1 Loxone token authentication by using the firmware-supported
+  JWT credential inside RSA/AES Command Encryption instead of the rejected
+  token-hash variant; the independent Gen. 2 hash path remains unchanged.
+- Stop Loxone token authentication attempts after three rejections of the
+  `authwithtoken` step per OAuth session until a local administrator explicitly
+  permits another bounded attempt. Miniserver source-IP lockouts are reported
+  separately and never increment that counter.
 - Enable LoxBerry Plugin Manager automatic update discovery for stable releases
   and explicitly opted-in prereleases.
 

--- a/docs/development/phase-0-loxone-test.md
+++ b/docs/development/phase-0-loxone-test.md
@@ -74,9 +74,10 @@ verschlüsselte `getkey2` und die verschlüsselte JWT-Anforderung mit dem
 vorgesehenen Testbenutzer. Der `apiKey`-Probe berücksichtigt dabei das
 historische Gen.-1-Format, in dem `LL.value` ein flaches, einfach quotiertes
 Objekt statt standardkonformem JSON enthält. `getkey2` bestimmt dynamisch SHA1
-oder SHA256 für den Passwort- und Tokenhash. Jede Tokenauthentifizierung,
--erneuerung und -widerrufung bezieht über die jeweilige verschlüsselte
-WebSocket-Verbindung einen frischen `getkey`-Einmalschlüssel.
+oder SHA256 für den Passworthash. Der Gen.-1-Pfad übermittelt den seit Firmware
+11.2 unterstützten JWT direkt innerhalb der RSA/AES-verschlüsselten
+Tokenoperationen; der Token erscheint dabei nie im unverschlüsselten
+WebSocket-Befehl.
 
 Der reale Strukturabruf bestätigte außerdem das dokumentierte Estimated-Bit
 `0x80` vor dem exakten Header. Der getestete Gen.-1-Miniserver kennzeichnet die

--- a/docs/development/phase-4-acceptance.md
+++ b/docs/development/phase-4-acceptance.md
@@ -169,3 +169,13 @@ additional stop command was sent; the accepted command was restricted to its
 60-second duration.
 This confirms that exact action and mode on the maintainer fixture, not the
 remaining HVAC/ventilation actions or timer modes.
+
+On 2026-08-14, the MCP user was granted access to all three eligible controls
+in the dedicated test intersection. The direct MCP connection and its structure
+snapshot were current, but neither the required confirmation states nor ordinary
+visible states received a current binary-state value. The runtime was corrected
+to retain a sanitized event-stream failure class without re-raising that task's
+error during cleanup; deterministic tests and a focused target deployment
+passed, and the target emitted no stream-failure event. The absent initial state
+tables therefore remain an external hardware/runtime observation. No additional
+control command was sent, and the remaining actions stay hardware-unverified.

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -136,6 +136,14 @@ Anwendung unterscheiden. Der Anwendungsname ist eine reine Anzeigeangabe des
 Clients; für die technische Zuordnung und Autorisierung bleibt die Client-ID
 maßgeblich.
 
+Wird der Schritt `authwithtoken` für ein gespeichertes Loxone-Token beim
+Neuaufbau einer Verbindung dreimal abgelehnt, erhält nur die betroffene Sitzung
+den Status **Adminbestätigung erforderlich**. Der Server unternimmt für diese
+Sitzung keine weitere Anmeldung, bis ein lokaler Administrator **Weiteren
+Token-Versuch erlauben** auswählt. Eine Quell-IP-Sperre des Miniservers wird
+separat gemeldet und erhöht diesen Zähler nicht. Andere Sitzungen bleiben nutzbar;
+eine erfolgreiche authentifizierte Verbindung löscht den Ablehnungszähler.
+
 Die lokalen Freigaben werden darunter nach `loxberry:read` und
 `loxberry:operate` getrennt angezeigt. Aktive Bindungen zeigen dieselbe
 Anwendung, Client-Instanz und gekürzte Loxone-Identität wie die zugehörige

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -130,6 +130,14 @@ application distinguishable. The application name is display-only metadata
 supplied by the client; the client ID remains authoritative for technical
 association and authorization.
 
+If the `authwithtoken` step rejects one stored Loxone token three times during a
+new connection, the affected session is marked **Admin confirmation required**.
+The server makes no further login attempt for that session until a local
+administrator chooses **Allow another token attempt**. A Miniserver source-IP
+lockout is reported separately and never increments this counter. This keeps
+other sessions usable and limits failed logins; a successful authenticated
+connection clears the rejection count.
+
 Local approvals are listed below separately for `loxberry:read` and
 `loxberry:operate`. Active bindings show the same application, client instance,
 and shortened Loxone identity as the related session. A binding itself does not

--- a/src/mcpserver/admin.py
+++ b/src/mcpserver/admin.py
@@ -490,6 +490,11 @@ def _sessions(snapshot: _AdminReadSnapshot | None = None) -> list[dict[str, Any]
                 "scopes": scopes,
                 "expires_at": record.get("expires_at"),
                 "revoked": bool(record.get("revoked", False)),
+                "loxone_token_confirmation_required": record.get(
+                    "loxone_token_confirmation_required"
+                )
+                is True
+                and record.get("loxone_token_rejection_kind") == "token_authentication",
                 "loxberry_read_eligible": pending_loxberry_read,
                 "loxberry_read_approved": read_binding in bindings if read_binding else False,
                 "loxberry_operate_eligible": pending_loxberry_operate,
@@ -499,6 +504,17 @@ def _sessions(snapshot: _AdminReadSnapshot | None = None) -> list[dict[str, Any]
             }
         )
     return sorted(result, key=lambda item: str(item["id"]))
+
+
+def _confirm_loxone_token(payload: object) -> dict[str, Any]:
+    from mcpserver.auth.loxone_health import LoxoneTokenHealthStore
+
+    family_id = payload.get("session_id") if isinstance(payload, dict) else None
+    if not isinstance(family_id, str) or len(family_id) > 128:
+        raise AdminError("session identifier is invalid")
+    if not LoxoneTokenHealthStore(_auth_store()).confirm_retry(family_id):
+        raise AdminError("Loxone token confirmation is unavailable")
+    return {"sessions": _sessions()}
 
 
 def _loxberry_binding(record: dict[str, Any], *, subject_key: bytes | None = None) -> str:
@@ -903,6 +919,8 @@ def dispatch(request: object) -> dict[str, Any]:
         if not isinstance(family_id, str) or len(family_id) > 128:
             raise AdminError("session identifier is invalid")
         return {"revoked": _revoke(family_id), "sessions": _sessions()}
+    if action == "confirm_loxone_token":
+        return _confirm_loxone_token(payload)
     if action == "revoke_all":
         return {"revoked": _revoke(None), "sessions": _sessions()}
     if action == "diagnostic":

--- a/src/mcpserver/auth/loxone_health.py
+++ b/src/mcpserver/auth/loxone_health.py
@@ -1,0 +1,90 @@
+"""Persisted, non-secret health state for one Loxone token binding."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mcpserver.auth.store import AtomicJsonAuthStore
+
+MAX_REJECTED_AUTHENTICATIONS = 3
+_REJECTION_KIND = "token_authentication"
+
+
+@dataclass(frozen=True, slots=True)
+class LoxoneTokenHealth:
+    """Sanitized state exposed to the local administrator."""
+
+    confirmation_required: bool
+    rejected_authentications: int
+
+
+class LoxoneTokenHealthStore:
+    """Fail closed per OAuth family after repeated rejected token authentication."""
+
+    def __init__(self, auth_store: AtomicJsonAuthStore) -> None:
+        self._auth_store = auth_store
+
+    def get(self, family_id: str) -> LoxoneTokenHealth:
+        document = self._auth_store.snapshot()
+        record = document.get("families", {}).get(family_id)
+        if not isinstance(record, dict):
+            return LoxoneTokenHealth(False, 0)
+        count = record.get("loxone_token_rejections", 0)
+        current = record.get("loxone_token_rejection_kind") == _REJECTION_KIND
+        return LoxoneTokenHealth(
+            current and record.get("loxone_token_confirmation_required") is True,
+            count if current and isinstance(count, int) and count >= 0 else 0,
+        )
+
+    def record_rejected_authentication(self, family_id: str) -> LoxoneTokenHealth:
+        def mutate(document: dict[str, object]) -> LoxoneTokenHealth:
+            families = document.get("families")
+            record = families.get(family_id) if isinstance(families, dict) else None
+            if not isinstance(record, dict) or record.get("revoked") is True:
+                return LoxoneTokenHealth(False, 0)
+            previous = (
+                record.get("loxone_token_rejections", 0)
+                if record.get("loxone_token_rejection_kind") == _REJECTION_KIND
+                else 0
+            )
+            count = previous if isinstance(previous, int) and previous >= 0 else 0
+            count = min(MAX_REJECTED_AUTHENTICATIONS, count + 1)
+            record["loxone_token_rejection_kind"] = _REJECTION_KIND
+            record["loxone_token_rejections"] = count
+            if count >= MAX_REJECTED_AUTHENTICATIONS:
+                record["loxone_token_confirmation_required"] = True
+            return LoxoneTokenHealth(
+                record.get("loxone_token_confirmation_required") is True,
+                count,
+            )
+
+        return self._auth_store.mutate(mutate)
+
+    def record_successful_authentication(self, family_id: str) -> None:
+        def mutate(document: dict[str, object]) -> None:
+            families = document.get("families")
+            record = families.get(family_id) if isinstance(families, dict) else None
+            if isinstance(record, dict):
+                record.pop("loxone_token_rejections", None)
+                record.pop("loxone_token_rejection_kind", None)
+                record.pop("loxone_token_confirmation_required", None)
+
+        self._auth_store.mutate(mutate)
+
+    def confirm_retry(self, family_id: str) -> bool:
+        def mutate(document: dict[str, object]) -> bool:
+            families = document.get("families")
+            record = families.get(family_id) if isinstance(families, dict) else None
+            if (
+                not isinstance(record, dict)
+                or record.get("revoked") is True
+                or record.get("loxone_token_confirmation_required") is not True
+                or record.get("loxone_token_rejection_kind") != _REJECTION_KIND
+            ):
+                return False
+            record.pop("loxone_token_rejections", None)
+            record.pop("loxone_token_rejection_kind", None)
+            record.pop("loxone_token_confirmation_required", None)
+            return True
+
+        return self._auth_store.mutate(mutate)

--- a/src/mcpserver/loxone/client.py
+++ b/src/mcpserver/loxone/client.py
@@ -15,7 +15,7 @@ from uuid import UUID
 
 import httpx
 from websockets.asyncio.client import ClientConnection, connect
-from websockets.exceptions import ConnectionClosedOK
+from websockets.exceptions import ConnectionClosed, ConnectionClosedOK
 from websockets.typing import Subprotocol
 
 from mcpserver.loxone.events import (
@@ -67,7 +67,15 @@ class LoxoneConnectionError(RuntimeError):
 
 
 class LoxoneCommandRejected(LoxoneConnectionError):
-    """Raised when an authenticated Miniserver rejects a control command."""
+    """Raised when the Miniserver rejects a command response."""
+
+    def __init__(self, message: str, *, response_code: str = "") -> None:
+        super().__init__(message)
+        self.response_code = response_code
+
+
+class LoxoneSourceIpBlocked(LoxoneConnectionError):
+    """The Miniserver temporarily blocked this source after failed logins."""
 
 
 class _WebSocketIdleTimeout(TimeoutError):
@@ -207,7 +215,7 @@ def _response_value(document: Mapping[str, Any]) -> Any:
         raise LoxoneConnectionError("Miniserver returned an invalid response")
     code = wrapper.get("Code", wrapper.get("code"))
     if str(code) != "200":
-        raise LoxoneCommandRejected("Miniserver rejected the request")
+        raise LoxoneCommandRejected("Miniserver rejected the request", response_code=str(code))
     return wrapper.get("value")
 
 
@@ -222,6 +230,13 @@ async def _receive_websocket(
             raw_header = await asyncio.wait_for(websocket.recv(), timeout=timeout_seconds)
         except TimeoutError:
             raise _WebSocketIdleTimeout from None
+        except ConnectionClosed as exc:
+            received = exc.rcvd
+            if received is not None and received.code == 4003:
+                raise LoxoneSourceIpBlocked(
+                    "Miniserver temporarily blocked this source IP"
+                ) from None
+            raise LoxoneConnectionError("Miniserver WebSocket connection closed") from None
         if not isinstance(raw_header, bytes):
             raise LoxoneProtocolError("Expected a binary WebSocket header")
         header = parse_header(raw_header, max_payload_bytes=max_payload_bytes)
@@ -563,11 +578,18 @@ class LoxoneWebSocketSession:
         if not self._secure_transport:
             session_key = self._encryptor.encrypted_session_key(self._public_key)
             await self._command(f"jdev/sys/keyexchange/{session_key}")
-        digest = await self._fresh_token_digest()
+        credential = await self._token_credential()
         await self._command(
-            f"authwithtoken/{digest}/{quote(self._token.username, safe='')}",
+            f"authwithtoken/{credential}/{quote(self._token.username, safe='')}",
             encrypted=not self._secure_transport,
         )
+
+    async def _token_credential(self) -> str:
+        if not self._secure_transport:
+            # Firmware 11.2 and newer accepts the JWT itself. On Gen. 1 the
+            # complete command remains protected by RSA/AES Command Encryption.
+            return self._token.value
+        return await self._fresh_token_digest()
 
     async def _fresh_token_digest(self) -> str:
         key = await self._command("jdev/sys/getkey", encrypted=not self._secure_transport)
@@ -612,10 +634,10 @@ class LoxoneWebSocketSession:
 
     async def refresh_token(self) -> None:
         """Rotate the in-memory JWT over the authenticated encrypted WebSocket."""
-        digest = await self._fresh_token_digest()
+        credential = await self._token_credential()
         user = quote(self._token.username, safe="")
         value = await self._command(
-            f"jdev/sys/refreshjwt/{digest}/{user}", encrypted=not self._secure_transport
+            f"jdev/sys/refreshjwt/{credential}/{user}", encrypted=not self._secure_transport
         )
         if not isinstance(value, Mapping):
             raise LoxoneConnectionError("Miniserver returned an invalid refreshed token")
@@ -628,11 +650,11 @@ class LoxoneWebSocketSession:
 
     async def kill_token(self) -> None:
         """Invalidate the current token over this authenticated session."""
-        digest = await self._fresh_token_digest()
+        credential = await self._token_credential()
         user = quote(self._token.username, safe="")
         try:
             await self._command(
-                f"jdev/sys/killtoken/{digest}/{user}", encrypted=not self._secure_transport
+                f"jdev/sys/killtoken/{credential}/{user}", encrypted=not self._secure_transport
             )
         except ConnectionClosedOK:
             # A Miniserver may close the authenticated connection immediately

--- a/src/mcpserver/loxone/runtime.py
+++ b/src/mcpserver/loxone/runtime.py
@@ -939,12 +939,16 @@ class LoxoneRuntime:
                     record.connected = False
                     self.cache.disconnect(access.family_id)
                     break
-        except Exception:
+        except Exception as exc:
+            _LOGGER.warning(
+                "component=state_cache outcome=event_stream_failed error_type=%s",
+                type(exc).__name__,
+            )
             record.connected = False
             self.cache.disconnect(access.family_id)
         finally:
             events.cancel()
-            with suppress(asyncio.CancelledError):
+            with suppress(asyncio.CancelledError, Exception):
                 await events
             await record.session.close()
 

--- a/src/mcpserver/loxone/runtime.py
+++ b/src/mcpserver/loxone/runtime.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from uuid import NAMESPACE_URL, uuid5
 
+from mcpserver.auth.loxone_health import LoxoneTokenHealthStore
 from mcpserver.auth.loxone_store import EncryptedLoxoneTokenStore, LoxoneTokenStoreError
 from mcpserver.auth.provider import CONTROL_SCOPE, HISTORY_SCOPE, READ_SCOPE, StoredAccessToken
 from mcpserver.loxone.cache import UserStateCache
@@ -22,6 +23,7 @@ from mcpserver.loxone.client import (
     LoxoneClient,
     LoxoneCommandRejected,
     LoxoneConnectionError,
+    LoxoneSourceIpBlocked,
     LoxoneToken,
     LoxoneWebSocketSession,
 )
@@ -49,6 +51,16 @@ _REFRESH_BEFORE_SECONDS = 24 * 60 * 60
 _MAX_LEGACY_STATISTIC_BYTES = 64 * 1024 * 1024
 _MAX_HISTORY_TIMESTAMP = 4_102_444_800
 _LOGGER = logging.getLogger(__name__)
+
+
+def _token_auth_rejection_message(response_code: str) -> str:
+    messages = {
+        "401": "Miniserver rejected token authentication as unauthorized",
+        "403": "Miniserver rejected token authentication due to insufficient rights",
+        "423": "Miniserver rejected token authentication because the user is disabled",
+        "429": "Miniserver rate-limited token authentication after failed logins",
+    }
+    return messages.get(response_code, "Miniserver token authentication was rejected")
 
 
 def _legacy_statistic_dates(start: int, end: int) -> tuple[str, ...]:
@@ -168,6 +180,7 @@ class LoxoneRuntime:
         endpoint: object,
         token_store: EncryptedLoxoneTokenStore,
         *,
+        token_health: LoxoneTokenHealthStore | None = None,
         timeout_seconds: float = 10.0,
         requests_per_minute: int = 60,
         max_parallel_calls: int = 4,
@@ -191,6 +204,7 @@ class LoxoneRuntime:
             raise TypeError("endpoint must be a MiniserverEndpoint")
         self.endpoint = endpoint
         self.token_store = token_store
+        self.token_health = token_health
         self.client = LoxoneClient(
             endpoint,
             client_uuid=uuid5(NAMESPACE_URL, "https://loxberry.local/plugins/mcpserver"),
@@ -783,6 +797,13 @@ class LoxoneRuntime:
         )
 
     async def _connect(self, access: StoredAccessToken) -> _ConnectionRecord:
+        if (
+            self.token_health is not None
+            and self.token_health.get(access.family_id).confirmation_required
+        ):
+            raise RuntimeUnavailable(
+                "Loxone token use requires local administrator confirmation before another login"
+            )
         try:
             token = self.token_store.get(access.family_id, access.miniserver_id, access.identity_id)
         except LoxoneTokenStoreError as exc:
@@ -791,9 +812,36 @@ class LoxoneRuntime:
             raise RuntimeUnavailable("Loxone authorization is unavailable")
         try:
             session = await self.client.open_session(token)
-            structure = await session.load_structure()
+        except LoxoneSourceIpBlocked as exc:
+            raise RuntimeUnavailable(
+                "Miniserver temporarily blocked this source IP after failed login attempts"
+            ) from exc
+        except LoxoneCommandRejected as exc:
+            if exc.response_code == "4003":
+                raise RuntimeUnavailable(
+                    "Miniserver temporarily blocked this source IP after failed login attempts"
+                ) from exc
+            health = (
+                self.token_health.record_rejected_authentication(access.family_id)
+                if self.token_health is not None
+                else None
+            )
+            if health is not None and health.confirmation_required:
+                _LOGGER.warning("component=auth outcome=token_confirmation_required")
+                raise RuntimeUnavailable(
+                    "Loxone token use requires local administrator confirmation "
+                    "before another login"
+                ) from exc
+            raise RuntimeUnavailable(_token_auth_rejection_message(exc.response_code)) from exc
         except LoxoneConnectionError as exc:
             raise RuntimeUnavailable("Miniserver connection failed") from exc
+        try:
+            structure = await session.load_structure()
+        except LoxoneConnectionError as exc:
+            await session.close()
+            raise RuntimeUnavailable("Miniserver structure access failed") from exc
+        if self.token_health is not None:
+            self.token_health.record_successful_authentication(access.family_id)
         allowed = _structure_state_uuids(structure)
         self.cache.begin_connection(access.family_id)
         placeholder = asyncio.create_task(asyncio.sleep(0))

--- a/src/mcpserver/server.py
+++ b/src/mcpserver/server.py
@@ -24,6 +24,7 @@ from starlette.responses import JSONResponse, Response
 from starlette.types import ASGIApp
 
 from mcpserver import __version__
+from mcpserver.auth.loxone_health import LoxoneTokenHealthStore
 from mcpserver.auth.loxone_store import EncryptedLoxoneTokenStore
 from mcpserver.auth.provider import (
     CONTROL_SCOPE,
@@ -403,6 +404,7 @@ def create_server(settings: ServerSettings) -> FastMCP:
             runtime = LoxoneRuntime(
                 settings.phase0_auth.loxone_endpoint,
                 loxone_store,
+                token_health=LoxoneTokenHealthStore(auth_store),
                 timeout_seconds=config.connection_timeout if config is not None else 10.0,
                 requests_per_minute=config.requests_per_minute if config is not None else 60,
                 max_parallel_calls=config.max_parallel_calls if config is not None else 4,

--- a/templates/index.html
+++ b/templates/index.html
@@ -240,14 +240,14 @@
     <div class="mcp-collapsible-content">
     <div id="session-list"><p><TMPL_VAR AJAX.WORKING></p>
     <TMPL_IF HAS_SESSIONS>
-      <div class="mcp-table-wrap"><table class="mcp-table"><thead><tr><th><TMPL_VAR SESSIONS.CLIENT></th><th><TMPL_VAR SESSIONS.INSTANCE></th><th><TMPL_VAR SESSIONS.IDENTITY></th><th><TMPL_VAR SESSIONS.SCOPES></th><th><TMPL_VAR SESSIONS.EXPIRES></th><th><TMPL_VAR SESSIONS.ACTION></th></tr></thead><tbody>
-      <TMPL_LOOP SESSIONS><tr data-session-id="<TMPL_VAR id ESCAPE=HTML>"><td><TMPL_IF client_name><TMPL_VAR client_name ESCAPE=HTML><TMPL_ELSE><TMPL_VAR SESSIONS.UNNAMED></TMPL_IF></td><td><code><TMPL_VAR client ESCAPE=HTML></code></td><td><code><TMPL_VAR identity ESCAPE=HTML></code></td><td><code><TMPL_VAR scopes ESCAPE=HTML></code></td><td><time class="mcp-expiry" data-expires-at="<TMPL_VAR expires_at ESCAPE=HTML>"><TMPL_VAR expires_display ESCAPE=HTML></time></td><td><TMPL_IF loxberry_read_eligible><TMPL_UNLESS loxberry_read_approved><form method="post" action="index.cgi" data-ajax="allow_loxberry_read"><input type="hidden" name="action" value="allow_loxberry_read"><input type="hidden" name="session_id" value="<TMPL_VAR id ESCAPE=HTML>"><button class="lb-button" type="submit"><TMPL_VAR ACTION.ALLOW_LOXBERRY_READ></button></form></TMPL_UNLESS></TMPL_IF><TMPL_IF loxberry_operate_eligible><TMPL_UNLESS loxberry_operate_approved><form method="post" action="index.cgi" data-ajax="allow_loxberry_operate"><input type="hidden" name="action" value="allow_loxberry_operate"><input type="hidden" name="session_id" value="<TMPL_VAR id ESCAPE=HTML>"><button class="lb-button" type="submit"><TMPL_VAR ACTION.ALLOW_LOXBERRY_OPERATE></button></form></TMPL_UNLESS></TMPL_IF><form method="post" action="index.cgi" data-ajax="revoke_session"><input type="hidden" name="action" value="revoke_session"><input type="hidden" name="id" value="<TMPL_VAR id ESCAPE=HTML>"><button class="lb-button" type="submit"><TMPL_VAR ACTION.REVOKE></button></form></td></tr></TMPL_LOOP>
+      <div class="mcp-table-wrap"><table class="mcp-table"><thead><tr><th><TMPL_VAR SESSIONS.CLIENT></th><th><TMPL_VAR SESSIONS.INSTANCE></th><th><TMPL_VAR SESSIONS.IDENTITY></th><th><TMPL_VAR SESSIONS.TOKEN></th><th><TMPL_VAR SESSIONS.SCOPES></th><th><TMPL_VAR SESSIONS.EXPIRES></th><th><TMPL_VAR SESSIONS.ACTION></th></tr></thead><tbody>
+      <TMPL_LOOP SESSIONS><tr data-session-id="<TMPL_VAR id ESCAPE=HTML>"><td><TMPL_IF client_name><TMPL_VAR client_name ESCAPE=HTML><TMPL_ELSE><TMPL_VAR SESSIONS.UNNAMED></TMPL_IF></td><td><code><TMPL_VAR client ESCAPE=HTML></code></td><td><code><TMPL_VAR identity ESCAPE=HTML></code></td><td><TMPL_IF loxone_token_confirmation_required><TMPL_VAR SESSIONS.TOKEN_CONFIRMATION_REQUIRED><TMPL_ELSE><TMPL_VAR SESSIONS.TOKEN_ACTIVE></TMPL_IF></td><td><code><TMPL_VAR scopes ESCAPE=HTML></code></td><td><time class="mcp-expiry" data-expires-at="<TMPL_VAR expires_at ESCAPE=HTML>"><TMPL_VAR expires_display ESCAPE=HTML></time></td><td><TMPL_IF loxone_token_confirmation_required><form method="post" action="index.cgi" data-ajax="confirm_loxone_token"><input type="hidden" name="action" value="confirm_loxone_token"><input type="hidden" name="session_id" value="<TMPL_VAR id ESCAPE=HTML>"><button class="lb-button" type="submit"><TMPL_VAR ACTION.CONFIRM_LOXONE_TOKEN></button></form></TMPL_IF><TMPL_IF loxberry_read_eligible><TMPL_UNLESS loxberry_read_approved><form method="post" action="index.cgi" data-ajax="allow_loxberry_read"><input type="hidden" name="action" value="allow_loxberry_read"><input type="hidden" name="session_id" value="<TMPL_VAR id ESCAPE=HTML>"><button class="lb-button" type="submit"><TMPL_VAR ACTION.ALLOW_LOXBERRY_READ></button></form></TMPL_UNLESS></TMPL_IF><TMPL_IF loxberry_operate_eligible><TMPL_UNLESS loxberry_operate_approved><form method="post" action="index.cgi" data-ajax="allow_loxberry_operate"><input type="hidden" name="action" value="allow_loxberry_operate"><input type="hidden" name="session_id" value="<TMPL_VAR id ESCAPE=HTML>"><button class="lb-button" type="submit"><TMPL_VAR ACTION.ALLOW_LOXBERRY_OPERATE></button></form></TMPL_UNLESS></TMPL_IF><form method="post" action="index.cgi" data-ajax="revoke_session"><input type="hidden" name="action" value="revoke_session"><input type="hidden" name="id" value="<TMPL_VAR id ESCAPE=HTML>"><button class="lb-button" type="submit"><TMPL_VAR ACTION.REVOKE></button></form></td></tr></TMPL_LOOP>
       </tbody></table></div>
       <form method="post" action="index.cgi" data-ajax="revoke_all"><input type="hidden" name="action" value="revoke_all"><button class="lb-button" type="submit"><TMPL_VAR ACTION.REVOKE_ALL></button></form>
     <TMPL_ELSE></TMPL_IF>
     </div>
     <template id="session-table-template">
-      <div class="mcp-table-wrap"><table class="mcp-table"><thead><tr><th><TMPL_VAR SESSIONS.CLIENT></th><th><TMPL_VAR SESSIONS.INSTANCE></th><th><TMPL_VAR SESSIONS.IDENTITY></th><th><TMPL_VAR SESSIONS.SCOPES></th><th><TMPL_VAR SESSIONS.EXPIRES></th><th><TMPL_VAR SESSIONS.ACTION></th></tr></thead><tbody></tbody></table></div>
+      <div class="mcp-table-wrap"><table class="mcp-table"><thead><tr><th><TMPL_VAR SESSIONS.CLIENT></th><th><TMPL_VAR SESSIONS.INSTANCE></th><th><TMPL_VAR SESSIONS.IDENTITY></th><th><TMPL_VAR SESSIONS.TOKEN></th><th><TMPL_VAR SESSIONS.SCOPES></th><th><TMPL_VAR SESSIONS.EXPIRES></th><th><TMPL_VAR SESSIONS.ACTION></th></tr></thead><tbody></tbody></table></div>
       <form method="post" action="index.cgi" data-ajax="revoke_all"><input type="hidden" name="action" value="revoke_all"><button class="lb-button" type="submit"><TMPL_VAR ACTION.REVOKE_ALL></button></form>
     </template>
     <section id="loxberry-binding-section" data-unnamed-label="<TMPL_VAR SESSIONS.UNNAMED ESCAPE=HTML>" data-no-active-label="<TMPL_VAR SESSIONS.NO_ACTIVE_SESSION ESCAPE=HTML>" data-no-identity-label="<TMPL_VAR SESSIONS.NO_IDENTITY ESCAPE=HTML>" <TMPL_UNLESS LOXBERRY_BINDINGS>hidden</TMPL_UNLESS>>
@@ -668,12 +668,13 @@
     session.scopes || '', String(session.expires_at ?? ''),
     Boolean(session.loxberry_read_eligible), Boolean(session.loxberry_read_approved),
     Boolean(session.loxberry_operate_eligible), Boolean(session.loxberry_operate_approved),
+    Boolean(session.loxone_token_confirmation_required),
   ]);
   const createSessionRow = (session) => {
     const row = document.createElement('tr');
     row.dataset.sessionId = String(session.id);
     row.dataset.fingerprint = sessionFingerprint(session);
-    const values = [session.client_name || sessionsSection.dataset.unnamedLabel, session.client, session.identity, session.scopes];
+    const values = [session.client_name || sessionsSection.dataset.unnamedLabel, session.client, session.identity];
     values.forEach((value, index) => {
       const cell = document.createElement('td');
       const content = index === 0 ? document.createTextNode(String(value ?? '')) : document.createElement('code');
@@ -681,6 +682,16 @@
       cell.append(content);
       row.append(cell);
     });
+    const tokenCell = document.createElement('td');
+    tokenCell.textContent = session.loxone_token_confirmation_required
+      ? '<TMPL_VAR SESSIONS.TOKEN_CONFIRMATION_REQUIRED ESCAPE=JS>'
+      : '<TMPL_VAR SESSIONS.TOKEN_ACTIVE ESCAPE=JS>';
+    row.append(tokenCell);
+    const scopesCell = document.createElement('td');
+    const scopes = document.createElement('code');
+    scopes.textContent = String(session.scopes || '');
+    scopesCell.append(scopes);
+    row.append(scopesCell);
     const expiryCell = document.createElement('td');
     const expiry = document.createElement('time');
     expiry.className = 'mcp-expiry';
@@ -688,6 +699,25 @@
     expiryCell.append(expiry);
     row.append(expiryCell);
     const actionCell = document.createElement('td');
+    if (session.loxone_token_confirmation_required) {
+      const confirmForm = document.createElement('form');
+      confirmForm.method = 'post';
+      confirmForm.action = 'index.cgi';
+      confirmForm.dataset.ajax = 'confirm_loxone_token';
+      for (const [name, value] of [['action', 'confirm_loxone_token'], ['session_id', session.id]]) {
+        const input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = name;
+        input.value = String(value || '');
+        confirmForm.append(input);
+      }
+      const confirmButton = document.createElement('button');
+      confirmButton.className = 'lb-button';
+      confirmButton.type = 'submit';
+      confirmButton.textContent = '<TMPL_VAR ACTION.CONFIRM_LOXONE_TOKEN ESCAPE=JS>';
+      confirmForm.append(confirmButton);
+      actionCell.append(confirmForm);
+    }
     if (session.loxberry_read_eligible && !session.loxberry_read_approved) {
       const allowForm = document.createElement('form');
       allowForm.method = 'post';
@@ -904,7 +934,7 @@
         servicePollTimer = null;
         renderService(lastService);
       }
-      if (['revoke_session', 'revoke_all', 'allow_loxberry_read', 'revoke_loxberry_read', 'allow_loxberry_operate', 'revoke_loxberry_operate'].includes(form.dataset.ajax)) {
+      if (['revoke_session', 'revoke_all', 'confirm_loxone_token', 'allow_loxberry_read', 'revoke_loxberry_read', 'allow_loxberry_operate', 'revoke_loxberry_operate'].includes(form.dataset.ajax)) {
         sessionActionRunning = true;
         window.clearTimeout(sessionPollTimer);
         sessionPollTimer = null;
@@ -957,7 +987,7 @@
           renderService(lastService);
           scheduleServicePoll(0);
         }
-        if (['revoke_session', 'revoke_all', 'allow_loxberry_read', 'revoke_loxberry_read', 'allow_loxberry_operate', 'revoke_loxberry_operate'].includes(form.dataset.ajax)) {
+        if (['revoke_session', 'revoke_all', 'confirm_loxone_token', 'allow_loxberry_read', 'revoke_loxberry_read', 'allow_loxberry_operate', 'revoke_loxberry_operate'].includes(form.dataset.ajax)) {
           sessionActionRunning = false;
           scheduleSessionPoll();
         }

--- a/templates/lang/language_de.ini
+++ b/templates/lang/language_de.ini
@@ -84,6 +84,9 @@ ERROR_ACTION=Die Dienstaktion konnte nicht ausgeführt werden.
 [SESSIONS]
 TITLE=Clients und Sitzungen
 CLIENT=Anwendung
+TOKEN=Loxone-Token
+TOKEN_ACTIVE=Aktiv
+TOKEN_CONFIRMATION_REQUIRED=Adminbestätigung erforderlich
 INSTANCE=Client-Instanz
 UNNAMED=Unbenannter OAuth-Client
 IDENTITY=Identität
@@ -162,6 +165,7 @@ ERROR_FAILED=Die Zertifikatsneuausstellung konnte nicht gestartet werden.
 [ACTION]
 SAVE=Speichern und anwenden
 TEST=Verbindung testen
+CONFIRM_LOXONE_TOKEN=Weiteren Token-Versuch erlauben
 REFRESH=Status aktualisieren
 START=Starten
 STOP=Stoppen

--- a/templates/lang/language_en.ini
+++ b/templates/lang/language_en.ini
@@ -84,6 +84,9 @@ ERROR_ACTION=The service action could not be completed.
 [SESSIONS]
 TITLE=Clients and sessions
 CLIENT=Application
+TOKEN=Loxone token
+TOKEN_ACTIVE=Active
+TOKEN_CONFIRMATION_REQUIRED=Admin confirmation required
 INSTANCE=Client instance
 UNNAMED=Unnamed OAuth client
 IDENTITY=Identity
@@ -162,6 +165,7 @@ ERROR_FAILED=The certificate reissue could not be started.
 [ACTION]
 SAVE=Save and apply
 TEST=Test connection
+CONFIRM_LOXONE_TOKEN=Allow another token attempt
 REFRESH=Refresh status
 START=Start
 STOP=Stop

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -881,6 +881,36 @@ def test_session_list_excludes_revoked_families(
     assert result["sessions"][0]["client"] == "active-clien"
 
 
+def test_admin_can_confirm_a_faulty_loxone_token_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    auth_path = (tmp_path / "data" / "auth" / "sessions.json").resolve()
+    store = AtomicJsonAuthStore(auth_path)
+    store.mutate(
+        lambda document: document["families"].update(
+            {
+                "family": {
+                    "client_id": "client",
+                    "identity_id": "identity",
+                    "revoked": False,
+                    "loxone_token_confirmation_required": True,
+                    "loxone_token_rejections": 3,
+                    "loxone_token_rejection_kind": "token_authentication",
+                }
+            }
+        )
+    )
+    monkeypatch.setenv("MCPSERVER_AUTH_STORE", str(auth_path))
+
+    result = dispatch({"action": "confirm_loxone_token", "payload": {"session_id": "family"}})
+
+    assert result["sessions"][0]["loxone_token_confirmation_required"] is False
+    record = store.snapshot()["families"]["family"]
+    assert "loxone_token_confirmation_required" not in record
+    assert "loxone_token_rejections" not in record
+    assert "loxone_token_rejection_kind" not in record
+
+
 def test_session_list_uses_empty_name_for_missing_or_invalid_client_metadata(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_loxone_client.py
+++ b/tests/test_loxone_client.py
@@ -8,18 +8,21 @@ import httpx
 import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
-from websockets.exceptions import ConnectionClosedOK
+from websockets.exceptions import ConnectionClosedError, ConnectionClosedOK
 from websockets.frames import Close
 
 from mcpserver.loxone.client import (
     LoxoneClient,
+    LoxoneCommandRejected,
     LoxoneConnectionError,
+    LoxoneSourceIpBlocked,
     LoxoneToken,
     LoxoneWebSocketSession,
     MiniserverEndpoint,
     _close_websocket,
     _loxone_uuid,
     _receive_websocket,
+    _response_value,
 )
 from mcpserver.loxone.events import MessageHeader, MessageType
 from mcpserver.loxone.security import token_hmac
@@ -433,6 +436,26 @@ async def test_websocket_receive_returns_complete_payload_without_waiting_again(
 
 
 @pytest.mark.asyncio
+async def test_websocket_receive_classifies_miniserver_source_ip_block() -> None:
+    class FakeWebSocket:
+        async def recv(self) -> bytes:
+            raise ConnectionClosedError(Close(4003, "blocked"), None)
+
+    with pytest.raises(LoxoneSourceIpBlocked):
+        await _receive_websocket(
+            cast(Any, FakeWebSocket()), timeout_seconds=0.1, max_payload_bytes=100
+        )
+
+
+def test_command_rejection_retains_only_the_sanitized_status_code() -> None:
+    with pytest.raises(LoxoneCommandRejected) as rejected:
+        _response_value({"LL": {"Code": "4003", "value": "private detail"}})
+
+    assert rejected.value.response_code == "4003"
+    assert "private detail" not in str(rejected.value)
+
+
+@pytest.mark.asyncio
 async def test_websocket_receive_skips_estimated_header() -> None:
     class FakeWebSocket:
         def __init__(self) -> None:
@@ -804,7 +827,7 @@ async def test_token_revocation_uses_encrypted_websocket_and_destroys_token(
 
 
 @pytest.mark.asyncio
-async def test_session_authentication_requests_a_fresh_token_hash_key(
+async def test_gen1_session_authentication_uses_encrypted_plaintext_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
@@ -836,14 +859,44 @@ async def test_session_authentication_requests_a_fresh_token_hash_key(
 
     await session.authenticate()
 
-    expected = token_hmac("jwt-secret", "aabbccdd", "SHA256")
     assert commands[0][0].startswith("jdev/sys/keyexchange/")
-    assert commands[1] == ("jdev/sys/getkey", True)
-    assert commands[2] == (f"authwithtoken/{expected}/reader", True)
+    assert commands[1] == ("authwithtoken/jwt-secret/reader", True)
 
 
 @pytest.mark.asyncio
-async def test_authenticated_session_kills_token_with_a_fresh_key(
+async def test_gen2_session_authentication_retains_negotiated_token_hash_algorithm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = LoxoneToken("jwt-secret", "reader", "expired-key", "SHA256", 100)
+    session = LoxoneWebSocketSession(
+        cast(Any, object()),
+        public_key="",
+        token=token,
+        timeout_seconds=1,
+        max_payload_bytes=100,
+        secure_transport=True,
+    )
+    commands: list[tuple[str, bool]] = []
+
+    async def fake_command(command: str, *, encrypted: bool = False) -> object:
+        commands.append((command, encrypted))
+        if command == "jdev/sys/getkey":
+            return "aabbccdd"
+        return "OK"
+
+    monkeypatch.setattr(session, "_command", fake_command)
+
+    await session.authenticate()
+
+    expected = token_hmac("jwt-secret", "aabbccdd", "SHA256")
+    assert commands == [
+        ("jdev/sys/getkey", False),
+        (f"authwithtoken/{expected}/reader", False),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_gen1_authenticated_session_kills_plaintext_token_inside_encryption(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     token = LoxoneToken("jwt-secret", "reader", "expired-key", "SHA256", 100)
@@ -853,6 +906,32 @@ async def test_authenticated_session_kills_token_with_a_fresh_key(
         token=token,
         timeout_seconds=1,
         max_payload_bytes=100,
+    )
+    commands: list[tuple[str, bool]] = []
+
+    async def fake_command(command: str, *, encrypted: bool = False) -> object:
+        commands.append((command, encrypted))
+        return "OK"
+
+    monkeypatch.setattr(session, "_command", fake_command)
+
+    await session.kill_token()
+
+    assert commands == [("jdev/sys/killtoken/jwt-secret/reader", True)]
+
+
+@pytest.mark.asyncio
+async def test_gen2_authenticated_session_kills_token_with_dynamic_hash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = LoxoneToken("jwt-secret", "reader", "expired-key", "SHA256", 100)
+    session = LoxoneWebSocketSession(
+        cast(Any, object()),
+        public_key="",
+        token=token,
+        timeout_seconds=1,
+        max_payload_bytes=100,
+        secure_transport=True,
     )
     commands: list[tuple[str, bool]] = []
 
@@ -868,8 +947,8 @@ async def test_authenticated_session_kills_token_with_a_fresh_key(
 
     expected = token_hmac("jwt-secret", "aabbccdd", "SHA256")
     assert commands == [
-        ("jdev/sys/getkey", True),
-        (f"jdev/sys/killtoken/{expected}/reader", True),
+        ("jdev/sys/getkey", False),
+        (f"jdev/sys/killtoken/{expected}/reader", False),
     ]
 
 
@@ -957,7 +1036,7 @@ async def test_structure_version_uses_authenticated_bounded_command(
 
 
 @pytest.mark.asyncio
-async def test_refresh_rotates_in_memory_token_with_dynamic_hash(
+async def test_gen1_refresh_rotates_in_memory_plaintext_token_inside_encryption(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     token = LoxoneToken("old-secret", "reader", "00112233", "SHA256", 100)
@@ -970,11 +1049,7 @@ async def test_refresh_rotates_in_memory_token_with_dynamic_hash(
     )
 
     async def fake_command(command: str, *, encrypted: bool = False) -> object:
-        if command == "jdev/sys/getkey":
-            assert encrypted is True
-            return "aabbccdd"
-        expected = token_hmac("old-secret", "aabbccdd", "SHA256")
-        assert command == f"jdev/sys/refreshjwt/{expected}/reader"
+        assert command == "jdev/sys/refreshjwt/old-secret/reader"
         assert encrypted is True
         return {"token": "new-secret", "validUntil": 200}
 
@@ -985,6 +1060,37 @@ async def test_refresh_rotates_in_memory_token_with_dynamic_hash(
     assert token.value == "new-secret"
     assert token.valid_until == 200
     assert "new-secret" not in repr(token)
+
+
+@pytest.mark.asyncio
+async def test_gen2_refresh_rotates_in_memory_token_with_dynamic_hash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = LoxoneToken("old-secret", "reader", "00112233", "SHA256", 100)
+    session = LoxoneWebSocketSession(
+        cast(Any, object()),
+        public_key="",
+        token=token,
+        timeout_seconds=1,
+        max_payload_bytes=100,
+        secure_transport=True,
+    )
+
+    async def fake_command(command: str, *, encrypted: bool = False) -> object:
+        if command == "jdev/sys/getkey":
+            assert encrypted is False
+            return "aabbccdd"
+        expected = token_hmac("old-secret", "aabbccdd", "SHA256")
+        assert command == f"jdev/sys/refreshjwt/{expected}/reader"
+        assert encrypted is False
+        return {"token": "new-secret", "validUntil": 200}
+
+    monkeypatch.setattr(session, "_command", fake_command)
+
+    await session.refresh_token()
+
+    assert token.value == "new-secret"
+    assert token.valid_until == 200
 
 
 @pytest.mark.asyncio

--- a/tests/test_loxone_health.py
+++ b/tests/test_loxone_health.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mcpserver.auth.loxone_health import (
+    MAX_REJECTED_AUTHENTICATIONS,
+    LoxoneTokenHealthStore,
+)
+from mcpserver.auth.provider import READ_SCOPE, StoredAccessToken
+from mcpserver.auth.store import AtomicJsonAuthStore
+from mcpserver.loxone.client import LoxoneCommandRejected, LoxoneToken, MiniserverEndpoint
+from mcpserver.loxone.runtime import LoxoneRuntime, RuntimeUnavailable
+
+
+def _store(tmp_path: Path) -> AtomicJsonAuthStore:
+    store = AtomicJsonAuthStore((tmp_path / "auth" / "sessions.json").resolve())
+    store.mutate(lambda document: document["families"].update({"family": {"revoked": False}}))
+    return store
+
+
+def test_rejected_authentication_requires_confirmation_and_success_resets(tmp_path: Path) -> None:
+    health = LoxoneTokenHealthStore(_store(tmp_path))
+
+    for expected in range(1, MAX_REJECTED_AUTHENTICATIONS):
+        result = health.record_rejected_authentication("family")
+        assert result.rejected_authentications == expected
+        assert result.confirmation_required is False
+
+    result = health.record_rejected_authentication("family")
+    assert result.rejected_authentications == MAX_REJECTED_AUTHENTICATIONS
+    assert result.confirmation_required is True
+    assert health.confirm_retry("family") is True
+    assert health.get("family").confirmation_required is False
+
+    health.record_rejected_authentication("family")
+    health.record_successful_authentication("family")
+    assert health.get("family").rejected_authentications == 0
+
+
+def test_confirmation_requires_a_blocked_active_family(tmp_path: Path) -> None:
+    health = LoxoneTokenHealthStore(_store(tmp_path))
+
+    assert health.confirm_retry("family") is False
+    assert health.confirm_retry("missing") is False
+
+
+def test_legacy_unclassified_rejections_are_ignored(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.mutate(
+        lambda document: document["families"]["family"].update(
+            {
+                "loxone_token_confirmation_required": True,
+                "loxone_token_rejections": MAX_REJECTED_AUTHENTICATIONS,
+            }
+        )
+    )
+
+    health = LoxoneTokenHealthStore(store)
+
+    assert health.get("family").confirmation_required is False
+    assert health.get("family").rejected_authentications == 0
+
+    result = health.record_rejected_authentication("family")
+    assert result.rejected_authentications == 1
+
+
+@pytest.mark.asyncio
+async def test_runtime_stops_token_login_attempts_until_admin_confirms(tmp_path: Path) -> None:
+    health = LoxoneTokenHealthStore(_store(tmp_path))
+
+    class TokenStore:
+        def get(self, *_args: object) -> LoxoneToken:
+            return LoxoneToken("jwt", "user", "key", "SHA256", 2_000_000_000)
+
+    class RejectingClient:
+        attempts = 0
+
+        async def open_session(self, _token: LoxoneToken) -> object:
+            self.attempts += 1
+            raise LoxoneCommandRejected("rejected")
+
+    access = StoredAccessToken(
+        token="opaque",
+        client_id="client",
+        scopes=[READ_SCOPE],
+        expires_at=2_000_000_000,
+        resource="https://loxberry.local/plugins/mcpserver/mcp",
+        subject="identity",
+        claims={},
+        family_id="family",
+        identity_id="identity",
+        miniserver_id="miniserver",
+    )
+    runtime = LoxoneRuntime(
+        MiniserverEndpoint.parse_gen1("http://192.168.1.10"),
+        TokenStore(),  # type: ignore[arg-type]
+        token_health=health,
+    )
+    client = RejectingClient()
+    runtime.client = client  # type: ignore[assignment]
+
+    for _ in range(MAX_REJECTED_AUTHENTICATIONS):
+        with pytest.raises(RuntimeUnavailable):
+            await runtime.snapshot(access)
+    assert client.attempts == MAX_REJECTED_AUTHENTICATIONS
+
+    with pytest.raises(RuntimeUnavailable, match="administrator confirmation"):
+        await runtime.snapshot(access)
+    assert client.attempts == MAX_REJECTED_AUTHENTICATIONS
+
+    assert health.confirm_retry("family") is True
+    with pytest.raises(RuntimeUnavailable):
+        await runtime.snapshot(access)
+    assert client.attempts == MAX_REJECTED_AUTHENTICATIONS + 1
+
+
+@pytest.mark.asyncio
+async def test_runtime_does_not_count_a_miniserver_source_ip_block(tmp_path: Path) -> None:
+    health = LoxoneTokenHealthStore(_store(tmp_path))
+
+    class TokenStore:
+        def get(self, *_args: object) -> LoxoneToken:
+            return LoxoneToken("jwt", "user", "key", "SHA256", 2_000_000_000)
+
+    class BlockedClient:
+        async def open_session(self, _token: LoxoneToken) -> object:
+            raise LoxoneCommandRejected("rejected", response_code="4003")
+
+    access = StoredAccessToken(
+        token="opaque",
+        client_id="client",
+        scopes=[READ_SCOPE],
+        expires_at=2_000_000_000,
+        resource="https://loxberry.local/plugins/mcpserver/mcp",
+        subject="identity",
+        claims={},
+        family_id="family",
+        identity_id="identity",
+        miniserver_id="miniserver",
+    )
+    runtime = LoxoneRuntime(
+        MiniserverEndpoint.parse_gen1("http://192.168.1.10"),
+        TokenStore(),  # type: ignore[arg-type]
+        token_health=health,
+    )
+    runtime.client = BlockedClient()  # type: ignore[assignment]
+
+    with pytest.raises(RuntimeUnavailable, match="source IP"):
+        await runtime.snapshot(access)
+
+    assert health.get("family").rejected_authentications == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("response_code", "message"),
+    [
+        ("401", "unauthorized"),
+        ("403", "insufficient rights"),
+        ("423", "user is disabled"),
+        ("429", "rate-limited"),
+        ("500", "token authentication was rejected"),
+    ],
+)
+async def test_runtime_reports_sanitized_token_rejection_reason(
+    tmp_path: Path, response_code: str, message: str
+) -> None:
+    class TokenStore:
+        def get(self, *_args: object) -> LoxoneToken:
+            return LoxoneToken("jwt", "user", "key", "SHA256", 2_000_000_000)
+
+    class RejectingClient:
+        async def open_session(self, _token: LoxoneToken) -> object:
+            raise LoxoneCommandRejected("rejected", response_code=response_code)
+
+    access = StoredAccessToken(
+        token="opaque",
+        client_id="client",
+        scopes=[READ_SCOPE],
+        expires_at=2_000_000_000,
+        resource="https://loxberry.local/plugins/mcpserver/mcp",
+        subject="identity",
+        claims={},
+        family_id="family",
+        identity_id="identity",
+        miniserver_id="miniserver",
+    )
+    runtime = LoxoneRuntime(
+        MiniserverEndpoint.parse_gen1("http://192.168.1.10"),
+        TokenStore(),  # type: ignore[arg-type]
+    )
+    runtime.client = RejectingClient()  # type: ignore[assignment]
+
+    with pytest.raises(RuntimeUnavailable, match=message):
+        await runtime.snapshot(access)

--- a/tests/test_loxone_runtime.py
+++ b/tests/test_loxone_runtime.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import defaultdict
+from types import SimpleNamespace
 
 import pytest
 
@@ -189,6 +190,37 @@ async def test_runtime_close_disconnects_all_records_without_revoking_tokens() -
     await runtime.close()
 
     assert closed == ["one", "two"]
+
+
+@pytest.mark.asyncio
+async def test_event_stream_failure_is_logged_without_payload_details(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    runtime = object.__new__(LoxoneRuntime)
+    runtime.cache = UserStateCache()
+    runtime.cache.begin_connection("family")
+
+    async def failed_pump(_subject: str, _record: _ConnectionRecord) -> None:
+        raise LoxoneConnectionError("private endpoint detail")
+
+    runtime._pump_events = failed_pump  # type: ignore[method-assign]
+    task = asyncio.create_task(asyncio.sleep(60))
+    record = _ConnectionRecord(_structure("current"), frozenset(), _Session(), task)
+
+    with caplog.at_level("WARNING", logger="mcpserver.loxone.runtime"):
+        await runtime._maintain(_access(), SimpleNamespace(valid_until=2_000_000_000), record)
+
+    assert record.connected is False
+    assert runtime.cache.get("family", "state-1").freshness.name == "UNAVAILABLE"
+    assert (
+        "component=state_cache outcome=event_stream_failed error_type=LoxoneConnectionError"
+        in caplog.text
+    )
+    assert "private endpoint detail" not in caplog.text
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
 
 
 @pytest.mark.asyncio

--- a/webfrontend/htmlauth/index.cgi
+++ b/webfrontend/htmlauth/index.cgi
@@ -398,6 +398,10 @@ if ($action ne '') {
         $result = admin_call('revoke_session', {id => ($q->{id} // '')});
         admin_log($result->{ok} ? 'info' : 'warning',
             'action=revoke_session outcome=' . ($result->{ok} ? 'completed' : 'rejected'));
+    } elsif ($action eq 'confirm_loxone_token') {
+        $result = admin_call('confirm_loxone_token', {session_id => ($q->{session_id} // '')});
+        admin_log($result->{ok} ? 'info' : 'warning',
+            'action=confirm_loxone_token outcome=' . ($result->{ok} ? 'completed' : 'rejected'));
     } elsif ($action eq 'allow_loxberry_read') {
         $result = admin_call('allow_loxberry_read', {session_id => ($q->{session_id} // '')});
         admin_log($result->{ok} ? 'info' : 'warning',


### PR DESCRIPTION
## Summary

- stop repeated `authwithtoken` attempts after three genuine token rejections until a local administrator confirms another bounded attempt
- distinguish Miniserver source-IP lockouts and sanitized authentication status reasons from invalid-token failures
- restore Gen. 1 authentication, refresh, and revocation by sending the firmware-supported JWT only inside RSA/AES Command Encryption
- keep a failed Loxone binary-state stream fail-closed, log only its sanitized exception class, and consume its finished task during cleanup
- add synchronized acceptance evidence, changelog, and regression coverage

## Root cause

The Explorer could acquire a fresh, valid app JWT, but the following Gen. 1 `authwithtoken` request was rejected with 401. Firmware 11.2 and newer supports the JWT credential directly; on Gen. 1 the complete command remains protected by RSA/AES Command Encryption.

A failed state-event task was logged and disconnected correctly, but was raised again during cleanup. The runtime now consumes that completed task after recording only its error class. On the authorized fixture the stream remains connected but does not provide initial state tables, so no additional control command was sent.

## Validation

- Python 3.13 Full gate: format, Ruff, MyPy, and 563 tests passed
- focused runtime regression: stream failure is sanitized, marks the cache unavailable, and does not re-raise
- two focused Loxberry-Test deployments passed with retained backups and healthy service
- direct MCP structure discovery confirmed the three eligible MCP-Test climate/ventilation controls; confirmation states remained unknown, so no write was issued
