### PR TITLE
Support beta release versions

### DIFF
--- a/.github/workflows/publish-plugin-release.yml
+++ b/.github/workflows/publish-plugin-release.yml
@@ -45,8 +45,13 @@ jobs:
             { echo "Only the repository owner may start or rerun publication." >&2; exit 1; }
           [[ "$REF_NAME" == "master" ]] || { echo "Official releases must run from master." >&2; exit 1; }
           [[ "$CONFIRMED" == "true" ]] || { echo "Release confirmation is required." >&2; exit 1; }
-          [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-alpha\.[0-9]+)?$ ]] ||
+          [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta)\.[0-9]+)?$ ]] ||
             { echo "Invalid release version." >&2; exit 1; }
+          if [[ "$CHANNEL" == "stable" ]]; then
+            [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "Stable requires a plain version." >&2; exit 1; }
+          else
+            [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-(alpha|beta)\.[0-9]+$ ]] || { echo "Prerelease requires an alpha or beta version." >&2; exit 1; }
+          fi
 
   build:
     needs: authorize

--- a/.github/workflows/publish-plugin-release.yml
+++ b/.github/workflows/publish-plugin-release.yml
@@ -39,6 +39,7 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
           CONFIRMED: ${{ inputs.confirm_release }}
           VERSION: ${{ inputs.version }}
+          CHANNEL: ${{ inputs.channel }}
         run: |
           set -euo pipefail
           [[ "$ACTOR" == "$OWNER" && "$TRIGGERING_ACTOR" == "$OWNER" ]] ||

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -13,4 +13,5 @@
 - [Evidence](../evidence/README.md) — current public evidence summary.
 - [Test strategy](test-strategy.md) — change-driven validation.
 - [Release process](release-process.md) — publication workflow.
+- [Release criteria](release-criteria.md) — feature freeze and publication gate.
 - [Architecture decisions](adr/README.md) — recorded decisions and their status.

--- a/docs/development/release-criteria.md
+++ b/docs/development/release-criteria.md
@@ -1,0 +1,18 @@
+# Release criteria
+
+A beta release freezes its declared feature scope. Until the matching stable
+release, only beta blockers, fixes and necessary compatibility work are added.
+
+Before publishing, require a green Full CI run on the final commit, reviewed
+documentation and changelog, verified package and checksum, and no known
+critical security, data-loss, installation or authorization defect. Record a
+dated dependency, license and vulnerability check. Native evidence includes a
+fresh install plus Alpha-to-Beta upgrade with preserved supported configuration,
+sessions and plugin identity, installed version, service and loopback health.
+Smoke the Admin UI and an OAuth read-only MCP flow. A write smoke is separate
+and requires explicit fixture authorization. Record automated and hardware
+evidence separately.
+
+Official publication runs only from reviewed `master` through the owner-triggered
+release workflow. Prereleases use an `alpha` or `beta` version; stable releases
+use a plain release version.

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -939,6 +939,7 @@ def test_release_workflow_is_manual_owner_only_and_separates_permissions() -> No
     assert "github.triggering_actor" in workflow
     assert "github.repository_owner" in workflow
     assert "REF_NAME: ${{ github.ref_name }}" in workflow
+    assert "CHANNEL: ${{ inputs.channel }}" in workflow
     assert "ref: ${{ github.sha }}" in workflow
     assert "confirm_release:" in workflow
     assert "contents: read" in workflow

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -4,7 +4,6 @@ import configparser
 import hashlib
 import json
 import os
-import re
 import shlex
 import shutil
 import subprocess
@@ -29,6 +28,7 @@ from tools.prepare_wheelhouse import main as prepare_wheelhouse
 from tools.validate_release_metadata import validate as validate_release_metadata
 from tools.verify_plugin import (
     PackageVerificationError,
+    _expected_project_version,
     verify_archive,
 )
 from tools.verify_plugin import (
@@ -341,7 +341,7 @@ def test_postinstall_rewrites_moved_venv_entrypoints() -> None:
 def test_postinstall_project_pin_matches_plugin_version() -> None:
     parser = configparser.ConfigParser()
     parser.read(ROOT / "plugin.cfg", encoding="utf-8")
-    project_version = re.sub(r"(?i)-alpha\.(\d+)$", r"a\1", parser["PLUGIN"]["VERSION"])
+    project_version = _expected_project_version(parser["PLUGIN"]["VERSION"])
     hook = (ROOT / "postinstall.sh").read_text(encoding="utf-8")
 
     assert f"loxberry-mcpserver=={project_version}" in hook
@@ -909,8 +909,26 @@ def test_release_metadata_and_changelog_match_current_prerelease() -> None:
     assert f'__version__ = "{parser["PLUGIN"]["VERSION"]}"' in source_fallback
     with pytest.raises(ValueError, match="stable releases"):
         validate_release_metadata(ROOT, "0.4.0-alpha.15", "stable")
+    with pytest.raises(ValueError, match="prerelease releases"):
+        validate_release_metadata(ROOT, "0.4.0", "prerelease")
+    with pytest.raises(ValueError, match="channel must"):
+        validate_release_metadata(ROOT, "0.4.0-alpha.15", "preview")
     with pytest.raises(ValueError, match="versions do not match"):
         validate_release_metadata(ROOT, "0.3.0-alpha.2", "prerelease")
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    (
+        ("0.4.0-alpha.15", "0.4.0a15"),
+        ("0.4.0-beta.1", "0.4.0b1"),
+        ("0.4.0", "0.4.0"),
+    ),
+)
+def test_project_version_normalization_supports_alpha_beta_and_stable(
+    version: str, expected: str
+) -> None:
+    assert _expected_project_version(version) == expected
 
 
 def test_release_workflow_is_manual_owner_only_and_separates_permissions() -> None:

