### PR TITLE
Prevent upgrade auth-store race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ extracted from the matching version heading.
 
 ## Unreleased
 
+- Stop the MCP service before an upgrade replaces its persistent auth data, so
+  in-flight requests cannot fail against a temporarily unavailable store.
+- Classify a Miniserver source-IP lockout received while sending a WebSocket
+  command as a recoverable connection failure, including deferred token cleanup.
 - Keep a failed Loxone binary-state stream fail-closed while recording only its
   sanitized exception class; the stream task is now consumed after that record
   so its error cannot be raised a second time during session cleanup.

--- a/preupgrade.sh
+++ b/preupgrade.sh
@@ -8,6 +8,11 @@ if [ -z "$actual_folder" ] || [ -z "$installer_root" ] || [ -z "${LBPCONFIG:-}" 
     exit 2
 fi
 
+if systemctl is-active --quiet loxberry-mcpserver.service; then
+    systemctl stop loxberry-mcpserver.service || exit 2
+    echo "<INFO> MCP service stopped before upgrade data migration."
+fi
+
 config_file="$LBPCONFIG/$actual_folder/mcpserver.json"
 auth_dir="$LBPDATA/$actual_folder/auth"
 backup_dir="$installer_root/.mcpserver-upgrade"

--- a/src/mcpserver/loxone/client.py
+++ b/src/mcpserver/loxone/client.py
@@ -275,7 +275,13 @@ async def _websocket_command(
     max_payload_bytes: int,
 ) -> Any:
     outgoing = encryptor.encrypted_command(command) if encrypted else command
-    await websocket.send(outgoing)
+    try:
+        await websocket.send(outgoing)
+    except ConnectionClosed as exc:
+        received = exc.rcvd
+        if received is not None and received.code == 4003:
+            raise LoxoneSourceIpBlocked("Miniserver temporarily blocked this source IP") from None
+        raise LoxoneConnectionError("Miniserver WebSocket connection closed") from None
     header, payload = await _receive_websocket(
         websocket,
         timeout_seconds=timeout_seconds,

--- a/tests/test_loxone_client.py
+++ b/tests/test_loxone_client.py
@@ -23,6 +23,7 @@ from mcpserver.loxone.client import (
     _loxone_uuid,
     _receive_websocket,
     _response_value,
+    _websocket_command,
 )
 from mcpserver.loxone.events import MessageHeader, MessageType
 from mcpserver.loxone.security import token_hmac
@@ -444,6 +445,23 @@ async def test_websocket_receive_classifies_miniserver_source_ip_block() -> None
     with pytest.raises(LoxoneSourceIpBlocked):
         await _receive_websocket(
             cast(Any, FakeWebSocket()), timeout_seconds=0.1, max_payload_bytes=100
+        )
+
+
+@pytest.mark.asyncio
+async def test_websocket_send_classifies_miniserver_source_ip_block() -> None:
+    class FakeWebSocket:
+        async def send(self, _message: str) -> None:
+            raise ConnectionClosedError(Close(4003, "blocked"), None)
+
+    with pytest.raises(LoxoneSourceIpBlocked):
+        await _websocket_command(
+            cast(Any, FakeWebSocket()),
+            cast(Any, object()),
+            "jdev/sys/keyexchange/value",
+            encrypted=False,
+            timeout_seconds=0.1,
+            max_payload_bytes=100,
         )
 
 

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -201,6 +201,10 @@ def test_upgrade_preserves_configuration_in_plugin_data() -> None:
     postinstall = (ROOT / "postinstall.sh").read_text(encoding="utf-8")
 
     assert "installer_root=${6:-}" in preupgrade
+    assert "systemctl stop loxberry-mcpserver.service || exit 2" in preupgrade
+    assert preupgrade.index(
+        "systemctl stop loxberry-mcpserver.service || exit 2"
+    ) < preupgrade.index('config_file="$LBPCONFIG/$actual_folder/mcpserver.json"')
     assert 'backup_dir="$installer_root/.mcpserver-upgrade"' in preupgrade
     assert 'install -m 600 "$config_file" "$backup_dir/mcpserver.json"' in preupgrade
     assert "sessions.json loxone-tokens.json.enc install.key" in preupgrade

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -91,6 +91,10 @@ def test_mcp_client_smoke_covers_skill_delivery_surfaces() -> None:
     assert "$proxyArguments.Insert($callbackIndex, [string]$CallbackPort)" in script
     assert "$controlAdvertised = $actual -contains 'loxone_operate_control'" in script
     assert "if ($ControlFixturePath -and -not $controlAdvertised)" in script
+    assert "'loxberry_get_system_status', 'loxberry_list_service_events'," in script
+    assert "Temporary override control is outside the approved test intersection." in script
+    assert "Temporary override starts must use the fixed 60-second test duration." in script
+    assert "Read-only tool $Name returned error code $($envelope.data.error)." in script
 
 
 @pytest.mark.parametrize("variant", ["extra", "duplicate", "missing"])

--- a/tools/test_mcp_client.ps1
+++ b/tools/test_mcp_client.ps1
@@ -3,6 +3,7 @@ param(
     [string]$ServerName = 'loxberry-mcp',
     [string]$VisibilityFixturePath,
     [string]$ControlFixturePath,
+    [string]$TemporaryOverrideFixturePath,
     [int]$CallbackPort,
     [int]$TimeoutSeconds = 120,
     [switch]$CheckConfigurationOnly
@@ -179,7 +180,9 @@ function Invoke-ToolEnvelope([int]$Id, [string]$Name, [hashtable]$Arguments) {
 
 function Invoke-ReadTool([int]$Id, [string]$Name, [hashtable]$Arguments) {
     $envelope = Invoke-ToolEnvelope $Id $Name $Arguments
-    if (-not $envelope.ok) { throw "Read-only tool $Name returned an error envelope." }
+    if (-not $envelope.ok) {
+        throw "Read-only tool $Name returned error code $($envelope.data.error)."
+    }
     return $envelope
 }
 
@@ -212,7 +215,8 @@ try {
     $optional = @(
         'loxone_operate_control', 'loxone_get_control_history', 'loxone_get_statistics',
         'loxberry_get_plugin_status', 'loxberry_get_service_health',
-        'loxberry_get_system_status', 'loxberry_clear_statistics_cache'
+        'loxberry_get_system_status', 'loxberry_list_service_events',
+        'loxberry_clear_statistics_cache'
     )
     $controlAdvertised = $actual -contains 'loxone_operate_control'
     if ($ControlFixturePath -and -not $controlAdvertised) {
@@ -364,6 +368,57 @@ try {
         }
         $controlUuid = $null
         'mcp_switch_control=pass'
+    }
+
+    if ($TemporaryOverrideFixturePath) {
+        $overrideFixture = Get-Content -LiteralPath $TemporaryOverrideFixturePath -Raw | ConvertFrom-Json
+        $operations = @($overrideFixture.operations)
+        $allowedActions = @{
+            IRoomControllerV2 = @('start_override', 'stop_override')
+            Ventilation = @('start_override', 'stop_override')
+            ClimateControllerUS = @(
+                'start_fan_override', 'stop_fan_override',
+                'start_mode_override', 'stop_mode_override'
+            )
+        }
+        if ($operations.Count -lt 1 -or $operations.Count -gt 6) {
+            throw 'Temporary override fixture must contain one to six operations.'
+        }
+        foreach ($item in $operations) {
+            $controlUuid = [string]$item.control_uuid
+            $controlType = [string]$item.control_type
+            $action = [string]$item.action
+            if (-not $controlUuid -or -not $allowedActions.ContainsKey($controlType) -or
+                $action -notin $allowedActions[$controlType]) {
+                throw 'Temporary override fixture contains an unsupported operation.'
+            }
+            $summary = @($allControls | Where-Object { $_.uuid -eq $controlUuid }) |
+                Select-Object -First 1
+            if (-not $summary -or $summary.type -ne $controlType -or
+                $summary.room.uuid -ne $overrideFixture.room_uuid -or
+                $summary.category.uuid -ne $overrideFixture.category_uuid) {
+                throw 'Temporary override control is outside the approved test intersection.'
+            }
+            $controlDescription = Invoke-ReadTool (Get-NextId) 'loxone_describe_control' @{
+                control_uuid = $controlUuid
+            }
+            if ($action -notin @($controlDescription.data.capabilities.allowed_actions)) {
+                throw 'Temporary override action is not currently advertised.'
+            }
+            $arguments = @{ control_uuid = $controlUuid; action = $action }
+            if ($action -in @('start_override', 'start_fan_override', 'start_mode_override')) {
+                if ($item.duration_seconds -ne 60) {
+                    throw 'Temporary override starts must use the fixed 60-second test duration.'
+                }
+                $arguments.duration_seconds = 60
+            }
+            if ($null -ne $item.value) { $arguments.value = [double]$item.value }
+            $operation = Invoke-ToolEnvelope (Get-NextId) 'loxone_operate_control' $arguments
+            if (-not $operation.ok -or -not $operation.data.accepted -or -not $operation.data.confirmed) {
+                throw 'Temporary override action was not accepted and confirmed; it will not be retried.'
+            }
+        }
+        'mcp_temporary_override_controls=pass'
     }
 
     $visibleUuid = $null


### PR DESCRIPTION
## Summary
- stop the MCP service before upgrade migration touches persistent auth data
- classify Miniserver source-IP lockouts during WebSocket sends as recoverable failures
- cover both paths with regression tests

## Root cause
During the native alpha.12 upgrade, the old service still accepted OAuth requests while the Plugin Manager had made its auth-store path unavailable.

## Validation
- Python 3.13 full gate: 567 passed, ruff format/check, mypy
- targeted regression tests: 100 passed