### PR TITLE
Document status and energy acceptance

### DIFF
--- a/docs/development/phase-4-acceptance.md
+++ b/docs/development/phase-4-acceptance.md
@@ -71,6 +71,32 @@ page was accepted for the Clients and sessions binding tables at 1280x800,
 headers, binding IDs and revoke actions remained visible and the page had no
 horizontal overflow.
 
+## Status and energy model read-only acceptance
+
+On 2026-08-14, the deployed service was queried read-only for one visible
+representative of each `StatusMonitor`, `WindowMonitor`, `SmokeAlarm`,
+`Tracker`, `Intercom`, `Meter`, `EFM`, and `PvProductionForecast` family. Each
+description exposed the documented visible state references, `readable` was
+true, and no operation was advertised. The `StatusMonitor` response included
+its position-stable input/status mapping; the `WindowMonitor` response included
+its typed item model. This accepts the live structure and description path for
+those eight families, without disclosing identifiers, names, addresses, or
+state values.
+
+The current-state result is deliberately narrower. A single bounded read of
+the 74 state references returned only `unknown` values after the documented
+WebSocket status subscription, while the Miniserver remained reachable and the
+structure cache current. The service therefore did not manufacture a value and
+this report does not claim hardware confirmation for current state delivery of
+these families. No state-changing command was issued to provoke an update.
+
+For the visible `Meter` and `EFM` representatives, the service advertised four
+and two statistic series respectively. One bounded one-day hourly query per
+control returned 97 and 24 points without pagination. This is hardware
+acceptance for their read-only statistics metadata and retrieval paths; it does
+not confirm current state values or the remaining `PvProductionForecast` state
+delivery.
+
 ## Authorized control-write acceptance
 
 On 2026-08-12, the user authorized tests only for the controls simultaneously

--- a/docs/development/support-matrix.md
+++ b/docs/development/support-matrix.md
@@ -3,7 +3,7 @@
 - **Stand:** Alpha 14 vorbereitet, 2026-08-14
 - **Pre-Release:** `0.4.0-alpha.14`
 - **Nächster Meilenstein:** gezielte reale Abnahme der verbleibenden
-  Phase-4-Aktionen
+  Phase-4-Aktionen und der aktuellen State-Übermittlung
 
 Diese Matrix unterscheidet reale Nachweise von implementierten, aber noch nicht
 real bestätigten Kombinationen. Phase 1, Phase 2 und Phase 3 sind abgenommen;
@@ -30,6 +30,14 @@ Ein einzelner, zeitlich auf 60 Sekunden begrenzter
 `Ventilation.start_override`-Befehl wurde dagegen angenommen und über den
 dokumentierten Timer-State bestätigt. `Ventilation.stop_override` sowie die
 `ClimateControllerUS`-Override-Aktionen bleiben nicht hardware-verifiziert.
