### PR TITLE
Keep source version fallback in sync

### DIFF
--- a/src/mcpserver/__init__.py
+++ b/src/mcpserver/__init__.py
@@ -5,6 +5,6 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("loxberry-mcpserver")
 except PackageNotFoundError:  # pragma: no cover - source tree without installation
-    __version__ = "0.4.0-alpha.12"
+    __version__ = "0.4.0-alpha.13"
 
 __all__ = ["__version__"]

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -902,8 +902,12 @@ def test_plugin_archive_verifier_rejects_checksum_mismatch(tmp_path: Path) -> No
 
 def test_release_metadata_and_changelog_match_current_prerelease() -> None:
     notes = validate_release_metadata(ROOT, "0.4.0-alpha.13", "prerelease")
+    parser = configparser.ConfigParser()
+    parser.read(ROOT / "plugin.cfg", encoding="utf-8")
+    source_fallback = (ROOT / "src" / "mcpserver" / "__init__.py").read_text(encoding="utf-8")
 
     assert "Stop the MCP service before an upgrade" in notes
+    assert f'__version__ = "{parser["PLUGIN"]["VERSION"]}"' in source_fallback
     with pytest.raises(ValueError, match="stable releases"):
         validate_release_metadata(ROOT, "0.4.0-alpha.13", "stable")
     with pytest.raises(ValueError, match="versions do not match"):


### PR DESCRIPTION
## Summary
- align the source-checkout version fallback with alpha.13
- assert that the fallback equals the packaged plugin version

## Review feedback
Addresses the actionable P2 comment on PR #78.

## Validation
- release metadata validation: pass
- Python 3.13 full gate: 567 passed, ruff format/check, mypy