### PR TITLE
Harden initial Loxone state stream startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@
 All notable user-visible changes are recorded here. GitHub release notes are
 extracted from the matching version heading.
 
-## Unreleased
+## 0.4.0-alpha.15 - 2026-08-15
+
+- Fail closed when the Miniserver binary-state stream ends before its first
+  state batch, instead of returning an apparently usable read session without
+  current values.
 
 - Wait briefly for the Miniserver's initial binary-state table when opening a
   read session, so current state reads no longer race the asynchronous stream.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Für jeden Assistenten sollte ein eigener Loxone-Benutzer mit den minimal erford
 ## Projektstatus
 
 Phase 1 bis Phase 3 sind abgenommen. Der vorbereitete Phase-4-Pre-Release
-`0.4.0-alpha.14` stoppt den Dienst mit der begrenzten vorhandenen
+`0.4.0-alpha.15` beendet einen Verbindungsaufbau sicher, wenn der binäre
+Miniserver-Zustandsstream vor seinem ersten Batch endet. `0.4.0-alpha.14` stoppt den Dienst mit der begrenzten vorhandenen
 Systemfreigabe vor einer Upgrade-Datenmigration und
 behandelt eine temporäre Miniserver-IP-Sperre auch während eines WebSocket-Sends
 als wiederherstellbaren Verbindungsfehler. Es enthält außerdem die begrenzten

--- a/docs/development/support-matrix.md
+++ b/docs/development/support-matrix.md
@@ -1,13 +1,13 @@
 # Support-Matrix
 
-- **Stand:** Alpha 14 vorbereitet, 2026-08-14
-- **Pre-Release:** `0.4.0-alpha.14`
+- **Stand:** Alpha 15 vorbereitet, 2026-08-15
+- **Pre-Release:** `0.4.0-alpha.15`
 - **Nächster Meilenstein:** gezielte reale Abnahme der verbleibenden
   Phase-4-Aktionen
 
 Diese Matrix unterscheidet reale Nachweise von implementierten, aber noch nicht
 real bestätigten Kombinationen. Phase 1, Phase 2 und Phase 3 sind abgenommen;
-`0.4.0-alpha.14` bleibt wegen seines Vorabversionsstatus ein Pre-Release.
+`0.4.0-alpha.15` bleibt wegen seines Vorabversionsstatus ein Pre-Release.
 Phase 4 ist implementiert und für die lesenden Statistik-/Historienpfade, die
 eng begrenzte plugin-eigene Cache-Operation und ausgewählte, reversible
 Control-Aktionen auf Hardware abgenommen; siehe

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -1,4 +1,4 @@
-# LoxBerry MCP Server 0.4.0-alpha.14
+# LoxBerry MCP Server 0.4.0-alpha.15
 
 ## Voraussetzungen
 

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -1,4 +1,4 @@
-# LoxBerry MCP Server 0.4.0-alpha.14
+# LoxBerry MCP Server 0.4.0-alpha.15
 
 ## Requirements
 

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -3,11 +3,11 @@ NAME=Miraculix2050
 EMAIL=198097126+Miraculix2050@users.noreply.github.com
 
 [PLUGIN]
-VERSION=0.4.0-alpha.14
+VERSION=0.4.0-alpha.15
 NAME=mcpserver
 FOLDER=mcpserver
 TITLE=LoxBerry MCP Server
-WEBSITE=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/blob/v0.4.0-alpha.14/README.md
+WEBSITE=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/blob/v0.4.0-alpha.15/README.md
 
 [AUTOUPDATE]
 AUTOMATIC_UPDATES=true

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -52,7 +52,7 @@ fi
 
 python3.13 -m venv "$new_venv" || exit 2
 "$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" -r "$plugin_bin/runtime-arm64.lock" || exit 2
-"$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" loxberry-mcpserver==0.4.0a14 || exit 2
+"$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" loxberry-mcpserver==0.4.0a15 || exit 2
 if [ -d "$venv" ]; then
     mv "$venv" "$old_venv" || exit 2
 fi

--- a/prerelease.cfg
+++ b/prerelease.cfg
@@ -1,4 +1,4 @@
 [AUTOUPDATE]
