### PR TITLE
Resolve room-group memberships from explicit names

### DIFF
--- a/src/mcpserver/loxone/structure.py
+++ b/src/mcpserver/loxone/structure.py
@@ -317,7 +317,7 @@ def _room_groups(
 
         if isinstance(value, Mapping):
             candidates = [*value.keys(), *value.values()]
-        elif isinstance(value, (list, tuple, set, frozenset)):
+        elif isinstance(value, list | tuple | set | frozenset):
             candidates = value
         else:
             return set()

--- a/src/mcpserver/loxone/structure.py
+++ b/src/mcpserver/loxone/structure.py
@@ -299,6 +299,36 @@ def _room_groups(
         return (), {}
     groups: list[NamedGroup] = []
     memberships: dict[str, set[str]] = {}
+    known_room_uuids: set[str] = set()
+    room_uuids_by_name: dict[str, set[str]] = {}
+    rooms = document.get("rooms")
+    if isinstance(rooms, Mapping):
+        for room_uuid, room in rooms.items():
+            if isinstance(room_uuid, str) and isinstance(room, Mapping):
+                known_room_uuids.add(room_uuid)
+                room_name = _bounded_text(room.get("name"))
+                if room_name is not None:
+                    room_uuids_by_name.setdefault(room_name, set()).add(room_uuid)
+
+    def references(value: object, targets: set[str]) -> set[str]:
+        """Find bounded explicit references across compatible LoxAPP3 variants."""
+
+        result: set[str] = set()
+        pending = [value]
+        inspected = 0
+        while pending and inspected < 100:
+            current = pending.pop()
+            inspected += 1
+            if isinstance(current, str):
+                if current in targets:
+                    result.add(current)
+            elif isinstance(current, Mapping):
+                pending.extend(list(current.keys())[:100 - inspected])
+                pending.extend(list(current.values())[:100 - inspected])
+            elif isinstance(current, (list, tuple, set, frozenset)):
+                pending.extend(list(current)[:100 - inspected])
+        return result
+
     for item in raw_groups[:100]:
         if not isinstance(item, Mapping):
             continue
@@ -306,21 +336,30 @@ def _room_groups(
         if identifier is None or name is None:
             continue
         groups.append(NamedGroup(identifier, name))
-        room_ids = item.get("rooms", item.get("roomUuids"))
-        if isinstance(room_ids, list) and len(room_ids) <= 100:
-            for room_uuid in room_ids:
-                normalized_room_uuid = _bounded_text(room_uuid, maximum=128)
-                if normalized_room_uuid is not None:
-                    memberships.setdefault(normalized_room_uuid, set()).add(identifier)
+        room_uuids = references(item, known_room_uuids)
+        for room_name in references(item, set(room_uuids_by_name)):
+            if len(room_uuids_by_name[room_name]) == 1:
+                room_uuids.update(room_uuids_by_name[room_name])
+        for room_uuid in room_uuids:
+            memberships.setdefault(room_uuid, set()).add(identifier)
     known_groups = {item.uuid for item in groups}
+    group_uuids_by_name: dict[str, set[str]] = {}
+    for group in groups:
+        group_uuids_by_name.setdefault(group.name, set()).add(group.uuid)
     rooms = document.get("rooms")
     if isinstance(rooms, Mapping):
         for room_uuid, room in rooms.items():
             if not isinstance(room_uuid, str) or not isinstance(room, Mapping):
                 continue
-            group_uuid = _bounded_text(room.get("roomGroup"))
-            if group_uuid in known_groups:
+            for group_uuid in references(room, known_groups):
                 memberships.setdefault(room_uuid, set()).add(group_uuid)
+            for field in ("roomGroup", "roomGroupName"):
+                group_name = _bounded_text(room.get(field))
+                if (
+                    group_name is not None
+                    and len(group_uuids_by_name.get(group_name, ())) == 1
+                ):
+                    memberships.setdefault(room_uuid, set()).update(group_uuids_by_name[group_name])
     return tuple(groups), {
         room_uuid: next(iter(group_uuids)) if len(group_uuids) == 1 else None
         for room_uuid, group_uuids in memberships.items()

--- a/src/mcpserver/loxone/structure.py
+++ b/src/mcpserver/loxone/structure.py
@@ -310,23 +310,26 @@ def _room_groups(
                 if room_name is not None:
                     room_uuids_by_name.setdefault(room_name, set()).add(room_uuid)
 
-    def references(value: object, targets: set[str]) -> set[str]:
-        """Find bounded explicit references across compatible LoxAPP3 variants."""
+    def collection_references(
+        value: object, targets: set[str], *, entry_fields: tuple[str, ...] = ()
+    ) -> set[str]:
+        """Read bounded references from an explicit LoxAPP3 membership collection."""
 
+        if isinstance(value, Mapping):
+            candidates = [*value.keys(), *value.values()]
+        elif isinstance(value, (list, tuple, set, frozenset)):
+            candidates = value
+        else:
+            return set()
         result: set[str] = set()
-        pending = [value]
-        inspected = 0
-        while pending and inspected < 100:
-            current = pending.pop()
-            inspected += 1
-            if isinstance(current, str):
-                if current in targets:
-                    result.add(current)
-            elif isinstance(current, Mapping):
-                pending.extend(list(current.keys())[:100 - inspected])
-                pending.extend(list(current.values())[:100 - inspected])
-            elif isinstance(current, (list, tuple, set, frozenset)):
-                pending.extend(list(current)[:100 - inspected])
+        for candidate in list(candidates)[:100]:
+            if isinstance(candidate, str) and candidate in targets:
+                result.add(candidate)
+            elif isinstance(candidate, Mapping):
+                for field in entry_fields:
+                    reference = _bounded_text(candidate.get(field))
+                    if reference in targets:
+                        result.add(reference)
         return result
 
     for item in raw_groups[:100]:
@@ -336,10 +339,20 @@ def _room_groups(
         if identifier is None or name is None:
             continue
         groups.append(NamedGroup(identifier, name))
-        room_uuids = references(item, known_room_uuids)
-        for room_name in references(item, set(room_uuids_by_name)):
-            if len(room_uuids_by_name[room_name]) == 1:
-                room_uuids.update(room_uuids_by_name[room_name])
+        room_uuids: set[str] = set()
+        for field in ("rooms", "roomUuids", "roomUUIDs", "roomIds", "roomIDs", "roomNames"):
+            room_uuids.update(
+                collection_references(
+                    item.get(field),
+                    known_room_uuids,
+                    entry_fields=("uuid", "roomUuid", "roomUUID", "roomId", "roomID"),
+                )
+            )
+            for room_name in collection_references(
+                item.get(field), set(room_uuids_by_name), entry_fields=("name", "roomName")
+            ):
+                if len(room_uuids_by_name[room_name]) == 1:
+                    room_uuids.update(room_uuids_by_name[room_name])
         for room_uuid in room_uuids:
             memberships.setdefault(room_uuid, set()).add(identifier)
     known_groups = {item.uuid for item in groups}
@@ -351,14 +364,20 @@ def _room_groups(
         for room_uuid, room in rooms.items():
             if not isinstance(room_uuid, str) or not isinstance(room, Mapping):
                 continue
-            for group_uuid in references(room, known_groups):
-                memberships.setdefault(room_uuid, set()).add(group_uuid)
-            for field in ("roomGroup", "roomGroupName"):
+            for field in (
+                "roomGroup",
+                "roomGroupUuid",
+                "roomGroupUUID",
+                "roomGroupId",
+                "roomGroupID",
+                "parentGroup",
+            ):
+                group_reference = _bounded_text(room.get(field))
+                if group_reference in known_groups:
+                    memberships.setdefault(room_uuid, set()).add(group_reference)
+            for field in ("roomGroup", "roomGroupName", "parentGroup"):
                 group_name = _bounded_text(room.get(field))
-                if (
-                    group_name is not None
-                    and len(group_uuids_by_name.get(group_name, ())) == 1
-                ):
+                if group_name is not None and len(group_uuids_by_name.get(group_name, ())) == 1:
                     memberships.setdefault(room_uuid, set()).update(group_uuids_by_name[group_name])
     return tuple(groups), {
         room_uuid: next(iter(group_uuids)) if len(group_uuids) == 1 else None

--- a/src/mcpserver/loxone/structure.py
+++ b/src/mcpserver/loxone/structure.py
@@ -318,7 +318,7 @@ def _room_groups(
         if isinstance(value, Mapping):
             candidates = [*value.keys(), *value.values()]
         elif isinstance(value, list | tuple | set | frozenset):
-            candidates = value
+            candidates = list(value)
         else:
             return set()
         result: set[str] = set()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -141,7 +141,7 @@ def test_obsolete_debug_window_is_ignored_and_removed() -> None:
 
 
 def test_gen2_control_configuration_is_rejected() -> None:
-    with pytest.raises(ConfigError, match="only for Gen. 1"):
+    with pytest.raises(ConfigError, match=r"only for Gen\. 1"):
         PluginConfig.from_document(
             {
                 "schema_version": 1,

--- a/tests/test_loxone_client.py
+++ b/tests/test_loxone_client.py
@@ -660,7 +660,7 @@ async def test_probe_rejects_tls_capable_miniserver(monkeypatch: pytest.MonkeyPa
 
     monkeypatch.setattr(client, "_get_json", fake_get_json)
 
-    with pytest.raises(LoxoneConnectionError, match="Gen. 2"):
+    with pytest.raises(LoxoneConnectionError, match=r"Gen\. 2"):
         await client.probe()
 
 

--- a/tests/test_loxone_structure.py
+++ b/tests/test_loxone_structure.py
@@ -191,12 +191,17 @@ def test_structure_resolves_only_unambiguous_explicit_room_group_membership() ->
             "room-4": {"name": "Mapped group"},
             "room-5": {"name": "Mapped IDs"},
             "room-6": {"name": "Direct UUID", "roomGroupUUID": "group-upper"},
-            "room-7": {"name": "Direct name", "roomGroup": "Upper floor"},
+            "room-7": {"name": "Direct name", "parentGroup": "Upper floor"},
             "room-8": {"name": "Mapped name"},
+            "room-9": {"name": "Object member"},
         },
         "cats": {},
         "roomGroups": [
-            {"uuid": "group-ground", "name": "Ground floor", "rooms": ["room-2", "room-3"]},
+            {
+                "uuid": "group-ground",
+                "name": "Ground floor",
+                "rooms": ["room-2", "room-3", {"name": "Object member"}],
+            },
             {
                 "uuid": "group-upper",
                 "name": "Upper floor",
@@ -217,6 +222,7 @@ def test_structure_resolves_only_unambiguous_explicit_room_group_membership() ->
                 "room-6",
                 "room-7",
                 "room-8",
+                "room-9",
             )
         },
     }
@@ -232,6 +238,7 @@ def test_structure_resolves_only_unambiguous_explicit_room_group_membership() ->
         "room-6": "group-upper",
         "room-7": "group-upper",
         "room-8": "group-upper",
+        "room-9": "group-ground",
     }
     assert [(item.uuid, item.name) for item in structure.room_groups] == [
         ("group-ground", "Ground floor"),
@@ -240,6 +247,36 @@ def test_structure_resolves_only_unambiguous_explicit_room_group_membership() ->
     assert {item.identifier for item in structure.global_metadata if item.kind == "room_group"} == {
         "group-ground",
         "group-upper",
+    }
+
+
+def test_structure_does_not_infer_room_group_membership_from_unrelated_fields() -> None:
+    raw = {
+        "msInfo": {"serialNr": "000000000000"},
+        "lastModified": "1",
+        "rooms": {
+            "room-1": {"name": "Ground floor"},
+            "room-2": {"name": "Office", "details": {"note": "group-ground"}},
+        },
+        "cats": {},
+        "roomGroups": [
+            {
+                "uuid": "group-ground",
+                "name": "Ground floor",
+                "details": {"defaultRoom": "room-2"},
+            }
+        ],
+        "controls": {
+            room_uuid: {"name": room_uuid, "type": "Switch", "room": room_uuid, "states": {}}
+            for room_uuid in ("room-1", "room-2")
+        },
+    }
+
+    structure = normalize_structure(raw, username="reader")
+
+    assert {item.uuid: item.room_group_uuid for item in structure.rooms} == {
+        "room-1": None,
+        "room-2": None,
     }
 
 
@@ -564,6 +601,6 @@ def test_structure_rejects_invalid_history_capabilities(raw_value: object) -> No
 
     with pytest.raises(
         LoxoneStructureError,
-        match="Control details.hasHistory must be boolean or non-negative integer",
+        match=r"Control details\.hasHistory must be boolean or non-negative integer",
     ):
         normalize_structure(raw, username="reader")

--- a/tests/test_loxone_structure.py
+++ b/tests/test_loxone_structure.py
@@ -188,15 +188,36 @@ def test_structure_resolves_only_unambiguous_explicit_room_group_membership() ->
             "room-1": {"name": "Kitchen", "roomGroup": "group-ground"},
             "room-2": {"name": "Office"},
             "room-3": {"name": "Ambiguous"},
+            "room-4": {"name": "Mapped group"},
+            "room-5": {"name": "Mapped IDs"},
+            "room-6": {"name": "Direct UUID", "roomGroupUUID": "group-upper"},
+            "room-7": {"name": "Direct name", "roomGroup": "Upper floor"},
+            "room-8": {"name": "Mapped name"},
         },
         "cats": {},
         "roomGroups": [
             {"uuid": "group-ground", "name": "Ground floor", "rooms": ["room-2", "room-3"]},
-            {"uuid": "group-upper", "name": "Upper floor", "roomUuids": ["room-3"]},
+            {
+                "uuid": "group-upper",
+                "name": "Upper floor",
+                "roomUuids": ["room-3"],
+                "roomUUIDs": {"room-4": {}},
+                "roomIds": ["room-5"],
+                "roomNames": ["Mapped name"],
+            },
         ],
         "controls": {
             room_uuid: {"name": room_uuid, "type": "Switch", "room": room_uuid, "states": {}}
-            for room_uuid in ("room-1", "room-2", "room-3")
+            for room_uuid in (
+                "room-1",
+                "room-2",
+                "room-3",
+                "room-4",
+                "room-5",
+                "room-6",
+                "room-7",
+                "room-8",
+            )
         },
     }
 
@@ -206,6 +227,11 @@ def test_structure_resolves_only_unambiguous_explicit_room_group_membership() ->
         "room-1": "group-ground",
         "room-2": "group-ground",
         "room-3": None,
+        "room-4": "group-upper",
+        "room-5": "group-upper",
+        "room-6": "group-upper",
+        "room-7": "group-upper",
+        "room-8": "group-upper",
     }
     assert [(item.uuid, item.name) for item in structure.room_groups] == [
         ("group-ground", "Ground floor"),

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -121,7 +121,7 @@ def test_invalid_phase0_public_origin_is_rejected(
     monkeypatch.setenv("MCPSERVER_AUTH_STORE", str(tmp_path / "sessions.json"))
     monkeypatch.setenv("MCPSERVER_LOXONE_ENDPOINT", "http://192.168.255.254")
 
-    with pytest.raises(ValueError, match="MCPSERVER_(PUBLIC_ORIGIN|ALLOWED_ORIGINS)"):
+    with pytest.raises(ValueError, match=r"MCPSERVER_(PUBLIC_ORIGIN|ALLOWED_ORIGINS)"):
         ServerSettings.from_environment()
 
 


### PR DESCRIPTION
## Summary
- resolve explicit room-group references represented by unique names as well as UUIDs
- accept bounded list and map membership variants without inferring from room names or floors
- add regression coverage for UUID, map, and unique-name representations

## Validation
- python -m compileall -q src/mcpserver/loxone/structure.py
- git diff --check
- read-only Loxberry-Test acceptance: 20 of 22 visible rooms resolve across all 4 configured room groups
- local Full profile unavailable: workspace has Python 3.14 without test dependencies; CI is the required Python 3.13 gate