### PR TITLE
Prepare 0.4.0-alpha.14 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ extracted from the matching version heading.
 
 - Use the existing narrow non-interactive service-stop permission during the
   pre-upgrade hook, so a native Plugin Manager upgrade can stop the MCP service
-  before migrating its persistent auth data.
+  before migrating its persistent auth data; upgrades from older releases
+  without that permission safely stop only the plugin's own service process.
 
 ## 0.4.0-alpha.13 - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ extracted from the matching version heading.
 
 ## Unreleased
 
+## 0.4.0-alpha.14 - 2026-08-14
+
+- Use the existing narrow non-interactive service-stop permission during the
+  pre-upgrade hook, so a native Plugin Manager upgrade can stop the MCP service
+  before migrating its persistent auth data.
+
 ## 0.4.0-alpha.13 - 2026-08-14
 
 - Stop the MCP service before an upgrade replaces its persistent auth data, so

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Für jeden Assistenten sollte ein eigener Loxone-Benutzer mit den minimal erford
 ## Projektstatus
 
 Phase 1 bis Phase 3 sind abgenommen. Der vorbereitete Phase-4-Pre-Release
-`0.4.0-alpha.13` stoppt den Dienst vor einer Upgrade-Datenmigration und
+`0.4.0-alpha.14` stoppt den Dienst mit der begrenzten vorhandenen
+Systemfreigabe vor einer Upgrade-Datenmigration und
 behandelt eine temporäre Miniserver-IP-Sperre auch während eines WebSocket-Sends
 als wiederherstellbaren Verbindungsfehler. Es enthält außerdem die begrenzten
 LoxAPP3-Modelle für Klima, Lüftung, Status, Energie und globale Metadaten sowie

--- a/docs/development/support-matrix.md
+++ b/docs/development/support-matrix.md
@@ -1,13 +1,13 @@
 # Support-Matrix
 
-- **Stand:** Alpha 13 vorbereitet, 2026-08-14
-- **Pre-Release:** `0.4.0-alpha.13`
+- **Stand:** Alpha 14 vorbereitet, 2026-08-14
+- **Pre-Release:** `0.4.0-alpha.14`
 - **Nächster Meilenstein:** gezielte reale Abnahme der verbleibenden
   Phase-4-Aktionen
 
 Diese Matrix unterscheidet reale Nachweise von implementierten, aber noch nicht
 real bestätigten Kombinationen. Phase 1, Phase 2 und Phase 3 sind abgenommen;
-`0.4.0-alpha.13` bleibt wegen seines Vorabversionsstatus ein Pre-Release.
+`0.4.0-alpha.14` bleibt wegen seines Vorabversionsstatus ein Pre-Release.
 Phase 4 ist implementiert und für die lesenden Statistik-/Historienpfade, die
 eng begrenzte plugin-eigene Cache-Operation und ausgewählte, reversible
 Control-Aktionen auf Hardware abgenommen; siehe

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -1,4 +1,4 @@
-# LoxBerry MCP Server 0.4.0-alpha.13
+# LoxBerry MCP Server 0.4.0-alpha.14
 
 ## Voraussetzungen
 

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -1,4 +1,4 @@
-# LoxBerry MCP Server 0.4.0-alpha.13
+# LoxBerry MCP Server 0.4.0-alpha.14
 
 ## Requirements
 

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -3,11 +3,11 @@ NAME=Miraculix2050
 EMAIL=198097126+Miraculix2050@users.noreply.github.com
 
 [PLUGIN]
-VERSION=0.4.0-alpha.13
+VERSION=0.4.0-alpha.14
 NAME=mcpserver
 FOLDER=mcpserver
 TITLE=LoxBerry MCP Server
-WEBSITE=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/blob/v0.4.0-alpha.13/README.md
+WEBSITE=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/blob/v0.4.0-alpha.14/README.md
 
 [AUTOUPDATE]
 AUTOMATIC_UPDATES=true

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -52,7 +52,7 @@ fi
 
 python3.13 -m venv "$new_venv" || exit 2
 "$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" -r "$plugin_bin/runtime-arm64.lock" || exit 2
-"$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" loxberry-mcpserver==0.4.0a13 || exit 2
+"$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" loxberry-mcpserver==0.4.0a14 || exit 2
 if [ -d "$venv" ]; then
     mv "$venv" "$old_venv" || exit 2
 fi

--- a/prerelease.cfg
+++ b/prerelease.cfg
@@ -1,4 +1,4 @@
 [AUTOUPDATE]
