### PR TITLE
Wait for initial Loxone state stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ extracted from the matching version heading.
 
 ## Unreleased
 
+- Wait briefly for the Miniserver's initial binary-state table when opening a
+  read session, so current state reads no longer race the asynchronous stream.
+
 - Suspend all pending remote Loxone token-revocation attempts for one hour after
   an authentication rejection or Miniserver source-IP lockout, preventing the
   revocation worker from creating a burst of further logins while retaining the

--- a/src/mcpserver/loxone/client.py
+++ b/src/mcpserver/loxone/client.py
@@ -844,6 +844,7 @@ class LoxoneWebSocketSession:
 
     async def state_events(self) -> AsyncIterator[tuple[StateEvent, ...]]:
         await self._command("jdev/sps/enablebinstatusupdate")
+        _LOGGER.debug("component=loxone.client severity=DEBUG outcome=state_subscription_accepted")
         keepalive_pending = False
         while True:
             try:

--- a/src/mcpserver/loxone/runtime.py
+++ b/src/mcpserver/loxone/runtime.py
@@ -169,6 +169,8 @@ class _ConnectionRecord:
     generation: int = 1
     last_structure_check: float = 0.0
     last_used: float = 0.0
+    state_stream_diagnostics_logged: bool = False
+    initial_state_batch: asyncio.Event = field(default_factory=asyncio.Event)
     refresh_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
 
@@ -213,6 +215,7 @@ class LoxoneRuntime:
             max_structure_state_references=max_structure_state_references,
             max_structure_depth=max_structure_depth,
         )
+        self._initial_state_timeout_seconds = min(timeout_seconds, 2.0)
         self.cache = UserStateCache(max_states_per_user=max_states_per_identity)
         self._records: dict[str, _ConnectionRecord] = {}
         self._locks: defaultdict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
@@ -855,6 +858,10 @@ class LoxoneRuntime:
             last_used=now,
         )
         record.task = asyncio.create_task(self._maintain(access, token, record))
+        with suppress(TimeoutError):
+            await asyncio.wait_for(
+                record.initial_state_batch.wait(), timeout=self._initial_state_timeout_seconds
+            )
         return record
 
     async def _prune_sessions(self, keep_subject: str) -> None:
@@ -954,7 +961,17 @@ class LoxoneRuntime:
 
     async def _pump_events(self, subject: str, record: _ConnectionRecord) -> None:
         async for event_batch in record.session.state_events():
+            if not record.state_stream_diagnostics_logged:
+                matching = sum(event.uuid in record.allowed_states for event in event_batch)
+                _LOGGER.debug(
+                    "component=loxone.runtime severity=DEBUG outcome=state_event_batch "
+                    "code=received_%d_matched_%d",
+                    len(event_batch),
+                    matching,
+                )
+                record.state_stream_diagnostics_logged = True
             self.cache.apply(subject, event_batch, allowed_uuids=record.allowed_states)
+            record.initial_state_batch.set()
 
     def state(self, snapshot: RuntimeSnapshot, uuid: str) -> StateRecord:
         return self.cache.get(snapshot.subject, uuid)

--- a/tests/test_loxone_runtime.py
+++ b/tests/test_loxone_runtime.py
@@ -10,6 +10,7 @@ import mcpserver.loxone.runtime as runtime_module
 from mcpserver.auth.provider import READ_SCOPE, StoredAccessToken
 from mcpserver.loxone.cache import UserStateCache
 from mcpserver.loxone.client import LoxoneConnectionError
+from mcpserver.loxone.events import StateEvent
 from mcpserver.loxone.models import LoxoneIdentity, LoxoneStructure
 from mcpserver.loxone.runtime import (
     LoxoneRuntime,
@@ -218,6 +219,27 @@ async def test_event_stream_failure_is_logged_without_payload_details(
     )
     assert "private endpoint detail" not in caplog.text
 
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_state_batch_populates_cache_before_marking_initial_batch_ready() -> None:
+    class EventSession(_Session):
+        async def state_events(self):
+            yield (StateEvent(uuid="state-1", value=1.0),)
+
+    runtime = object.__new__(LoxoneRuntime)
+    runtime.cache = UserStateCache()
+    runtime.cache.begin_connection("family")
+    task = asyncio.create_task(asyncio.sleep(60))
+    record = _ConnectionRecord(_structure("current"), frozenset({"state-1"}), EventSession(), task)
+
+    await runtime._pump_events("family", record)
+
+    assert record.initial_state_batch.is_set()
+    assert runtime.cache.get("family", "state-1").value == 1.0
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await task

--- a/tests/test_loxone_runtime.py
+++ b/tests/test_loxone_runtime.py
@@ -246,6 +246,41 @@ async def test_state_batch_populates_cache_before_marking_initial_batch_ready() 
 
 
 @pytest.mark.asyncio
+async def test_connect_waits_for_the_initial_state_batch() -> None:
+    release = asyncio.Event()
+
+    class Session(_Session):
+        async def load_structure(self) -> LoxoneStructure:
+            return _structure("current")
+
+        async def state_events(self):
+            await release.wait()
+            yield ()
+
+    class Client:
+        async def open_session(self, _token: object) -> Session:
+            return Session()
+
+    runtime = object.__new__(LoxoneRuntime)
+    runtime.token_health = None
+    runtime.token_store = SimpleNamespace(
+        get=lambda *_args: SimpleNamespace(valid_until=2_000_000_000)
+    )
+    runtime.client = Client()
+    runtime.cache = UserStateCache()
+    runtime._initial_state_timeout_seconds = 1.0
+    task = asyncio.create_task(runtime._connect(_access()))
+    await asyncio.sleep(0)
+    assert not task.done()
+    release.set()
+    record = await task
+    assert record.initial_state_batch.is_set()
+    record.task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await record.task
+
+
+@pytest.mark.asyncio
 async def test_session_pruning_prefers_idle_then_least_recently_used(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Fixes the race between opening a Loxone read session and reading its state cache.\n\nValidation: 61 focused tests and real LoxBerry/Miniserver state-stream acceptance.