### PR TITLE
Prepare 0.4.0 beta 1

### DIFF
--- a/.github/workflows/publish-plugin-release.yml
+++ b/.github/workflows/publish-plugin-release.yml
@@ -46,12 +46,12 @@ jobs:
             { echo "Only the repository owner may start or rerun publication." >&2; exit 1; }
           [[ "$REF_NAME" == "master" ]] || { echo "Official releases must run from master." >&2; exit 1; }
           [[ "$CONFIRMED" == "true" ]] || { echo "Release confirmation is required." >&2; exit 1; }
-          [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta)\.[0-9]+)?$ ]] ||
+          [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta)\.(0|[1-9][0-9]*))?$ ]] ||
             { echo "Invalid release version." >&2; exit 1; }
           if [[ "$CHANNEL" == "stable" ]]; then
             [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "Stable requires a plain version." >&2; exit 1; }
           else
-            [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-(alpha|beta)\.[0-9]+$ ]] || { echo "Prerelease requires an alpha or beta version." >&2; exit 1; }
+            [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-(alpha|beta)\.(0|[1-9][0-9]*)$ ]] || { echo "Prerelease requires an alpha or beta version." >&2; exit 1; }
           fi
 
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable user-visible changes are recorded here. GitHub release notes are
 extracted from the matching version heading.
 
-## Unreleased
+## 0.4.0-beta.1 - 2026-08-15
 
 - Add `loxone_get_room_snapshot` for bounded current states in one exact visible
   room and `loxone_get_weather` for current or paginated forecast weather.
@@ -22,6 +22,11 @@ extracted from the matching version heading.
 - Preserve explicit WindowMonitor item mappings when LoxAPP3 represents them as
   a bounded object keyed by control identifier, so their referenced visible
   controls can be resolved without name inference.
+
+- Begin the feature-frozen `0.4.0` beta channel. Future `0.4.0` changes are
+  limited to beta blockers, fixes and necessary compatibility corrections.
+
+## Unreleased
 
 ## 0.4.0-alpha.15 - 2026-08-15
 

--- a/docs/evidence/README.md
+++ b/docs/evidence/README.md
@@ -7,3 +7,4 @@
 ## Contents
 
 - [Current evidence](current-evidence.md) — what is implemented, automatically tested and hardware confirmed.
+- [Beta 1 readiness](beta-1-readiness.md) — final release gate and dated audit status.

--- a/docs/evidence/beta-1-readiness.md
+++ b/docs/evidence/beta-1-readiness.md
@@ -1,0 +1,45 @@
+# Beta 1 readiness record
+
+- **Date:** 2026-08-15
+- **Candidate:** `0.4.0-beta.1`
+- **Scope:** Feature-frozen `0.4.0` beta; only blockers, fixes and required compatibility changes may follow.
+
+## Deterministic evidence
+
+The final commit requires the Python 3.13 Full gate, release metadata validation,
+a verified release-candidate ZIP and SHA-256 sidecar. CI is the authoritative
+gate for the merged commit.
+
+## Dependency and license check
+
+Runtime dependencies are locked in `requirements/runtime-arm64.lock`. The
+repository's Dependabot alerts endpoint was checked on 2026-08-15 but is disabled
+for this repository, so it provides no vulnerability result. `pip-audit` is not
+installed in the release environment. This is recorded as an incomplete external
+vulnerability check, not as a clean result. The existing Apache-2.0 project
+license and locked dependency set have not received a dated beta review.
+Publication is blocked until the dependency, license and vulnerability check is
+completed and recorded.
+
+## Required native acceptance
+
+Before publication, perform a native fresh install and a separate Alpha-15
+upgrade of the verified candidate on the authorized target. For both paths,
+verify terminal installer status, version, active service and loopback health;
+for the upgrade also verify preserved supported configuration, sessions and
+plugin identity. Smoke the Admin UI and an OAuth read-only MCP flow. No write
+action is part of this record without separate current fixture authorization.
+
+## Candidate evidence
+
+The verified local candidate SHA-256 was
+`92c26365f350977a2a2a89faae66ec7e201e8cb0bd4ed25a348c6d274da3a5a6`.
+Its native installation on the authorized target restarted the service. The
+subsequent loopback health response reported `0.4.0b1`; the bounded diagnostic
+reported an active, enabled service and five retained sessions. The Plugin
+Manager status files include terminal success (`0`) records for the install.
+
+The Admin UI and OAuth read-only smoke remain open: both available browsers
+received native HTTP Basic authentication rejection and no credentials were
+entered. The incomplete external vulnerability check and these two smokes are
+release blockers; this record does not claim publication readiness.

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -3,11 +3,11 @@ NAME=Miraculix2050
 EMAIL=198097126+Miraculix2050@users.noreply.github.com
 
 [PLUGIN]
