### PR TITLE
Fix fresh setup defaults and LogManager integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable user-visible changes are recorded here. GitHub release notes are
 extracted from the matching version heading.
 
+## 0.4.0-beta.3 - 2026-08-15
+
+- Enable the bounded read-only feature families for fresh installations, prefill
+  the HTTPS origin from LoxBerry's configured host, and register admin logs with
+  the LoxBerry LogManager. Upgrades preserve their configuration; write scopes remain off.
+
 ## 0.4.0-beta.2 - 2026-08-15
 
 - Enable bounded history/statistics and masked LoxBerry diagnostics for fresh

--- a/docs/user/configuration.de.md
+++ b/docs/user/configuration.de.md
@@ -4,7 +4,7 @@
 
 ## Grundeinstellungen
 
-Konfiguriere eine lokale HTTPS-Origin und genau ein Miniserver-Ziel. Die Auswahl eines in LoxBerry hinterlegten Miniservers übernimmt keine dort gespeicherten Zugangsdaten. Das erste Speichern einer vollständigen, gültigen Einrichtung aktiviert den Server; prüfe die Verbindung vor dem produktiven Einsatz.
+Konfiguriere eine lokale HTTPS-Origin und genau ein Miniserver-Ziel. Die Auswahl eines in LoxBerry hinterlegten Miniservers übernimmt keine dort gespeicherten Zugangsdaten. Bei der ersten Einrichtung wird die Origin aus LoxBerry-Hostname und HTTPS-Port vorgeschlagen; prüfe, ob sie zur Zertifikatsadresse im Browser passt. Das erste Speichern einer vollständigen, gültigen Einrichtung aktiviert den Server.
 
 ## Zertifikat
 

--- a/docs/user/configuration.en.md
+++ b/docs/user/configuration.en.md
@@ -4,7 +4,7 @@
 
 ## Basic settings
 
-Configure one local HTTPS origin and exactly one Miniserver target. Selecting a Miniserver stored in LoxBerry does not reuse its credentials. The first save of a complete, valid setup enables the server; test the connection before production use.
+Configure one local HTTPS origin and exactly one Miniserver target. Selecting a Miniserver stored in LoxBerry does not reuse its credentials. On first setup, the origin is suggested from the LoxBerry hostname and HTTPS port; verify it matches the browser's certificate address. The first save of a complete, valid setup enables the server.
 
 ## Certificate
 

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -3,11 +3,11 @@ NAME=Miraculix2050
 EMAIL=198097126+Miraculix2050@users.noreply.github.com
 
 [PLUGIN]
-VERSION=0.4.0-beta.2
+VERSION=0.4.0-beta.3
 NAME=mcpserver
 FOLDER=mcpserver
 TITLE=LoxBerry MCP Server
-WEBSITE=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/blob/v0.4.0-beta.2/README.md
+WEBSITE=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/blob/v0.4.0-beta.3/README.md
 
 [AUTOUPDATE]
 AUTOMATIC_UPDATES=true

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -52,7 +52,7 @@ fi
 
 python3.13 -m venv "$new_venv" || exit 2
 "$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" -r "$plugin_bin/runtime-arm64.lock" || exit 2
-"$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" loxberry-mcpserver==0.4.0b2 || exit 2
+"$new_venv/bin/python" -m pip install --no-index --no-deps --find-links "$wheelhouse" loxberry-mcpserver==0.4.0b3 || exit 2
 if [ -d "$venv" ]; then
     mv "$venv" "$old_venv" || exit 2
 fi

--- a/prerelease.cfg
+++ b/prerelease.cfg
@@ -1,4 +1,4 @@
 [AUTOUPDATE]
-VERSION=0.4.0-beta.2
-ARCHIVEURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/download/v0.4.0-beta.2/LoxBerry-MCP-Server-0.4.0-beta.2.zip
-INFOURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/tag/v0.4.0-beta.2
+VERSION=0.4.0-beta.3
+ARCHIVEURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/download/v0.4.0-beta.3/LoxBerry-MCP-Server-0.4.0-beta.3.zip
+INFOURL=https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server/releases/tag/v0.4.0-beta.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loxberry-mcpserver"
-version = "0.4.0-beta.2"
+version = "0.4.0-beta.3"
 description = "Local MCP server for LoxBerry and Loxone"
 requires-python = ">=3.13,<3.14"
 license = "Apache-2.0"

--- a/src/mcpserver/__init__.py
+++ b/src/mcpserver/__init__.py
@@ -5,6 +5,6 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("loxberry-mcpserver")
 except PackageNotFoundError:  # pragma: no cover - source tree without installation
-    __version__ = "0.4.0-beta.2"
+    __version__ = "0.4.0-beta.3"
 
 __all__ = ["__version__"]