+
+Auf derselben Fixture sind die LoxAPP3-Beschreibungen für `StatusMonitor`,
+`WindowMonitor`, `SmokeAlarm`, `Tracker`, `Intercom`, `Meter`, `EFM` und
+`PvProductionForecast` real bestätigt. Die Statistikabfragen eines sichtbaren
+`Meter` und `EFM` lieferten je einen begrenzten Stundenverlauf. Die aktuelle
+State-Übermittlung dieser Familien blieb nach der Subskription `unknown`; sie
+wird daher nicht als hardware-bestätigt ausgewiesen. Der vollständige,
+maskierte Befund steht im [Phase-4-Abnahmebericht](phase-4-acceptance.md#status-and-energy-model-read-only-acceptance).
 
 ## Plattformen und Geräte
 

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -352,8 +352,8 @@ Umbenennungs-, Experten- oder freien Kommandos.
 | Klima/Lüftung | `ClimateControllerUS` | ja | ja | temporäre Lüfter-/Modus-Overrides nur ohne zugehörigen Logikeingang | offizielle Doku und automatisierter Vertrag; Lesen real bestätigt, Writes nicht hardware-verifiziert |
 | Klima/Lüftung | `IRCV2Daytimer` | ja | nein | typisierte analoge Kalender-Metadaten; keine Kalenderwrites | in eigener Installation lesend prüfbar |
 | Klima/Lüftung | entsprechende V1-Typen, sofern vom Miniserver sichtbar | ja | nein | – | generischer Lesepfad, nicht real verifiziert |
-| Sensorik/Status | `InfoOnlyAnalog`, `InfoOnlyDigital`, `InfoOnlyText`, `TextState`, `StatusMonitor`, `WindowMonitor`, `SmokeAlarm`, `Tracker`, `Intercom` | ja | nein | typisierte sichtbare Statusmetadaten, soweit dokumentiert; keine Alarm-, Sperr-, Intercom- oder Quittierungsaktionen | dokumentationsbasiertes Lesemodell; nicht hardware-verifiziert |
-| Energie/sonstige | `Meter`, `EFM`, `PvProductionForecast`, `Slider`, `Webpage` | ja | nein | sichtbare States und Statistik, soweit angeboten | dokumentationsbasiertes Lesemodell; nicht hardware-verifiziert |
+| Sensorik/Status | `InfoOnlyAnalog`, `InfoOnlyDigital`, `InfoOnlyText`, `TextState`, `StatusMonitor`, `WindowMonitor`, `SmokeAlarm`, `Tracker`, `Intercom` | ja | nein | typisierte sichtbare Statusmetadaten, soweit dokumentiert; keine Alarm-, Sperr-, Intercom- oder Quittierungsaktionen | die sichtbaren Beschreibungen von `StatusMonitor`, `WindowMonitor`, `SmokeAlarm`, `Tracker` und `Intercom` sind real bestätigt; aktuelle States dieser Fixture blieben nach der Subskription `unknown`, die übrigen Typen sind dokumentationsbasiert |
+| Energie/sonstige | `Meter`, `EFM`, `PvProductionForecast`, `Slider`, `Webpage` | ja | nein | sichtbare States und Statistik, soweit angeboten | `Meter` und `EFM` sind mit sichtbarer Beschreibung und begrenzter Stundenstatistik real bestätigt; aktuelle States und `PvProductionForecast` bleiben nicht hardware-verifiziert |
 
 „Lesen“ umfasst nur sichtbare Struktur und Zustände. Bei `Jalousie` werden
 `set_slat_position` und `set_position_and_slats` nur angeboten, wenn die sichtbare

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -328,8 +328,8 @@ room, bulk, learning, rename, expert, or free-form commands.
 | Climate/ventilation | `ClimateControllerUS` | yes | yes | temporary fan/mode overrides only when the matching logic input is absent | official documentation and automated contract; read path hardware confirmed, writes not hardware-verified |
 | Climate/ventilation | `IRCV2Daytimer` | yes | no | typed analog schedule metadata; no schedule writes | readable in the maintainer installation |
 | Climate/ventilation | corresponding visible V1 types | yes | no | – | generic read path; not hardware-verified |
-| Sensors/status | `InfoOnlyAnalog`, `InfoOnlyDigital`, `InfoOnlyText`, `TextState`, `StatusMonitor`, `WindowMonitor`, `SmokeAlarm`, `Tracker`, `Intercom` | yes | no | typed visible state metadata where documented; no alarm, lock, intercom, or acknowledgement actions | documentation-based read model; not hardware-verified |
-| Energy/other | `Meter`, `EFM`, `PvProductionForecast`, `Slider`, `Webpage` | yes | no | visible states and statistics where advertised | documentation-based read model; not hardware-verified |
+| Sensors/status | `InfoOnlyAnalog`, `InfoOnlyDigital`, `InfoOnlyText`, `TextState`, `StatusMonitor`, `WindowMonitor`, `SmokeAlarm`, `Tracker`, `Intercom` | yes | no | typed visible state metadata where documented; no alarm, lock, intercom, or acknowledgement actions | visible descriptions of `StatusMonitor`, `WindowMonitor`, `SmokeAlarm`, `Tracker`, and `Intercom` are hardware-confirmed; current states on this fixture remained `unknown` after subscription, and the remaining types are documentation-based |
+| Energy/other | `Meter`, `EFM`, `PvProductionForecast`, `Slider`, `Webpage` | yes | no | visible states and statistics where advertised | `Meter` and `EFM` are hardware-confirmed for visible descriptions and bounded hourly statistics; current states and `PvProductionForecast` remain unverified |
 
 “Read” means only visible structure and states. For `Jalousie`,
 `set_slat_position` and `set_position_and_slats` are offered only when the visible


### PR DESCRIPTION
## Summary
- record live read-only descriptions for status and energy control families
- record hardware-confirmed Meter and EFM hourly statistic retrieval
- retain the observed unknown current-state boundary instead of overstating hardware coverage

## Validation
- .venv Scripts Python tools/test.py --profile changed with the four documentation paths
- git diff --check
- read-only authorized LoxBerry-Test acceptance; no control operations