### PR TITLE
Prepare 0.4.0-alpha.12 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ extracted from the matching version heading.
 - Enable LoxBerry Plugin Manager automatic update discovery for stable releases
   and explicitly opted-in prereleases.
 
+## 0.4.0-alpha.12 - 2026-08-14
+
+- Prevent concurrent local LoxBerry read or operate binding changes from
+  overwriting one another. The Admin UI keeps parallel session actions pending
+  until it refreshes one consistent server state.
+- Add a reproducible Windows development-environment setup and keep temporary
+  test data inside the project data area.
+
 ## 0.4.0-alpha.11 - 2026-08-14
 
 - Add `loxberry_list_service_events`: a bounded, read-only MCP diagnostic feed

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ Für jeden Assistenten sollte ein eigener Loxone-Benutzer mit den minimal erford
 ## Projektstatus
 
 Phase 1 bis Phase 3 sind abgenommen. Der vorbereitete Phase-4-Pre-Release
-`0.4.0-alpha.11` ergänzt die verzögerungsfreie Admin-Ansicht und eine robuste,
-asynchrone Loxone-Token-Widerrufswiederholung sowie eine reparierte MCP-Tool-
-Explorer-Anmeldung über freigegebene HTTPS-IP- und Host-Aliase. Es enthält außerdem die begrenzten
+`0.4.0-alpha.12` schützt parallele Widerrufe lokaler LoxBerry-Freigaben vor
+verlorenen Konfigurationsänderungen und ergänzt eine reproduzierbare
+Windows-Entwicklungsumgebung. Es enthält außerdem die begrenzten
 LoxAPP3-Modelle für Klima, Lüftung, Status, Energie und globale Metadaten sowie
 nur dokumentierte temporäre Overrides. Die vorherige `0.4.0-alpha.8` blockiert die MCP-Tool-Explorer-Anmeldung auf HTTP mit einem
 Link zur gleichen IP-Adresse oder demselben Hostnamen über HTTPS sowie die versionsgeprüfte, begrenzte single-flight
@@ -45,7 +45,8 @@ standardmäßig deaktiviert, akzeptiert ausschließlich typabhängige dokumentie
 Aktionen und benötigt den separat bestätigten Scope `loxone:control`. Freie
 Kommandos, Namens- und Sammelziele sind ausgeschlossen. Die sechs stabilen
 lesenden Tools und bestehende Read-only-Sitzungen bleiben kompatibel. Die neuen
-Phase-4-Pfade sind automatisiert geprüft, aber noch nicht auf Hardware abgenommen.
+Phase-4-Pfade sind automatisiert geprüft; die abgegrenzten Hardware-Nachweise
+stehen im Phase-4-Abnahmebericht.
 
 Bestätigte Kombinationen, Nachweise und bekannte Clientgrenzen stehen in der
 [Support-Matrix](docs/development/support-matrix.md), im

--- a/docs/development/support-matrix.md
+++ b/docs/development/support-matrix.md
@@ -1,13 +1,13 @@
 # Support-Matrix
 
-- **Stand:** Alpha 10 veröffentlicht, 2026-08-14
-- **Pre-Release:** `0.4.0-alpha.11`
+- **Stand:** Alpha 12 vorbereitet, 2026-08-14
+- **Pre-Release:** `0.4.0-alpha.12`
 - **Nächster Meilenstein:** gezielte reale Abnahme der verbleibenden
   Phase-4-Aktionen
 
 Diese Matrix unterscheidet reale Nachweise von implementierten, aber noch nicht
 real bestätigten Kombinationen. Phase 1, Phase 2 und Phase 3 sind abgenommen;
-`0.4.0-alpha.11` bleibt wegen seines Vorabversionsstatus ein Pre-Release.
+`0.4.0-alpha.12` bleibt wegen seines Vorabversionsstatus ein Pre-Release.
 Phase 4 ist implementiert und für die lesenden Statistik-/Historienpfade, die
 eng begrenzte plugin-eigene Cache-Operation und ausgewählte, reversible
 Control-Aktionen auf Hardware abgenommen; siehe

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -1,4 +1,4 @@
-# LoxBerry MCP Server 0.4.0-alpha.11
+# LoxBerry MCP Server 0.4.0-alpha.12
 
 ## Voraussetzungen
 

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -1,4 +1,4 @@
-# LoxBerry MCP Server 0.4.0-alpha.11
+# LoxBerry MCP Server 0.4.0-alpha.12
 
 ## Requirements
 

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -3,11 +3,11 @@ NAME=Miraculix2050
 EMAIL=198097126+Miraculix2050@users.noreply.github.com
 
 [PLUGIN]
-VERSION=0.4.0-alpha.11
+VERSION=0.4.0-alpha.12
 NAME=mcpserver
 FOLDER=mcpserver
 TITLE=LoxBerry MCP Server
-WEBSITE=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/blob/v0.4.0-alpha.11/README.md
+WEBSITE=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/blob/v0.4.0-alpha.12/README.md
 
 [AUTOUPDATE]
 AUTOMATIC_UPDATES=true

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -52,7 +52,7 @@ fi
 
 python3.13 -m venv "$new_venv" || exit 2
 "$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" -r "$plugin_bin/runtime-arm64.lock" || exit 2