--- a/tools/build_plugin.py
+++ b/tools/build_plugin.py
@@ -10,7 +10,10 @@ import zipfile
 from pathlib import Path
 from typing import Final
 
-from tools.versioning import project_version
+try:
+    from tools.versioning import project_version
+except ModuleNotFoundError:  # Direct documented CLI execution from repository root.
+    from versioning import project_version
 
 _TIMESTAMP: Final = (2026, 1, 1, 0, 0, 0)
 _ROOT_FILES: Final = (

--- a/tools/build_plugin.py
+++ b/tools/build_plugin.py
@@ -10,6 +10,8 @@ import zipfile
 from pathlib import Path
 from typing import Final
 
+from tools.versioning import project_version
+
 _TIMESTAMP: Final = (2026, 1, 1, 0, 0, 0)
 _ROOT_FILES: Final = (
     "LICENSE",
@@ -105,7 +107,7 @@ def _project_version(root: Path) -> str:
     version = document.get("project", {}).get("version")
     if not isinstance(version, str):
         raise SystemExit("project version is missing")
-    return re.sub(r"(?i)-alpha\.(\d+)$", r"a\1", version)
+    return project_version(version)
 
 
 def _wheel_names(wheelhouse: Path) -> set[str]:

--- a/tools/validate_release_metadata.py
+++ b/tools/validate_release_metadata.py
@@ -15,10 +15,16 @@ def _read(path: Path) -> configparser.ConfigParser:
 
 
 def validate(root: Path, version: str, channel: str) -> str:
-    if re.fullmatch(r"\d+\.\d+\.\d+(?:-alpha\.\d+)?", version) is None:
-        raise ValueError("version must use x.y.z or x.y.z-alpha.n")
-    if channel == "stable" and "-alpha." in version:
-        raise ValueError("stable releases must not use an alpha version")
+    if channel not in {"prerelease", "stable"}:
+        raise ValueError("channel must be prerelease or stable")
+    prerelease = re.fullmatch(r"\d+\.\d+\.\d+-(?:alpha|beta)\.\d+", version)
+    stable = re.fullmatch(r"\d+\.\d+\.\d+", version)
+    if not prerelease and not stable:
+        raise ValueError("version must use x.y.z, x.y.z-alpha.n or x.y.z-beta.n")
+    if channel == "stable" and not stable:
+        raise ValueError("stable releases must not use a prerelease version")
+    if channel == "prerelease" and not prerelease:
+        raise ValueError("prerelease releases must use an alpha or beta version")
     plugin = _read(root / "plugin.cfg")
     selected = _read(root / ("release.cfg" if channel == "stable" else "prerelease.cfg"))
     plugin_version = plugin["PLUGIN"]["VERSION"]

--- a/tools/verify_plugin.py
+++ b/tools/verify_plugin.py
@@ -14,8 +14,10 @@ from typing import Final
 
 try:
     from tools.build_plugin import _TIMESTAMP, expected_source_entries
+    from tools.versioning import project_version
 except ModuleNotFoundError:  # Direct documented CLI execution from repository root.
     from build_plugin import _TIMESTAMP, expected_source_entries
+    from versioning import project_version
 
 _REQUIRED: Final = {
     "plugin.cfg",
@@ -99,7 +101,7 @@ def _wheel_identity(filename: str) -> tuple[str, str] | None:
 
 
 def _expected_project_version(plugin_version: str) -> str:
-    return re.sub(r"(?i)-alpha\.(\d+)$", r"a\1", plugin_version)
+    return project_version(plugin_version)
 
 
 def _verify_checksum(archive: Path, digest: str) -> None:

--- a/tools/versioning.py
+++ b/tools/versioning.py
@@ -1,0 +1,14 @@
+"""Shared release-version contract helpers."""
+
+from __future__ import annotations
+
+import re
+
+
+def project_version(version: str) -> str:
+    """Convert project prerelease labels to their PEP 440 wheel form."""
+    return re.sub(
+        r"(?i)-(alpha|beta)\.(\d+)$",
+        lambda match: {"alpha": "a", "beta": "b"}[match.group(1).lower()] + match.group(2),
+        version,
+    )


### PR DESCRIPTION
## Summary
- add strict alpha, beta and stable release contracts
- share PEP 440 project-wheel normalization
- document beta release criteria

## Validation
- Python 3.13: 587 passed, 1 known warning
- focused package/docs tests: 51 passed