### PR TITLE
Enable bounded read defaults on fresh setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable user-visible changes are recorded here. GitHub release notes are
 extracted from the matching version heading.
 
+## 0.4.0-beta.2 - 2026-08-15
+
+- Enable bounded history/statistics and masked LoxBerry diagnostics for fresh
+  installations. Saving the first complete configuration also enables the
+  service; OAuth consent and local diagnostic approvals remain required.
+
 ## 0.4.0-beta.1 - 2026-08-15
 
 - Add `loxone_get_room_snapshot` for bounded current states in one exact visible

--- a/config/default-config.json
+++ b/config/default-config.json
@@ -35,9 +35,9 @@
   },
   "tools": {
     "loxone_control_enabled": false,
-    "loxone_history_enabled": false,
+    "loxone_history_enabled": true,
     "loxone_read_enabled": true,
-    "loxberry_read_enabled": false,
+    "loxberry_read_enabled": true,
     "loxberry_operate_enabled": false
   }
 }

--- a/docs/user/configuration.de.md
+++ b/docs/user/configuration.de.md
@@ -4,7 +4,7 @@
 
 ## Grundeinstellungen
 
-Konfiguriere eine lokale HTTPS-Origin und genau ein Miniserver-Ziel. Die Auswahl eines in LoxBerry hinterlegten Miniservers übernimmt keine dort gespeicherten Zugangsdaten. Ein nicht erreichbares oder ungültiges Ziel wird nicht aktiviert.
+Konfiguriere eine lokale HTTPS-Origin und genau ein Miniserver-Ziel. Die Auswahl eines in LoxBerry hinterlegten Miniservers übernimmt keine dort gespeicherten Zugangsdaten. Das erste Speichern einer vollständigen, gültigen Einrichtung aktiviert den Server; prüfe die Verbindung vor dem produktiven Einsatz.
 
 ## Zertifikat
 
@@ -12,6 +12,6 @@ Verwende für MCP-Clients eine Adresse, die vom LoxBerry-Webserverzertifikat abg
 
 ## Funktionsfreigaben
 
-Die Admin-Oberfläche aktiviert Funktionen nur grundsätzlich. Der Client muss den passenden Scope zusätzlich anfordern und der Benutzer bestätigen.
+Lesezugriff sowie Historie/Statistiken und LoxBerry-Diagnose sind grundsätzlich verfügbar. Der Client muss den passenden Scope zusätzlich anfordern und der Benutzer bestätigen; LoxBerry-Diagnose benötigt außerdem eine lokale Freigabe.
 
 Weiter: [Berechtigungen](permissions.de.md).

--- a/docs/user/configuration.en.md
+++ b/docs/user/configuration.en.md
@@ -4,7 +4,7 @@
 
 ## Basic settings
 
-Configure one local HTTPS origin and exactly one Miniserver target. Selecting a Miniserver stored in LoxBerry does not reuse its credentials. An unreachable or invalid target is not enabled.
+Configure one local HTTPS origin and exactly one Miniserver target. Selecting a Miniserver stored in LoxBerry does not reuse its credentials. The first save of a complete, valid setup enables the server; test the connection before production use.
 
 ## Certificate
 
@@ -12,6 +12,6 @@ Use an MCP client address covered by the LoxBerry web-server certificate. Certif
 
 ## Feature switches
 
-The admin interface only enables a feature globally. The client must also request the matching scope and the user must approve it.
+Read access, history/statistics and LoxBerry diagnostics are globally available. The client must still request the matching scope and the user must approve it; LoxBerry diagnostics also require local approval.
 
 Next: [Permissions](permissions.en.md).

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -3,11 +3,11 @@ NAME=Miraculix2050
 EMAIL=198097126+Miraculix2050@users.noreply.github.com
 
 [PLUGIN]
-VERSION=0.4.0-beta.1
+VERSION=0.4.0-beta.2
 NAME=mcpserver
 FOLDER=mcpserver
 TITLE=LoxBerry MCP Server
-WEBSITE=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/blob/v0.4.0-beta.1/README.md
+WEBSITE=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/blob/v0.4.0-beta.2/README.md
 
 [AUTOUPDATE]
 AUTOMATIC_UPDATES=true

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -52,7 +52,7 @@ fi
 
 python3.13 -m venv "$new_venv" || exit 2
 "$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" -r "$plugin_bin/runtime-arm64.lock" || exit 2