-"$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" loxberry-mcpserver==0.4.0a11 || exit 2
+"$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" loxberry-mcpserver==0.4.0a12 || exit 2
 if [ -d "$venv" ]; then
     mv "$venv" "$old_venv" || exit 2
 fi

--- a/prerelease.cfg
+++ b/prerelease.cfg
@@ -1,4 +1,4 @@
 [AUTOUPDATE]
-VERSION=0.4.0-alpha.11
-ARCHIVEURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/download/v0.4.0-alpha.11/LoxBerry-MCP-Server-0.4.0-alpha.11.zip
-INFOURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/tag/v0.4.0-alpha.11
+VERSION=0.4.0-alpha.12
+ARCHIVEURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/download/v0.4.0-alpha.12/LoxBerry-MCP-Server-0.4.0-alpha.12.zip
+INFOURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/tag/v0.4.0-alpha.12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loxberry-mcpserver"
-version = "0.4.0-alpha.11"
+version = "0.4.0-alpha.12"
 description = "Local MCP server for LoxBerry and Loxone"
 requires-python = ">=3.13,<3.14"
 license = "Apache-2.0"

--- a/src/mcpserver/__init__.py
+++ b/src/mcpserver/__init__.py
@@ -5,6 +5,6 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("loxberry-mcpserver")
 except PackageNotFoundError:  # pragma: no cover - source tree without installation
-    __version__ = "0.4.0-alpha.11"
+    __version__ = "0.4.0-alpha.12"
 
 __all__ = ["__version__"]

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -475,7 +475,7 @@ def test_plugin_archive_verifier_accepts_builder_output(tmp_path: Path) -> None:
     for name, version in _locked_requirements(ROOT / "requirements" / "runtime-arm64.lock").items():
         wheel_name = name.replace("-", "_")
         (wheelhouse / f"{wheel_name}-{version}-py3-none-any.whl").write_bytes(b"wheel")
-    project_wheel = wheelhouse / "loxberry_mcpserver-0.4.0a11-py3-none-any.whl"
+    project_wheel = wheelhouse / "loxberry_mcpserver-0.4.0a12-py3-none-any.whl"
     _write_project_wheel(project_wheel)
     hash_lock = tmp_path / "runtime-arm64.sha256"
     hash_lock.write_text(
@@ -895,7 +895,7 @@ def test_plugin_archive_verifier_rejects_checksum_mismatch(tmp_path: Path) -> No
 def test_release_metadata_and_changelog_match_current_prerelease() -> None:
     notes = validate_release_metadata(ROOT, "0.4.0-alpha.12", "prerelease")
 
-    assert "Restore MCP Tool Explorer sign-in" in notes
+    assert "Prevent concurrent local LoxBerry read or operate binding changes" in notes
     with pytest.raises(ValueError, match="stable releases"):
         validate_release_metadata(ROOT, "0.4.0-alpha.12", "stable")
     with pytest.raises(ValueError, match="versions do not match"):

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -137,7 +137,7 @@ def test_plugin_identity_and_platform_contract() -> None:
     assert parser["PLUGIN"]["NAME"] == "mcpserver"
     assert parser["PLUGIN"]["FOLDER"] == "mcpserver"
     assert parser["PLUGIN"]["TITLE"] == "LoxBerry MCP Server"
-    assert parser["PLUGIN"]["VERSION"] == "0.4.0-alpha.11"
+    assert parser["PLUGIN"]["VERSION"] == "0.4.0-alpha.12"
     assert parser["AUTOUPDATE"]["AUTOMATIC_UPDATES"] == "true"
     assert parser["AUTOUPDATE"]["RELEASECFG"].startswith("https://")
     assert parser["AUTOUPDATE"]["PRERELEASECFG"].startswith("https://")
@@ -893,11 +893,11 @@ def test_plugin_archive_verifier_rejects_checksum_mismatch(tmp_path: Path) -> No
 
 
 def test_release_metadata_and_changelog_match_current_prerelease() -> None:
-    notes = validate_release_metadata(ROOT, "0.4.0-alpha.11", "prerelease")
+    notes = validate_release_metadata(ROOT, "0.4.0-alpha.12", "prerelease")
 
     assert "Restore MCP Tool Explorer sign-in" in notes
     with pytest.raises(ValueError, match="stable releases"):
-        validate_release_metadata(ROOT, "0.4.0-alpha.11", "stable")
+        validate_release_metadata(ROOT, "0.4.0-alpha.12", "stable")
     with pytest.raises(ValueError, match="versions do not match"):
         validate_release_metadata(ROOT, "0.3.0-alpha.2", "prerelease")
 


### PR DESCRIPTION
## Summary
- prepare the 0.4.0-alpha.12 prerelease metadata, update source fallback and package-contract expectations
- document concurrent local binding revocation protection and the Windows development setup
- keep release and support statements scoped to verified evidence

## Validation
- release metadata validation passed
- local candidate package verification passed (SHA-256 f9d7fd43577b1906e331e8b0a01d30d9061c3fa1f3b600ef2a463885c111ddc6)
- local Full runner is incomplete: Python 3.13 and its check tools are unavailable; CI is the required gate
- native Plugin Manager script returned no terminal evidence, so no target acceptance is claimed