-VERSION=0.4.0-alpha.13
-ARCHIVEURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/download/v0.4.0-alpha.13/LoxBerry-MCP-Server-0.4.0-alpha.13.zip
-INFOURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/tag/v0.4.0-alpha.13
+VERSION=0.4.0-alpha.14
+ARCHIVEURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/download/v0.4.0-alpha.14/LoxBerry-MCP-Server-0.4.0-alpha.14.zip
+INFOURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/tag/v0.4.0-alpha.14

--- a/preupgrade.sh
+++ b/preupgrade.sh
@@ -9,7 +9,27 @@ if [ -z "$actual_folder" ] || [ -z "$installer_root" ] || [ -z "${LBPCONFIG:-}" 
 fi
 
 if systemctl is-active --quiet loxberry-mcpserver.service; then
-    sudo -n /bin/systemctl stop loxberry-mcpserver.service || exit 2
+    if ! sudo -n /bin/systemctl stop loxberry-mcpserver.service; then
+        # Older plugin releases did not grant `stop`, but their service runs as
+        # this hook's loxberry user and treats SIGTERM as a clean exit.
+        main_pid=$(systemctl show --property=MainPID --value --no-pager loxberry-mcpserver.service || true)
+        case "$main_pid" in
+            ''|0|*[!0-9]*) echo "<ERROR> MCP service has no safe main PID."; exit 2 ;;
+        esac
+        kill -TERM "$main_pid" || exit 2
+        stopped=0
+        for _ in {1..20}; do
+            if ! systemctl is-active --quiet loxberry-mcpserver.service; then
+                stopped=1
+                break
+            fi
+            sleep 1
+        done
+        if [ "$stopped" -ne 1 ]; then
+            echo "<ERROR> MCP service did not stop before upgrade migration."
+            exit 2
+        fi
+    fi
     echo "<INFO> MCP service stopped before upgrade data migration."
 fi
 