-VERSION=0.4.0-alpha.15
+VERSION=0.4.0-beta.1
 NAME=mcpserver
 FOLDER=mcpserver
 TITLE=LoxBerry MCP Server
-WEBSITE=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/blob/v0.4.0-alpha.15/README.md
+WEBSITE=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/blob/v0.4.0-beta.1/README.md
 
 [AUTOUPDATE]
 AUTOMATIC_UPDATES=true

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -52,7 +52,7 @@ fi
 
 python3.13 -m venv "$new_venv" || exit 2
 "$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" -r "$plugin_bin/runtime-arm64.lock" || exit 2
-"$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" loxberry-mcpserver==0.4.0a15 || exit 2
+"$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" loxberry-mcpserver==0.4.0b1 || exit 2
 if [ -d "$venv" ]; then
     mv "$venv" "$old_venv" || exit 2
 fi

--- a/preinstall.sh
+++ b/preinstall.sh
@@ -6,7 +6,7 @@ if ! command -v python3.13 >/dev/null 2>&1; then
     exit 2
 fi
 if [ "$(dpkg --print-architecture 2>/dev/null)" != "arm64" ]; then
-    echo "<ERROR> This alpha package contains arm64 runtime wheels only."
+    echo "<ERROR> This prerelease package contains arm64 runtime wheels only."
     exit 2
 fi
 for command in openssl systemctl systemd-run apache2ctl; do

--- a/prerelease.cfg
+++ b/prerelease.cfg
@@ -1,4 +1,4 @@
 [AUTOUPDATE]
-VERSION=0.4.0-alpha.15
-ARCHIVEURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/download/v0.4.0-alpha.15/LoxBerry-MCP-Server-0.4.0-alpha.15.zip
-INFOURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/tag/v0.4.0-alpha.15
+VERSION=0.4.0-beta.1
+ARCHIVEURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/download/v0.4.0-beta.1/LoxBerry-MCP-Server-0.4.0-beta.1.zip
+INFOURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/tag/v0.4.0-beta.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loxberry-mcpserver"
-version = "0.4.0-alpha.15"
+version = "0.4.0-beta.1"
 description = "Local MCP server for LoxBerry and Loxone"
 requires-python = ">=3.13,<3.14"
 license = "Apache-2.0"

--- a/src/mcpserver/__init__.py
+++ b/src/mcpserver/__init__.py
@@ -5,6 +5,6 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("loxberry-mcpserver")
 except PackageNotFoundError:  # pragma: no cover - source tree without installation
-    __version__ = "0.4.0-alpha.15"
+    __version__ = "0.4.0-beta.1"
 
 __all__ = ["__version__"]

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -145,7 +145,7 @@ def test_plugin_identity_and_platform_contract() -> None:
     assert parser["PLUGIN"]["NAME"] == "mcpserver"
     assert parser["PLUGIN"]["FOLDER"] == "mcpserver"
     assert parser["PLUGIN"]["TITLE"] == "LoxBerry MCP Server"
-    assert parser["PLUGIN"]["VERSION"] == "0.4.0-alpha.15"
+    assert parser["PLUGIN"]["VERSION"] == "0.4.0-beta.1"
     assert parser["AUTOUPDATE"]["AUTOMATIC_UPDATES"] == "true"
     assert parser["AUTOUPDATE"]["RELEASECFG"].startswith("https://")
     assert parser["AUTOUPDATE"]["PRERELEASECFG"].startswith("https://")
@@ -480,7 +480,7 @@ def test_plugin_archive_verifier_accepts_builder_output(tmp_path: Path) -> None:
     for name, version in _locked_requirements(ROOT / "requirements" / "runtime-arm64.lock").items():
         wheel_name = name.replace("-", "_")
         (wheelhouse / f"{wheel_name}-{version}-py3-none-any.whl").write_bytes(b"wheel")