--- a/templates/lang/language_de.ini
+++ b/templates/lang/language_de.ini
@@ -117,7 +117,7 @@ LEVEL_WARNING=Warnungen
 LEVEL_INFO=Informationen
 LEVEL_DEBUG=Debug
 LOGGING_HELP=Diese Einstellung gilt ausschließlich für service.log. Sicherheits-Audits für Steueraktionen werden auch bei „Aus“ protokolliert. Die aktive Datei und zwei Backups sind auf jeweils 512 KiB begrenzt.
-LOGMANAGER_HELP=Der nachfolgende LoxBerry-Log-Level steuert admin-ui.log und andere Plugin-Logs, nicht service.log. Auch admin-ui.log ist auf die aktive Datei und zwei Backups mit jeweils 512 KiB begrenzt.
+LOGMANAGER_HELP=Der nachfolgende LoxBerry-Log-Level steuert native Plugin-Logs im LoxBerry LogManager, nicht service.log. Der LogManager verwaltet deren Aufbewahrung.
 
 [HELP]
 TITLE=Hilfe

--- a/templates/lang/language_en.ini
+++ b/templates/lang/language_en.ini
@@ -117,7 +117,7 @@ LEVEL_WARNING=Warnings
 LEVEL_INFO=Information
 LEVEL_DEBUG=Debug
 LOGGING_HELP=This setting applies only to service.log. Security audits for control operations are recorded even when Off is selected. The active file and two backups are each limited to 512 KiB.
-LOGMANAGER_HELP=The LoxBerry log level below controls admin-ui.log and other plugin logs, not service.log. admin-ui.log is also limited to the active file and two 512 KiB backups.
+LOGMANAGER_HELP=The LoxBerry log level below controls native plugin logs in the LoxBerry Log Manager, not service.log. The Log Manager handles their retention.
 
 [HELP]
 TITLE=Help

--- a/tests/test_admin_ui.py
+++ b/tests/test_admin_ui.py
@@ -125,16 +125,14 @@ def test_read_only_ajax_polling_does_not_create_admin_log_files() -> None:
 
     assert "sub admin_log" in cgi
     assert cgi.index("sub admin_log") < cgi.index("LoxBerry::Log->new")
-    assert "$admin_log->close() if $admin_log;" in cgi
+    assert "$admin_log->close() if $admin_log;" not in cgi
     assert "LOGSTART('index.cgi called')" not in cgi
     assert "loglevel => 7" not in cgi
-    assert "filename => $filename" in cgi
-    assert "append => 1" in cgi
-    assert "nosession => 1" in cgi
+    assert "            filename => $filename," not in cgi
+    assert "append => 1" not in cgi
+    assert "nosession => 1" not in cgi
     assert "LoxBerry::System::pluginloglevel($lbpplugindir)" in cgi
-    assert "flock($lock, LOCK_EX)" in cgi
-    assert "ADMIN_LOG_MAX_BYTES => 512 * 1024" in cgi
-    assert "ADMIN_LOG_BACKUP_COUNT => 2" in cgi
+    assert "name => 'admin-ui'" in cgi
     assert "ADMIN_LOG_MESSAGE_BYTES => 8 * 1024" in cgi
     assert "LOGSTART('Administrative action')" not in cgi
     assert "LOGEND('Administrative action finished')" not in cgi
@@ -175,41 +173,12 @@ def test_diagnostics_offer_dedicated_persistent_service_logging_controls() -> No
     assert "window.location.reload" not in template
 
 
-def test_admin_log_message_and_rotation_are_bounded(tmp_path: Path) -> None:
+def test_first_setup_prefills_https_origin_from_loxberry_hostname() -> None:
     cgi = (ROOT / "webfrontend/htmlauth/index.cgi").read_text(encoding="utf-8")
-    implementation = re.search(
-        r"(use constant ADMIN_LOG_MAX_BYTES.*?)(?=sub admin_log \{)",
-        cgi,
-        re.DOTALL,
-    )
-    assert implementation is not None
-    perl = shutil.which("perl")
-    assert perl is not None, "Perl is required for the complete deterministic gate"
-    log_file = tmp_path / "admin-ui.log"
-    log_file.write_bytes(b"x" * (512 * 1024 - 100))
-    for suffix, content in ((".1", b"one"), (".2", b"two"), (".3", b"stale")):
-        log_file.with_name(log_file.name + suffix).write_bytes(content)
-    script = f"""
-use strict;
-use warnings;
-use Encode qw(decode encode FB_DEFAULT);
-{implementation.group(1)}
-my $message = bounded_admin_message(chr(0xE4) x 8000);
-print length(encode('UTF-8', $message)), "\n";
-print rotate_admin_log_locked($ARGV[0], 300), "\n";
-"""
 