-VERSION=0.4.0-alpha.14
-ARCHIVEURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/download/v0.4.0-alpha.14/LoxBerry-MCP-Server-0.4.0-alpha.14.zip
-INFOURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/tag/v0.4.0-alpha.14
+VERSION=0.4.0-alpha.15
+ARCHIVEURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/download/v0.4.0-alpha.15/LoxBerry-MCP-Server-0.4.0-alpha.15.zip
+INFOURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/tag/v0.4.0-alpha.15

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loxberry-mcpserver"
-version = "0.4.0-alpha.14"
+version = "0.4.0-alpha.15"
 description = "Local MCP server for LoxBerry and Loxone"
 requires-python = ">=3.13,<3.14"
 license = "Apache-2.0"

--- a/src/mcpserver/__init__.py
+++ b/src/mcpserver/__init__.py
@@ -5,6 +5,6 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("loxberry-mcpserver")
 except PackageNotFoundError:  # pragma: no cover - source tree without installation
-    __version__ = "0.4.0-alpha.14"
+    __version__ = "0.4.0-alpha.15"
 
 __all__ = ["__version__"]

--- a/src/mcpserver/loxone/runtime.py
+++ b/src/mcpserver/loxone/runtime.py
@@ -858,10 +858,27 @@ class LoxoneRuntime:
             last_used=now,
         )
         record.task = asyncio.create_task(self._maintain(access, token, record))