--- a/preupgrade.sh
+++ b/preupgrade.sh
@@ -9,7 +9,7 @@ if [ -z "$actual_folder" ] || [ -z "$installer_root" ] || [ -z "${LBPCONFIG:-}" 
 fi
 
 if systemctl is-active --quiet loxberry-mcpserver.service; then
-    systemctl stop loxberry-mcpserver.service || exit 2
+    sudo -n /bin/systemctl stop loxberry-mcpserver.service || exit 2
     echo "<INFO> MCP service stopped before upgrade data migration."
 fi
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loxberry-mcpserver"
-version = "0.4.0-alpha.13"
+version = "0.4.0-alpha.14"
 description = "Local MCP server for LoxBerry and Loxone"
 requires-python = ">=3.13,<3.14"
 license = "Apache-2.0"

--- a/src/mcpserver/__init__.py
+++ b/src/mcpserver/__init__.py
@@ -5,6 +5,6 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("loxberry-mcpserver")
 except PackageNotFoundError:  # pragma: no cover - source tree without installation
-    __version__ = "0.4.0-alpha.13"
+    __version__ = "0.4.0-alpha.14"
 
 __all__ = ["__version__"]

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -201,9 +201,16 @@ def test_upgrade_preserves_configuration_in_plugin_data() -> None:
     postinstall = (ROOT / "postinstall.sh").read_text(encoding="utf-8")
 
     assert "installer_root=${6:-}" in preupgrade
-    assert "sudo -n /bin/systemctl stop loxberry-mcpserver.service || exit 2" in preupgrade
+    assert "if ! sudo -n /bin/systemctl stop loxberry-mcpserver.service; then" in preupgrade
+    assert (
+        "main_pid=$(systemctl show --property=MainPID --value --no-pager "
+        "loxberry-mcpserver.service || true)"
+    ) in preupgrade
+    assert 'kill -TERM "$main_pid" || exit 2' in preupgrade
+    assert "for _ in {1..20}" in preupgrade
+    assert "MCP service did not stop before upgrade migration." in preupgrade
     assert preupgrade.index(
-        "sudo -n /bin/systemctl stop loxberry-mcpserver.service || exit 2"
+        "if ! sudo -n /bin/systemctl stop loxberry-mcpserver.service; then"
     ) < preupgrade.index('config_file="$LBPCONFIG/$actual_folder/mcpserver.json"')
     assert 'backup_dir="$installer_root/.mcpserver-upgrade"' in preupgrade
     assert 'install -m 600 "$config_file" "$backup_dir/mcpserver.json"' in preupgrade

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -141,7 +141,7 @@ def test_plugin_identity_and_platform_contract() -> None:
     assert parser["PLUGIN"]["NAME"] == "mcpserver"
     assert parser["PLUGIN"]["FOLDER"] == "mcpserver"
     assert parser["PLUGIN"]["TITLE"] == "LoxBerry MCP Server"
-    assert parser["PLUGIN"]["VERSION"] == "0.4.0-alpha.13"
+    assert parser["PLUGIN"]["VERSION"] == "0.4.0-alpha.14"
     assert parser["AUTOUPDATE"]["AUTOMATIC_UPDATES"] == "true"
     assert parser["AUTOUPDATE"]["RELEASECFG"].startswith("https://")
     assert parser["AUTOUPDATE"]["PRERELEASECFG"].startswith("https://")
@@ -201,9 +201,9 @@ def test_upgrade_preserves_configuration_in_plugin_data() -> None:
     postinstall = (ROOT / "postinstall.sh").read_text(encoding="utf-8")
 
     assert "installer_root=${6:-}" in preupgrade
-    assert "systemctl stop loxberry-mcpserver.service || exit 2" in preupgrade
+    assert "sudo -n /bin/systemctl stop loxberry-mcpserver.service || exit 2" in preupgrade
     assert preupgrade.index(
-        "systemctl stop loxberry-mcpserver.service || exit 2"
+        "sudo -n /bin/systemctl stop loxberry-mcpserver.service || exit 2"
     ) < preupgrade.index('config_file="$LBPCONFIG/$actual_folder/mcpserver.json"')
     assert 'backup_dir="$installer_root/.mcpserver-upgrade"' in preupgrade
     assert 'install -m 600 "$config_file" "$backup_dir/mcpserver.json"' in preupgrade
@@ -483,7 +483,7 @@ def test_plugin_archive_verifier_accepts_builder_output(tmp_path: Path) -> None:
     for name, version in _locked_requirements(ROOT / "requirements" / "runtime-arm64.lock").items():
         wheel_name = name.replace("-", "_")
         (wheelhouse / f"{wheel_name}-{version}-py3-none-any.whl").write_bytes(b"wheel")
-    project_wheel = wheelhouse / "loxberry_mcpserver-0.4.0a13-py3-none-any.whl"
+    project_wheel = wheelhouse / "loxberry_mcpserver-0.4.0a14-py3-none-any.whl"
     _write_project_wheel(project_wheel)
     hash_lock = tmp_path / "runtime-arm64.sha256"
     hash_lock.write_text(
@@ -901,15 +901,15 @@ def test_plugin_archive_verifier_rejects_checksum_mismatch(tmp_path: Path) -> No
 
 
 def test_release_metadata_and_changelog_match_current_prerelease() -> None:
-    notes = validate_release_metadata(ROOT, "0.4.0-alpha.13", "prerelease")
+    notes = validate_release_metadata(ROOT, "0.4.0-alpha.14", "prerelease")
     parser = configparser.ConfigParser()
     parser.read(ROOT / "plugin.cfg", encoding="utf-8")
     source_fallback = (ROOT / "src" / "mcpserver" / "__init__.py").read_text(encoding="utf-8")
 
-    assert "Stop the MCP service before an upgrade" in notes
+    assert "Use the existing narrow non-interactive service-stop permission" in notes
     assert f'__version__ = "{parser["PLUGIN"]["VERSION"]}"' in source_fallback
     with pytest.raises(ValueError, match="stable releases"):
-        validate_release_metadata(ROOT, "0.4.0-alpha.13", "stable")
+        validate_release_metadata(ROOT, "0.4.0-alpha.14", "stable")
     with pytest.raises(ValueError, match="versions do not match"):
         validate_release_metadata(ROOT, "0.3.0-alpha.2", "prerelease")
 


### PR DESCRIPTION
## Summary
- use the existing scoped sudo permission to stop the MCP service before pre-upgrade data migration
- prepare alpha.14 metadata, package pin and prerelease feed
- preserve the source-tree fallback/version contract

## Root cause
Alpha.13 called systemctl directly from the non-root pre-upgrade hook, so LoxBerry required interactive authentication and returned installer status 2 before any migration.

## Validation
- release metadata validation: pass
- Python 3.13 full gate: 567 passed, ruff format/check, mypy
- native alpha.13 install failure diagnosed from Plugin Manager log