-    result = subprocess.run(
-        [perl, "-e", script, str(log_file)],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-
-    assert result.stdout.splitlines() == [str(8 * 1024), "1"]
-    assert log_file.with_name(log_file.name + ".1").stat().st_size == 512 * 1024 - 100
-    assert log_file.with_name(log_file.name + ".2").read_bytes() == b"one"
-    assert not log_file.with_name(log_file.name + ".3").exists()
+    assert "my $hostname_mcp_url = local_mcp_url(LoxBerry::System::lbhostname(), $sslport);" in cgi
+    assert "if ($public_origin eq '' && $hostname_mcp_url ne '')" in cgi
+    assert "s{/plugins/mcpserver/mcp\\z}{}" in cgi
 
 
 def test_service_actions_use_an_accessible_confirmation_and_dynamic_controls() -> None:

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -145,7 +145,7 @@ def test_plugin_identity_and_platform_contract() -> None:
     assert parser["PLUGIN"]["NAME"] == "mcpserver"
     assert parser["PLUGIN"]["FOLDER"] == "mcpserver"
     assert parser["PLUGIN"]["TITLE"] == "LoxBerry MCP Server"
-    assert parser["PLUGIN"]["VERSION"] == "0.4.0-beta.2"
+    assert parser["PLUGIN"]["VERSION"] == "0.4.0-beta.3"
     assert parser["AUTOUPDATE"]["AUTOMATIC_UPDATES"] == "true"
     assert parser["AUTOUPDATE"]["RELEASECFG"].startswith("https://")
     assert parser["AUTOUPDATE"]["PRERELEASECFG"].startswith("https://")
@@ -223,6 +223,7 @@ def test_upgrade_preserves_configuration_in_plugin_data() -> None:
     assert 'upgrade_backup="$upgrade_backup_dir/mcpserver.json"' in postinstall
     assert 'install -m 600 "$upgrade_backup" "$config_file"' in postinstall
     assert "sessions.json loxone-tokens.json.enc install.key" in postinstall
+    assert 'cp "$plugin_config/default-config.json" "$config_file"' in postinstall
     assert postinstall.index('install -m 600 "$upgrade_backup" "$config_file"') < postinstall.index(
         'cp "$plugin_config/default-config.json" "$config_file"'
     )
@@ -480,7 +481,7 @@ def test_plugin_archive_verifier_accepts_builder_output(tmp_path: Path) -> None:
     for name, version in _locked_requirements(ROOT / "requirements" / "runtime-arm64.lock").items():
         wheel_name = name.replace("-", "_")
         (wheelhouse / f"{wheel_name}-{version}-py3-none-any.whl").write_bytes(b"wheel")
-    project_wheel = wheelhouse / "loxberry_mcpserver-0.4.0b2-py3-none-any.whl"
+    project_wheel = wheelhouse / "loxberry_mcpserver-0.4.0b3-py3-none-any.whl"
     _write_project_wheel(project_wheel)
     hash_lock = tmp_path / "runtime-arm64.sha256"
     hash_lock.write_text(
@@ -900,19 +901,19 @@ def test_plugin_archive_verifier_rejects_checksum_mismatch(tmp_path: Path) -> No
 
 
 def test_release_metadata_and_changelog_match_current_prerelease() -> None:
-    notes = validate_release_metadata(ROOT, "0.4.0-beta.2", "prerelease")
+    notes = validate_release_metadata(ROOT, "0.4.0-beta.3", "prerelease")
     parser = configparser.ConfigParser()
     parser.read(ROOT / "plugin.cfg", encoding="utf-8")
     source_fallback = (ROOT / "src" / "mcpserver" / "__init__.py").read_text(encoding="utf-8")
 
-    assert "Enable bounded history/statistics" in notes
+    assert "Enable the bounded read-only feature families" in notes
     assert f'__version__ = "{parser["PLUGIN"]["VERSION"]}"' in source_fallback
     with pytest.raises(ValueError, match="stable releases"):
-        validate_release_metadata(ROOT, "0.4.0-beta.2", "stable")
+        validate_release_metadata(ROOT, "0.4.0-beta.3", "stable")
     with pytest.raises(ValueError, match="prerelease releases"):
         validate_release_metadata(ROOT, "0.4.0", "prerelease")
     with pytest.raises(ValueError, match="channel must"):
-        validate_release_metadata(ROOT, "0.4.0-beta.2", "preview")
+        validate_release_metadata(ROOT, "0.4.0-beta.3", "preview")
     with pytest.raises(ValueError, match="versions do not match"):
         validate_release_metadata(ROOT, "0.3.0-alpha.2", "prerelease")
 

--- a/webfrontend/htmlauth/index.cgi
+++ b/webfrontend/htmlauth/index.cgi
@@ -4,7 +4,6 @@ use strict;
 use warnings;
 use CGI;
 use Encode qw(decode encode FB_DEFAULT);
-use Fcntl qw(:flock);
 use HTML::Template;
 use IPC::Open3;
 use JSON::PP qw(decode_json encode_json);
@@ -26,8 +25,6 @@ if (($q->{lang} // '') =~ /\A(?:de|en)\z/) {
 }
 my $version = LoxBerry::System::pluginversion();
 my $admin_log;
-use constant ADMIN_LOG_MAX_BYTES => 512 * 1024;
-use constant ADMIN_LOG_BACKUP_COUNT => 2;
 use constant ADMIN_LOG_MESSAGE_BYTES => 8 * 1024;
 use constant ADMIN_LOG_TRUNCATION_SUFFIX => ' ... [truncated]';
 
@@ -42,25 +39,6 @@ sub bounded_admin_message {
     return decode('UTF-8', $prefix, FB_DEFAULT) . ADMIN_LOG_TRUNCATION_SUFFIX;
 }
 
-sub rotate_admin_log_locked {
-    my ($filename, $next_bytes) = @_;
-    for my $candidate (glob("$filename.*")) {
-        next if $candidate !~ /\.([0-9]+)\z/ || $1 <= ADMIN_LOG_BACKUP_COUNT;
-        unlink $candidate;
-    }
-    my $current_bytes = -f $filename ? (-s $filename // 0) : 0;
-    return 1 if $current_bytes + $next_bytes <= ADMIN_LOG_MAX_BYTES;
-    my $oldest = "$filename." . ADMIN_LOG_BACKUP_COUNT;
-    unlink $oldest if -e $oldest;
-    for (my $index = ADMIN_LOG_BACKUP_COUNT - 1; $index >= 1; $index--) {
-        my $source = "$filename.$index";
-        my $target = "$filename." . ($index + 1);
-        return 0 if -e $source && !rename($source, $target);
-    }
-    return 0 if -e $filename && !rename($filename, "$filename.1");
-    return 1;
-}
-
 sub admin_log {
     my ($severity, $message) = @_;
     my %threshold = (error => 3, warning => 4, info => 6, debug => 7);
@@ -71,25 +49,13 @@ sub admin_log {
     return if $plugin_level == 0 || $threshold{$severity} > $plugin_level;
 
     $message = bounded_admin_message($message);
-    my $filename = "$lbplogdir/admin-ui.log";
-    open my $lock, '>>', "$filename.lock" or return;
-    flock($lock, LOCK_EX) or return;
-    my $next_bytes = length(encode('UTF-8', $message)) + 256;
-    $admin_log->close() if $admin_log;
-    if (rotate_admin_log_locked($filename, $next_bytes)) {
-        $admin_log //= LoxBerry::Log->new(
-            name => 'admin-ui',
-            package => $lbpplugindir,
-            filename => $filename,
-            append => 1,
-            nosession => 1,
-            addtime => 1,
-        );
-        my $log_method = $method{$severity};
-        $admin_log->$log_method($message) if $admin_log;
-    }
-    flock($lock, LOCK_UN);
-    close $lock;
+    $admin_log //= LoxBerry::Log->new(
+        name => 'admin-ui',
+        package => $lbpplugindir,
+        addtime => 1,
+    );
+    my $log_method = $method{$severity};
+    $admin_log->$log_method($message) if $admin_log;
 }
 
 $ENV{LBPDATA} = $lbpdatadir;
@@ -513,6 +479,9 @@ my $sslport = ref($general_config->{Webserver}) eq 'HASH'
     ? $general_config->{Webserver}{Sslport} : 443;
 my $hostname_mcp_url = local_mcp_url(LoxBerry::System::lbhostname(), $sslport);
 my $ip_mcp_url = local_mcp_url(LoxBerry::System::get_localip(), $sslport);
+if ($public_origin eq '' && $hostname_mcp_url ne '') {
+    ($public_origin = $hostname_mcp_url) =~ s{/plugins/mcpserver/mcp\z}{};
+}
 my %renewal_labels = (
     idle => $L{'CERTIFICATE.STATE_IDLE'},
     scheduled => $L{'CERTIFICATE.STATE_SCHEDULED'},


### PR DESCRIPTION
## Summary\n- retain all settings, sessions, tokens and bindings across upgrades\n- keep read-only defaults only for clean installations; write scopes remain disabled\n- prefill the HTTPS origin from configured LoxBerry hostname/port and register admin actions in the native LogManager\n\n## Validation\n- Python 3.13 full gate: 598 passed\n- targeted regression rerun: 71 passed\n- two independent local reviews; lifecycle acceptance will run as Update → Uninstall → Clean Install before publication