### PR TITLE
Document CA certificate installation

### DIFF
--- a/docs/user/configuration.de.md
+++ b/docs/user/configuration.de.md
@@ -10,6 +10,24 @@ Konfiguriere eine lokale HTTPS-Origin und genau ein Miniserver-Ziel. Die Auswahl
 
 Verwende für MCP-Clients eine Adresse, die vom LoxBerry-Webserverzertifikat abgedeckt wird. Die Zertifikatsdiagnose zeigt verständlich, ob die konfigurierte Origin passt. Eine lokale Zertifikatsneuausstellung benötigt SecurePIN und eine Bestätigung; externe Zertifikate werden nicht verändert.
 
+Damit ein Endgerät das lokale Zertifikat akzeptiert, installiere dessen CA-Zertifikat `cacert.cer` auf dem Endgerät. Lade es in LoxBerry unter `https://<LoxBerry-Hostname>/admin/system/services.php` herunter.
+
+### Windows
+
+1. Öffne die heruntergeladene Datei `cacert.cer` per Doppelklick.
+2. Wähle **Zertifikat installieren…**.
+3. Wähle **Zertifikatsspeicher manuell auswählen** und danach **Vertrauenswürdige Stammzertifizierungsstellen**.
+4. Schließe die Installation ab und öffne die HTTPS-Origin erneut.
+
+### Android
+
+1. Lade `cacert.cer` über die LoxBerry-Systemdienste auf das Gerät herunter.
+2. Öffne **Einstellungen** und suche nach **Zertifikat installieren**. Je nach Hersteller liegt die Funktion beispielsweise unter **Sicherheit und Datenschutz** → **Weitere Sicherheitseinstellungen** → **Verschlüsselung und Anmeldedaten**.
+3. Wähle **CA-Zertifikat** und dann die heruntergeladene Datei `cacert.cer`. Bestätige die Sicherheitsabfrage; eine Bildschirmsperre kann erforderlich sein.
+4. Öffne die HTTPS-Origin erneut.
+
+Installiere ein CA-Zertifikat nur von deinem eigenen, vertrauenswürdigen LoxBerry: Es erlaubt dem Gerät, Zertifikate dieser CA zu akzeptieren. Die genaue Menübezeichnung kann je nach Android-Version und Hersteller abweichen.
+
 ## Funktionsfreigaben
 
 Lesezugriff sowie Historie/Statistiken und LoxBerry-Diagnose sind grundsätzlich verfügbar. Der Client muss den passenden Scope zusätzlich anfordern und der Benutzer bestätigen; LoxBerry-Diagnose benötigt außerdem eine lokale Freigabe.

--- a/docs/user/configuration.en.md
+++ b/docs/user/configuration.en.md
@@ -10,6 +10,24 @@ Configure one local HTTPS origin and exactly one Miniserver target. Selecting a 
 
 Use an MCP client address covered by the LoxBerry web-server certificate. Certificate diagnostics show whether the configured origin matches. Reissuing a local certificate requires SecurePIN and confirmation; externally issued certificates are not changed.
 
+To let an endpoint accept the local certificate, install its CA certificate, `cacert.cer`, on that endpoint. Download it in LoxBerry from `https://<LoxBerry-hostname>/admin/system/services.php`.
+
+### Windows
+
+1. Double-click the downloaded `cacert.cer` file.
+2. Select **Install Certificate…**.
+3. Select **Place all certificates in the following store**, then choose **Trusted Root Certification Authorities**.
+4. Complete the installation, then open the HTTPS origin again.
+
+### Android
+
+1. Download `cacert.cer` to the device through the LoxBerry system services page.
+2. Open **Settings** and search for **Install a certificate**. Depending on the device, it may be under **Security & privacy** → **More security settings** → **Encryption & credentials**.
+3. Choose **CA certificate**, then select the downloaded `cacert.cer` file. Confirm the security prompt; a screen lock may be required.
+4. Open the HTTPS origin again.
+
+Install a CA certificate only from your own trusted LoxBerry: it allows the device to accept certificates issued by that CA. Menu names can differ between Android versions and device manufacturers.
+
 ## Feature switches
 
 Read access, history/statistics and LoxBerry diagnostics are globally available. The client must still request the matching scope and the user must approve it; LoxBerry diagnostics also require local approval.


### PR DESCRIPTION
Documents downloading and installing the LoxBerry CA certificate on Windows and Android in the synchronized German and English configuration guides. Includes the trusted-root store selection, Android navigation guidance, and a CA trust warning.