-"$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" loxberry-mcpserver==0.4.0b1 || exit 2
+"$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" loxberry-mcpserver==0.4.0b2 || exit 2
 if [ -d "$venv" ]; then
     mv "$venv" "$old_venv" || exit 2
 fi

--- a/prerelease.cfg
+++ b/prerelease.cfg
@@ -1,4 +1,4 @@
 [AUTOUPDATE]
-VERSION=0.4.0-beta.1
-ARCHIVEURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/download/v0.4.0-beta.1/LoxBerry-MCP-Server-0.4.0-beta.1.zip
-INFOURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/tag/v0.4.0-beta.1
+VERSION=0.4.0-beta.2
+ARCHIVEURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/download/v0.4.0-beta.2/LoxBerry-MCP-Server-0.4.0-beta.2.zip
+INFOURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/tag/v0.4.0-beta.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loxberry-mcpserver"
-version = "0.4.0-beta.1"
+version = "0.4.0-beta.2"
 description = "Local MCP server for LoxBerry and Loxone"
 requires-python = ">=3.13,<3.14"
 license = "Apache-2.0"

--- a/src/mcpserver/__init__.py
+++ b/src/mcpserver/__init__.py
@@ -5,6 +5,6 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("loxberry-mcpserver")
 except PackageNotFoundError:  # pragma: no cover - source tree without installation
-    __version__ = "0.4.0-beta.1"
+    __version__ = "0.4.0-beta.2"
 
 __all__ = ["__version__"]

--- a/src/mcpserver/admin.py
+++ b/src/mcpserver/admin.py
@@ -269,6 +269,16 @@ def _save(payload: object) -> dict[str, Any]:
     config = PluginConfig.from_document(payload)
     store = _config_store()
     previous = store.load()
