### PR TITLE
Prevent revocation login bursts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ extracted from the matching version heading.
 
 ## Unreleased
 
+- Suspend all pending remote Loxone token-revocation attempts for one hour after
+  an authentication rejection or Miniserver source-IP lockout, preventing the
+  revocation worker from creating a burst of further logins while retaining the
+  tokens until remote confirmation is possible.
+
 ## 0.4.0-alpha.14 - 2026-08-14
 
 - Use the existing narrow non-interactive service-stop permission during the

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -143,6 +143,10 @@ Sitzung keine weitere Anmeldung, bis ein lokaler Administrator **Weiteren
 Token-Versuch erlauben** auswählt. Eine Quell-IP-Sperre des Miniservers wird
 separat gemeldet und erhöht diesen Zähler nicht. Andere Sitzungen bleiben nutzbar;
 eine erfolgreiche authentifizierte Verbindung löscht den Ablehnungszähler.
+Ausstehende Hintergrund-Widerrufe von Tokens werden nach einer abgelehnten
+Anmeldung oder einer Quell-IP-Sperre eine Stunde ausgesetzt, damit sie keinen
+weiteren Anmeldeversuch-Block erzeugen. Die Tokens bleiben bis zur bestätigten
+Löschung sicher gespeichert.
 
 Die lokalen Freigaben werden darunter nach `loxberry:read` und
 `loxberry:operate` getrennt angezeigt. Aktive Bindungen zeigen dieselbe

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -137,6 +137,9 @@ administrator chooses **Allow another token attempt**. A Miniserver source-IP
 lockout is reported separately and never increments this counter. This keeps
 other sessions usable and limits failed logins; a successful authenticated
 connection clears the rejection count.
+Pending background token revocations pause for one hour after an authentication
+rejection or source-IP lockout so they cannot create a further block of login
+attempts. Tokens remain securely stored until deletion is confirmed.
 
 Local approvals are listed below separately for `loxberry:read` and
 `loxberry:operate`. Active bindings show the same application, client instance,

--- a/src/mcpserver/auth/loxone_store.py
+++ b/src/mcpserver/auth/loxone_store.py
@@ -328,6 +328,22 @@ class EncryptedLoxoneTokenStore:
             record["remote_revoke_after"] = now + min(300, 2 ** min(attempts, 8))
             self._write(document)
 
+    def suspend_remote_revoke(self, family_id: str, now: int, *, delay_seconds: int) -> None:
+        """Retain a token without retrying an authentication-sensitive revoke too soon."""
+        if not 1 <= delay_seconds <= 86_400:
+            raise ValueError("remote revoke suspension delay is invalid")
+        with self._locked():
+            document = self._read()
+            record = document["tokens"].get(family_id)
+            if not isinstance(record, dict) or record.get("remote_revoke_pending") is not True:
+                return
+            after = now + delay_seconds
+            current = record.get("remote_revoke_after", 0)
+            record["remote_revoke_after"] = (
+                max(current, after) if isinstance(current, int) else after
+            )
+            self._write(document)
+
     def complete_remote_revoke(self, family_id: str) -> None:
         """Delete only after the Miniserver accepted killtoken."""
         self.delete(family_id)

--- a/src/mcpserver/auth/remote_revocation.py
+++ b/src/mcpserver/auth/remote_revocation.py
@@ -14,11 +14,18 @@ from mcpserver.auth.loxone_store import (
     LoxoneTokenStoreError,
     RemoteRevocation,
 )
-from mcpserver.loxone.client import LoxoneClient, LoxoneConnectionError, MiniserverEndpoint
+from mcpserver.loxone.client import (
+    LoxoneClient,
+    LoxoneCommandRejected,
+    LoxoneConnectionError,
+    LoxoneSourceIpBlocked,
+    MiniserverEndpoint,
+)
 from mcpserver.loxone.events import LoxoneProtocolError
 
 _LOGGER = logging.getLogger("mcpserver.auth.remote_revocation")
 _POLL_SECONDS: Final = 5
+_AUTHENTICATION_RETRY_SECONDS: Final = 3_600
 _CLIENT_UUID: Final = UUID("3f52f6fe-3af0-4d30-a8bb-f429b9da4465")
 
 
