### PR TITLE
Prepare 0.4.0-alpha.13 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ extracted from the matching version heading.
 
 ## Unreleased
 
+## 0.4.0-alpha.13 - 2026-08-14
+
 - Stop the MCP service before an upgrade replaces its persistent auth data, so
   in-flight requests cannot fail against a temporarily unavailable store.
 - Classify a Miniserver source-IP lockout received while sending a WebSocket

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ Für jeden Assistenten sollte ein eigener Loxone-Benutzer mit den minimal erford
 ## Projektstatus
 
 Phase 1 bis Phase 3 sind abgenommen. Der vorbereitete Phase-4-Pre-Release
-`0.4.0-alpha.12` schützt parallele Widerrufe lokaler LoxBerry-Freigaben vor
-verlorenen Konfigurationsänderungen und ergänzt eine reproduzierbare
-Windows-Entwicklungsumgebung. Es enthält außerdem die begrenzten
+`0.4.0-alpha.13` stoppt den Dienst vor einer Upgrade-Datenmigration und
+behandelt eine temporäre Miniserver-IP-Sperre auch während eines WebSocket-Sends
+als wiederherstellbaren Verbindungsfehler. Es enthält außerdem die begrenzten
 LoxAPP3-Modelle für Klima, Lüftung, Status, Energie und globale Metadaten sowie
 nur dokumentierte temporäre Overrides. Die vorherige `0.4.0-alpha.8` blockiert die MCP-Tool-Explorer-Anmeldung auf HTTP mit einem
 Link zur gleichen IP-Adresse oder demselben Hostnamen über HTTPS sowie die versionsgeprüfte, begrenzte single-flight

--- a/docs/development/support-matrix.md
+++ b/docs/development/support-matrix.md
@@ -1,13 +1,13 @@
 # Support-Matrix
 
-- **Stand:** Alpha 12 vorbereitet, 2026-08-14
-- **Pre-Release:** `0.4.0-alpha.12`
+- **Stand:** Alpha 13 vorbereitet, 2026-08-14
+- **Pre-Release:** `0.4.0-alpha.13`
 - **Nächster Meilenstein:** gezielte reale Abnahme der verbleibenden
   Phase-4-Aktionen
 
 Diese Matrix unterscheidet reale Nachweise von implementierten, aber noch nicht
 real bestätigten Kombinationen. Phase 1, Phase 2 und Phase 3 sind abgenommen;
-`0.4.0-alpha.12` bleibt wegen seines Vorabversionsstatus ein Pre-Release.
+`0.4.0-alpha.13` bleibt wegen seines Vorabversionsstatus ein Pre-Release.
 Phase 4 ist implementiert und für die lesenden Statistik-/Historienpfade, die
 eng begrenzte plugin-eigene Cache-Operation und ausgewählte, reversible
 Control-Aktionen auf Hardware abgenommen; siehe

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -1,4 +1,4 @@
-# LoxBerry MCP Server 0.4.0-alpha.12
+# LoxBerry MCP Server 0.4.0-alpha.13
 
 ## Voraussetzungen
 

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -1,4 +1,4 @@
-# LoxBerry MCP Server 0.4.0-alpha.12
+# LoxBerry MCP Server 0.4.0-alpha.13
 
 ## Requirements
 

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -3,11 +3,11 @@ NAME=Miraculix2050
 EMAIL=198097126+Miraculix2050@users.noreply.github.com
 
 [PLUGIN]
-VERSION=0.4.0-alpha.12
+VERSION=0.4.0-alpha.13
 NAME=mcpserver
 FOLDER=mcpserver
 TITLE=LoxBerry MCP Server
-WEBSITE=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/blob/v0.4.0-alpha.12/README.md
+WEBSITE=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/blob/v0.4.0-alpha.13/README.md
 
 [AUTOUPDATE]
 AUTOMATIC_UPDATES=true

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -52,7 +52,7 @@ fi
 
 python3.13 -m venv "$new_venv" || exit 2
 "$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" -r "$plugin_bin/runtime-arm64.lock" || exit 2