-    project_wheel = wheelhouse / "loxberry_mcpserver-0.4.0a15-py3-none-any.whl"
+    project_wheel = wheelhouse / "loxberry_mcpserver-0.4.0b1-py3-none-any.whl"
     _write_project_wheel(project_wheel)
     hash_lock = tmp_path / "runtime-arm64.sha256"
     hash_lock.write_text(
@@ -900,19 +900,19 @@ def test_plugin_archive_verifier_rejects_checksum_mismatch(tmp_path: Path) -> No
 
 
 def test_release_metadata_and_changelog_match_current_prerelease() -> None:
-    notes = validate_release_metadata(ROOT, "0.4.0-alpha.15", "prerelease")
+    notes = validate_release_metadata(ROOT, "0.4.0-beta.1", "prerelease")
     parser = configparser.ConfigParser()
     parser.read(ROOT / "plugin.cfg", encoding="utf-8")
     source_fallback = (ROOT / "src" / "mcpserver" / "__init__.py").read_text(encoding="utf-8")
 
-    assert "Fail closed when the Miniserver binary-state stream ends" in notes
+    assert "Add `loxone_get_room_snapshot`" in notes
     assert f'__version__ = "{parser["PLUGIN"]["VERSION"]}"' in source_fallback
     with pytest.raises(ValueError, match="stable releases"):
-        validate_release_metadata(ROOT, "0.4.0-alpha.15", "stable")
+        validate_release_metadata(ROOT, "0.4.0-beta.1", "stable")
     with pytest.raises(ValueError, match="prerelease releases"):
         validate_release_metadata(ROOT, "0.4.0", "prerelease")
     with pytest.raises(ValueError, match="channel must"):
-        validate_release_metadata(ROOT, "0.4.0-alpha.15", "preview")
+        validate_release_metadata(ROOT, "0.4.0-beta.1", "preview")
     with pytest.raises(ValueError, match="versions do not match"):
         validate_release_metadata(ROOT, "0.3.0-alpha.2", "prerelease")
 
@@ -929,6 +929,14 @@ def test_project_version_normalization_supports_alpha_beta_and_stable(
     version: str, expected: str
 ) -> None:
     assert _expected_project_version(version) == expected
+
+
+@pytest.mark.parametrize("version", ("0.4.0-alpha.01", "0.4.0-beta.01", "0.4.0-BETA.1"))
+def test_project_version_normalization_rejects_leading_zero_prerelease_counter(
+    version: str,
+) -> None:
+    with pytest.raises(ValueError, match="version must use"):
+        _expected_project_version(version)
 
 
 def test_release_workflow_is_manual_owner_only_and_separates_permissions() -> None:

--- a/tools/validate_release_metadata.py
+++ b/tools/validate_release_metadata.py
@@ -7,6 +7,11 @@ import configparser
 import re
 from pathlib import Path
 
+try:
+    from tools.versioning import VERSION_PATTERN
+except ModuleNotFoundError:  # Direct documented CLI execution from repository root.
+    from versioning import VERSION_PATTERN
+
 
 def _read(path: Path) -> configparser.ConfigParser:
     parser = configparser.ConfigParser()
@@ -17,9 +22,9 @@ def _read(path: Path) -> configparser.ConfigParser:
 def validate(root: Path, version: str, channel: str) -> str:
     if channel not in {"prerelease", "stable"}:
         raise ValueError("channel must be prerelease or stable")
-    prerelease = re.fullmatch(r"\d+\.\d+\.\d+-(?:alpha|beta)\.\d+", version)
+    prerelease = re.fullmatch(r"\d+\.\d+\.\d+-(?:alpha|beta)\.(?:0|[1-9]\d*)", version)
     stable = re.fullmatch(r"\d+\.\d+\.\d+", version)
-    if not prerelease and not stable:
+    if VERSION_PATTERN.fullmatch(version) is None or (not prerelease and not stable):
         raise ValueError("version must use x.y.z, x.y.z-alpha.n or x.y.z-beta.n")
     if channel == "stable" and not stable:
         raise ValueError("stable releases must not use a prerelease version")

--- a/tools/versioning.py
+++ b/tools/versioning.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 import re
 
+VERSION_PATTERN = re.compile(r"[0-9]+\.[0-9]+\.[0-9]+(?:-(?:alpha|beta)\.(?:0|[1-9][0-9]*))?$")
+
 
 def project_version(version: str) -> str:
     """Convert project prerelease labels to their PEP 440 wheel form."""
+    if VERSION_PATTERN.fullmatch(version) is None:
+        raise ValueError("version must use x.y.z, x.y.z-alpha.n or x.y.z-beta.n")
     return re.sub(
-        r"(?i)-(alpha|beta)\.(\d+)$",
+        r"-(alpha|beta)\.([0-9]+)$",
         lambda match: {"alpha": "a", "beta": "b"}[match.group(1).lower()] + match.group(2),
         version,
     )


### PR DESCRIPTION
## Summary
- Freeze the 0.4.0 beta scope and synchronize all prerelease version contracts to 0.4.0-beta.1.
- Add a dated Beta-1 readiness record and hardened alpha/beta version validation.
- Update package fixtures, wheel pinning and prerelease-only wording.

## Validation
- Python 3.13: ruff format/check, mypy, 594 pytest passed.
- Verified local release-candidate ZIP and SHA-256; native target health reports 0.4.0b1 with active service and retained sessions.
- Three review rounds completed; no open P1/P2 findings.

## Publication gate
This PR deliberately records remaining blockers before the owner-triggered GitHub prerelease: separate fresh-install proof, a completed dated dependency/license/vulnerability review, and authenticated Admin-UI plus OAuth read-only smoke. No write smoke was performed.