+    if (
+        not previous.enabled
+        and not previous.public_origin
+        and not previous.loxone_endpoint
+        and not config.enabled
+        and config.public_origin
+        and config.loxone_endpoint
+        and config.loxone_read_enabled
+    ):
+        config = replace(config, enabled=True)
     if "logging" not in payload:
         config = replace(config, log_level=previous.log_level)
     if "policies" not in payload:

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -785,6 +785,51 @@ def test_failed_config_apply_restores_previous_configuration(
     assert store.load().to_document() == previous.to_document()
 
 
+def test_first_complete_configuration_enables_the_service(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = AtomicConfigStore((tmp_path / "config" / "mcpserver.json").resolve())
+    store.save(PluginConfig.defaults())
+    monkeypatch.setattr("mcpserver.admin._config_store", lambda: store)
+    monkeypatch.setattr("mcpserver.admin._restart_service", lambda: None)
+    monkeypatch.setattr("mcpserver.admin._sessions", lambda: [])
+    monkeypatch.setattr("mcpserver.admin._service_response", lambda: {"service_active": True})
+
+    result = _save(
+        {
+            "schema_version": 4,
+            "server": {"enabled": False, "public_origin": "https://loxberry.example"},
+            "loxone": {"endpoint": "http://192.168.10.20"},
+        }
+    )
+
+    assert store.load().enabled is True
+    assert result["configuration"]["server"]["enabled"] is True
+
+
+def test_first_complete_configuration_respects_disabled_read_access(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = AtomicConfigStore((tmp_path / "config" / "mcpserver.json").resolve())
+    store.save(PluginConfig.defaults())
+    monkeypatch.setattr("mcpserver.admin._config_store", lambda: store)
+    monkeypatch.setattr("mcpserver.admin._restart_service", lambda: None)
+    monkeypatch.setattr("mcpserver.admin._sessions", lambda: [])
+    monkeypatch.setattr("mcpserver.admin._service_response", lambda: {"service_active": True})
+
+    result = _save(
+        {
+            "schema_version": 4,
+            "server": {"enabled": False, "public_origin": "https://loxberry.example"},
+            "loxone": {"endpoint": "http://192.168.10.20"},
+            "tools": {"loxone_read_enabled": False},
+        }
+    )
+
+    assert store.load().enabled is False
+    assert result["configuration"]["server"]["enabled"] is False
+
+
 @pytest.mark.parametrize(
     "mode",
     ["off", "error", "warning", "info", "debug"],

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -35,6 +35,21 @@ def test_defaults_are_disabled_and_bounded() -> None:
     assert config.log_level == "warning"
 
 
+def test_fresh_install_default_enables_read_only_history_and_diagnostics() -> None:
+    document = json.loads(
+        (Path(__file__).resolve().parents[1] / "config" / "default-config.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    config = PluginConfig.from_document(document)
+
+    assert config.enabled is False
+    assert config.loxone_read_enabled is True
+    assert config.loxone_history_enabled is True
+    assert config.loxberry_read_enabled is True
+    assert config.loxberry_read_bindings == ()
+
+
 def test_configuration_round_trip_preserves_unknown_keys(tmp_path: Path) -> None:
     store = AtomicConfigStore((tmp_path / "config.json").resolve())
     config = PluginConfig.from_document(

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -145,7 +145,7 @@ def test_plugin_identity_and_platform_contract() -> None:
     assert parser["PLUGIN"]["NAME"] == "mcpserver"
     assert parser["PLUGIN"]["FOLDER"] == "mcpserver"
     assert parser["PLUGIN"]["TITLE"] == "LoxBerry MCP Server"
-    assert parser["PLUGIN"]["VERSION"] == "0.4.0-beta.1"
+    assert parser["PLUGIN"]["VERSION"] == "0.4.0-beta.2"
     assert parser["AUTOUPDATE"]["AUTOMATIC_UPDATES"] == "true"
     assert parser["AUTOUPDATE"]["RELEASECFG"].startswith("https://")
     assert parser["AUTOUPDATE"]["PRERELEASECFG"].startswith("https://")
@@ -480,7 +480,7 @@ def test_plugin_archive_verifier_accepts_builder_output(tmp_path: Path) -> None:
     for name, version in _locked_requirements(ROOT / "requirements" / "runtime-arm64.lock").items():
         wheel_name = name.replace("-", "_")
         (wheelhouse / f"{wheel_name}-{version}-py3-none-any.whl").write_bytes(b"wheel")
-    project_wheel = wheelhouse / "loxberry_mcpserver-0.4.0b1-py3-none-any.whl"
+    project_wheel = wheelhouse / "loxberry_mcpserver-0.4.0b2-py3-none-any.whl"
     _write_project_wheel(project_wheel)
     hash_lock = tmp_path / "runtime-arm64.sha256"
     hash_lock.write_text(
@@ -900,19 +900,19 @@ def test_plugin_archive_verifier_rejects_checksum_mismatch(tmp_path: Path) -> No
 
 
 def test_release_metadata_and_changelog_match_current_prerelease() -> None:
-    notes = validate_release_metadata(ROOT, "0.4.0-beta.1", "prerelease")
+    notes = validate_release_metadata(ROOT, "0.4.0-beta.2", "prerelease")
     parser = configparser.ConfigParser()
     parser.read(ROOT / "plugin.cfg", encoding="utf-8")
     source_fallback = (ROOT / "src" / "mcpserver" / "__init__.py").read_text(encoding="utf-8")
 
-    assert "Add `loxone_get_room_snapshot`" in notes
+    assert "Enable bounded history/statistics" in notes
     assert f'__version__ = "{parser["PLUGIN"]["VERSION"]}"' in source_fallback
     with pytest.raises(ValueError, match="stable releases"):
-        validate_release_metadata(ROOT, "0.4.0-beta.1", "stable")
+        validate_release_metadata(ROOT, "0.4.0-beta.2", "stable")
     with pytest.raises(ValueError, match="prerelease releases"):
         validate_release_metadata(ROOT, "0.4.0", "prerelease")
     with pytest.raises(ValueError, match="channel must"):
-        validate_release_metadata(ROOT, "0.4.0-beta.1", "preview")
+        validate_release_metadata(ROOT, "0.4.0-beta.2", "preview")
     with pytest.raises(ValueError, match="versions do not match"):
         validate_release_metadata(ROOT, "0.3.0-alpha.2", "prerelease")
 


### PR DESCRIPTION
## Summary\n- enable history/statistics and masked LoxBerry diagnostics in the fresh-install configuration\n- activate the service when the first complete valid setup is saved, without changing existing installations\n- prepare the corrective prerelease as 0.4.0-beta.2 and cover defaults, activation, package pin and release metadata\n\n## Validation\n- Python 3.13: ruff format --check ., ruff check ., mypy src\n- Python 3.13: pytest -q --basetemp=.pytest-tmp\\beta2 -p no:cacheprovider (597 passed)