-        with suppress(TimeoutError):
-            await asyncio.wait_for(
-                record.initial_state_batch.wait(), timeout=self._initial_state_timeout_seconds
+        initial_state_wait = asyncio.create_task(record.initial_state_batch.wait())
+        try:
+            done, _pending = await asyncio.wait(
+                {initial_state_wait, record.task}, timeout=self._initial_state_timeout_seconds
             )
+            if record.task in done and not record.initial_state_batch.is_set():
+                await record.task
+                raise RuntimeUnavailable("Miniserver state subscription failed")
+        except BaseException:
+            if not record.task.done():
+                record.task.cancel()
+            with suppress(asyncio.CancelledError, Exception):
+                await record.task
+            await record.session.close()
+            self.cache.disconnect(access.family_id)
+            raise
+        finally:
+            if not initial_state_wait.done():
+                initial_state_wait.cancel()
+                with suppress(asyncio.CancelledError):
+                    await initial_state_wait
         return record
 
     async def _prune_sessions(self, keep_subject: str) -> None:

--- a/tests/test_loxone_runtime.py
+++ b/tests/test_loxone_runtime.py
@@ -275,9 +275,84 @@ async def test_connect_waits_for_the_initial_state_batch() -> None:
     release.set()
     record = await task
     assert record.initial_state_batch.is_set()
-    record.task.cancel()
+    await record.task
+
+
+@pytest.mark.asyncio
+async def test_connect_fails_closed_when_state_stream_ends_before_initial_batch() -> None:
+    closed = False
+
+    class Session(_Session):
+        async def load_structure(self) -> LoxoneStructure:
+            return _structure("current")
+
+        async def state_events(self):
+            raise LoxoneConnectionError("connection closed")
+            yield ()  # pragma: no cover - make this an async generator
+
+        async def close(self) -> None:
+            nonlocal closed
+            closed = True
+
+    class Client:
+        async def open_session(self, _token: object) -> Session:
+            return Session()
+
+    runtime = object.__new__(LoxoneRuntime)
+    runtime.token_health = None
+    runtime.token_store = SimpleNamespace(
+        get=lambda *_args: SimpleNamespace(valid_until=2_000_000_000)
+    )
+    runtime.client = Client()
+    runtime.cache = UserStateCache()
+    runtime._initial_state_timeout_seconds = 1.0
+
+    with pytest.raises(RuntimeUnavailable, match="state subscription failed"):
+        await runtime._connect(_access())
+    assert closed
+    assert runtime.cache.get("family", "state-1").freshness.name == "UNAVAILABLE"
+
+
+@pytest.mark.asyncio
+async def test_connect_cancellation_closes_unregistered_state_session() -> None:
+    state_stream_started = asyncio.Event()
+    state_stream_release = asyncio.Event()
+    closed = False
+
+    class Session(_Session):
+        async def load_structure(self) -> LoxoneStructure:
+            return _structure("current")
+
+        async def state_events(self):
+            state_stream_started.set()
+            await state_stream_release.wait()
+            yield ()
+
+        async def close(self) -> None:
+            nonlocal closed
+            closed = True
+
+    class Client:
+        async def open_session(self, _token: object) -> Session:
+            return Session()
+
+    runtime = object.__new__(LoxoneRuntime)
+    runtime.token_health = None
+    runtime.token_store = SimpleNamespace(
+        get=lambda *_args: SimpleNamespace(valid_until=2_000_000_000)
+    )
+    runtime.client = Client()
+    runtime.cache = UserStateCache()
+    runtime._initial_state_timeout_seconds = 1.0
+    task = asyncio.create_task(runtime._connect(_access()))
+    await state_stream_started.wait()
+
+    task.cancel()
     with pytest.raises(asyncio.CancelledError):
-        await record.task
+        await task
+
+    assert closed
+    assert runtime.cache.get("family", "state-1").freshness.name == "UNAVAILABLE"
 
 
 @pytest.mark.asyncio

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -141,7 +141,7 @@ def test_plugin_identity_and_platform_contract() -> None:
     assert parser["PLUGIN"]["NAME"] == "mcpserver"
     assert parser["PLUGIN"]["FOLDER"] == "mcpserver"
     assert parser["PLUGIN"]["TITLE"] == "LoxBerry MCP Server"
-    assert parser["PLUGIN"]["VERSION"] == "0.4.0-alpha.14"
+    assert parser["PLUGIN"]["VERSION"] == "0.4.0-alpha.15"
     assert parser["AUTOUPDATE"]["AUTOMATIC_UPDATES"] == "true"
     assert parser["AUTOUPDATE"]["RELEASECFG"].startswith("https://")
     assert parser["AUTOUPDATE"]["PRERELEASECFG"].startswith("https://")
@@ -490,7 +490,7 @@ def test_plugin_archive_verifier_accepts_builder_output(tmp_path: Path) -> None:
     for name, version in _locked_requirements(ROOT / "requirements" / "runtime-arm64.lock").items():
         wheel_name = name.replace("-", "_")
         (wheelhouse / f"{wheel_name}-{version}-py3-none-any.whl").write_bytes(b"wheel")
-    project_wheel = wheelhouse / "loxberry_mcpserver-0.4.0a14-py3-none-any.whl"
+    project_wheel = wheelhouse / "loxberry_mcpserver-0.4.0a15-py3-none-any.whl"
     _write_project_wheel(project_wheel)
     hash_lock = tmp_path / "runtime-arm64.sha256"
     hash_lock.write_text(
@@ -908,15 +908,15 @@ def test_plugin_archive_verifier_rejects_checksum_mismatch(tmp_path: Path) -> No
 
 
 def test_release_metadata_and_changelog_match_current_prerelease() -> None:
-    notes = validate_release_metadata(ROOT, "0.4.0-alpha.14", "prerelease")
+    notes = validate_release_metadata(ROOT, "0.4.0-alpha.15", "prerelease")
     parser = configparser.ConfigParser()
     parser.read(ROOT / "plugin.cfg", encoding="utf-8")
     source_fallback = (ROOT / "src" / "mcpserver" / "__init__.py").read_text(encoding="utf-8")
 
-    assert "Use the existing narrow non-interactive service-stop permission" in notes
+    assert "Fail closed when the Miniserver binary-state stream ends" in notes
     assert f'__version__ = "{parser["PLUGIN"]["VERSION"]}"' in source_fallback
     with pytest.raises(ValueError, match="stable releases"):
-        validate_release_metadata(ROOT, "0.4.0-alpha.14", "stable")
+        validate_release_metadata(ROOT, "0.4.0-alpha.15", "stable")
     with pytest.raises(ValueError, match="versions do not match"):
         validate_release_metadata(ROOT, "0.3.0-alpha.2", "prerelease")
 


### PR DESCRIPTION
## Summary
- fail closed when the binary state stream ends before its first batch
- clean up an unregistered state session when connection setup is cancelled
- prepare the reviewed 