-"$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" loxberry-mcpserver==0.4.0a12 || exit 2
+"$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" loxberry-mcpserver==0.4.0a13 || exit 2
 if [ -d "$venv" ]; then
     mv "$venv" "$old_venv" || exit 2
 fi

--- a/prerelease.cfg
+++ b/prerelease.cfg
@@ -1,4 +1,4 @@
 [AUTOUPDATE]
-VERSION=0.4.0-alpha.12
-ARCHIVEURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/download/v0.4.0-alpha.12/LoxBerry-MCP-Server-0.4.0-alpha.12.zip
-INFOURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/tag/v0.4.0-alpha.12
+VERSION=0.4.0-alpha.13
+ARCHIVEURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/download/v0.4.0-alpha.13/LoxBerry-MCP-Server-0.4.0-alpha.13.zip
+INFOURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/tag/v0.4.0-alpha.13

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loxberry-mcpserver"
-version = "0.4.0-alpha.12"
+version = "0.4.0-alpha.13"
 description = "Local MCP server for LoxBerry and Loxone"
 requires-python = ">=3.13,<3.14"
 license = "Apache-2.0"

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -141,7 +141,7 @@ def test_plugin_identity_and_platform_contract() -> None:
     assert parser["PLUGIN"]["NAME"] == "mcpserver"
     assert parser["PLUGIN"]["FOLDER"] == "mcpserver"
     assert parser["PLUGIN"]["TITLE"] == "LoxBerry MCP Server"
-    assert parser["PLUGIN"]["VERSION"] == "0.4.0-alpha.12"
+    assert parser["PLUGIN"]["VERSION"] == "0.4.0-alpha.13"
     assert parser["AUTOUPDATE"]["AUTOMATIC_UPDATES"] == "true"
     assert parser["AUTOUPDATE"]["RELEASECFG"].startswith("https://")
     assert parser["AUTOUPDATE"]["PRERELEASECFG"].startswith("https://")
@@ -483,7 +483,7 @@ def test_plugin_archive_verifier_accepts_builder_output(tmp_path: Path) -> None:
     for name, version in _locked_requirements(ROOT / "requirements" / "runtime-arm64.lock").items():
         wheel_name = name.replace("-", "_")
         (wheelhouse / f"{wheel_name}-{version}-py3-none-any.whl").write_bytes(b"wheel")
-    project_wheel = wheelhouse / "loxberry_mcpserver-0.4.0a12-py3-none-any.whl"
+    project_wheel = wheelhouse / "loxberry_mcpserver-0.4.0a13-py3-none-any.whl"
     _write_project_wheel(project_wheel)
     hash_lock = tmp_path / "runtime-arm64.sha256"
     hash_lock.write_text(
@@ -901,11 +901,11 @@ def test_plugin_archive_verifier_rejects_checksum_mismatch(tmp_path: Path) -> No
 
 
 def test_release_metadata_and_changelog_match_current_prerelease() -> None:
-    notes = validate_release_metadata(ROOT, "0.4.0-alpha.12", "prerelease")
+    notes = validate_release_metadata(ROOT, "0.4.0-alpha.13", "prerelease")
 
-    assert "Prevent concurrent local LoxBerry read or operate binding changes" in notes
+    assert "Stop the MCP service before an upgrade" in notes
     with pytest.raises(ValueError, match="stable releases"):
-        validate_release_metadata(ROOT, "0.4.0-alpha.12", "stable")
+        validate_release_metadata(ROOT, "0.4.0-alpha.13", "stable")
     with pytest.raises(ValueError, match="versions do not match"):
         validate_release_metadata(ROOT, "0.3.0-alpha.2", "prerelease")
 


### PR DESCRIPTION
## Summary
- prepare the alpha.13 prerelease contract and update feed
- align offline package installation with the alpha.13 project wheel
- update release documentation and metadata tests

## Validation
- release metadata validation: pass
- Python 3.13 full gate: 567 passed, ruff format/check, mypy