@@ -40,22 +47,44 @@ async def process_remote_revocations(
         return
     client = LoxoneClient(endpoint, client_uuid=_CLIENT_UUID, timeout_seconds=timeout_seconds)
 
-    async def process(item: RemoteRevocation) -> None:
+    async def process(item: RemoteRevocation) -> bool:
         # Keep identifiers and tokens out of logs.
         try:
             await asyncio.wait_for(client.kill_token(item.token), timeout=timeout_seconds + 5)
+        except LoxoneSourceIpBlocked:
+            store.suspend_remote_revoke(
+                item.family_id, int(time.time()), delay_seconds=_AUTHENTICATION_RETRY_SECONDS
+            )
+            _LOGGER.warning("component=remote_revocation outcome=source_ip_blocked")
+            return False
+        except LoxoneCommandRejected:
+            store.suspend_remote_revoke(
+                item.family_id, int(time.time()), delay_seconds=_AUTHENTICATION_RETRY_SECONDS
+            )
+            _LOGGER.warning("component=remote_revocation outcome=authentication_rejected")
+            return False
         except (TimeoutError, LoxoneConnectionError, LoxoneProtocolError):
             with suppress(LoxoneTokenStoreError):
                 store.defer_remote_revoke(item.family_id, int(time.time()))
             _LOGGER.warning("component=remote_revocation outcome=deferred")
+            return True
         else:
             with suppress(LoxoneTokenStoreError):
                 store.complete_remote_revoke(item.family_id)
             _LOGGER.info("component=remote_revocation outcome=completed")
+            return True
 
-    async with asyncio.TaskGroup() as group:
-        for item in pending:
-            group.create_task(process(item))
+    for index, item in enumerate(pending):
+        if await process(item):
+            continue
+        for remaining in pending[index + 1 :]:
+            with suppress(LoxoneTokenStoreError):
+                store.suspend_remote_revoke(
+                    remaining.family_id,
+                    int(time.time()),
+                    delay_seconds=_AUTHENTICATION_RETRY_SECONDS,
+                )
+        return
 
 
 async def run_remote_revocation_worker(

--- a/tests/test_remote_revocation.py
+++ b/tests/test_remote_revocation.py
@@ -3,9 +3,16 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 
+import pytest
+
 from mcpserver.auth.loxone_store import EncryptedLoxoneTokenStore
 from mcpserver.auth.remote_revocation import process_remote_revocations
-from mcpserver.loxone.client import LoxoneToken, MiniserverEndpoint
+from mcpserver.loxone.client import (
+    LoxoneCommandRejected,
+    LoxoneSourceIpBlocked,
+    LoxoneToken,
+    MiniserverEndpoint,
+)
 from mcpserver.loxone.events import LoxoneProtocolError
 
 
@@ -42,3 +49,45 @@ def test_remote_revoke_keeps_token_after_failure_and_removes_it_after_success(
     store.defer_remote_revoke("family", -10)
     asyncio.run(process_remote_revocations(endpoint, store, 0.1))
     assert store.get("family", "miniserver", "identity") is None
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        LoxoneCommandRejected("rejected", response_code="401"),
+        LoxoneSourceIpBlocked("blocked"),
+    ],
+)
+def test_remote_revoke_authentication_failures_suspend_all_pending_attempts(
+    tmp_path: Path, monkeypatch, error: Exception
+) -> None:
+    store = _store(tmp_path)
+    for family_id in ("first", "second"):
+        store.put(
+            family_id,
+            "miniserver",
+            "identity",
+            LoxoneToken("jwt", "user", "key", "SHA256", 1),
+        )
+        store.schedule_remote_revoke(family_id)
+    calls: list[str] = []
+
+    class RejectingClient:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        async def kill_token(self, _token: LoxoneToken) -> None:
+            calls.append("attempt")
+            raise error
+
+    monkeypatch.setattr("mcpserver.auth.remote_revocation.LoxoneClient", RejectingClient)
+    monkeypatch.setattr("mcpserver.auth.remote_revocation.time.time", lambda: 100)
+    endpoint = MiniserverEndpoint.parse_gen1("http://192.168.10.20")
+    asyncio.run(process_remote_revocations(endpoint, store, 100))
+
+    assert calls == ["attempt"]
+    assert store.pending_remote_revocations(3_699) == ()
+    assert [item.family_id for item in store.pending_remote_revocations(3_700)] == [
+        "first",
+        "second",
+    ]


### PR DESCRIPTION
## Summary

- stop a remote-revocation batch after the first token-authentication rejection or Miniserver source-IP lockout
- retain each token and suspend every pending remote revocation for one hour
- document the safeguard in both user guides and the changelog

## Root cause

The remote-revocation worker treated authentication rejections like transient connection failures and retried pending `killtoken` requests. Each request starts with `authwithtoken`, so a pending batch could create a burst of further login attempts despite the normal per-session rejection guard.

## Validation

- `ruff format --check` and `ruff check`
- `mypy`
- 113 focused tests passed
- the repository Full profile correctly requires Python 3.13; this workstation has Python 3.12 only
