### PR TITLE
Add CA certificate download link

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -226,7 +226,7 @@
           <p class="mcp-warning"><TMPL_VAR CERTIFICATE.RENEW_TEXT></p>
           <label class="mcp-field"><span><TMPL_VAR CERTIFICATE.PIN></span><input name="securepin" type="password" inputmode="numeric" pattern="[0-9]{4}" minlength="4" maxlength="4" autocomplete="off" required></label>
           <label><input name="renew_confirmation" type="checkbox" value="renew" required> <TMPL_VAR CERTIFICATE.CONFIRM></label>
-          <div class="mcp-actions"><button class="lb-button" type="submit"><TMPL_VAR ACTION.RENEW_CERTIFICATE></button></div>
+          <div class="mcp-actions"><button class="lb-button" type="submit"><TMPL_VAR ACTION.RENEW_CERTIFICATE></button><a class="lb-button" href="/admin/system/services.php"><TMPL_VAR ACTION.DOWNLOAD_CA_CERTIFICATE></a></div>
         </form>
       <p id="certificate-unsupported" class="mcp-help" hidden><TMPL_VAR CERTIFICATE.UNSUPPORTED></p>
       <p id="certificate-unavailable" class="mcp-status" hidden><TMPL_VAR CERTIFICATE.UNAVAILABLE></p>

--- a/templates/lang/language_de.ini
+++ b/templates/lang/language_de.ini
@@ -178,6 +178,7 @@ EXPLORER=MCP Tool Explorer öffnen
 COPY=Kopieren
 COPIED=Kopiert
 RENEW_CERTIFICATE=Webserver-Zertifikat neu ausstellen
+DOWNLOAD_CA_CERTIFICATE=CA-Zertifikat herunterladen
 ALLOW_LOXBERRY_READ=loxberry:read freigeben
 ALLOW_LOXBERRY_OPERATE=loxberry:operate freigeben
 

--- a/templates/lang/language_en.ini
+++ b/templates/lang/language_en.ini
@@ -178,6 +178,7 @@ EXPLORER=Open MCP Tool Explorer
 COPY=Copy
 COPIED=Copied
 RENEW_CERTIFICATE=Reissue web server certificate
+DOWNLOAD_CA_CERTIFICATE=Download CA certificate
 ALLOW_LOXBERRY_READ=Allow loxberry:read
 ALLOW_LOXBERRY_OPERATE=Allow loxberry:operate
 

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -426,6 +426,8 @@ def test_ui_is_nojqm_responsive_and_progressively_enhanced() -> None:
     assert 'type="password"' in template
     assert 'name="renew_confirmation"' in template
     assert 'data-ajax="renew_certificate"' in template
+    assert 'href="/admin/system/services.php"' in template
+    assert "ACTION.DOWNLOAD_CA_CERTIFICATE" in template
     assert 'data-copy-target="mcp-url-hostname"' in template
     assert 'data-copy-target="mcp-url-ip"' in template
     assert "LoxBerry::System::check_securepin" not in cgi


### PR DESCRIPTION
Adds a localized CA certificate download link next to the web-server certificate reissue button. The link opens the native LoxBerry system services page where cacert.cer is available. Includes a UI regression assertion.\n\nValidation: python tools/test.py --profile changed --files templates/index.html templates/lang/language_de.ini templates/lang/language_en.ini tests/test_plugin_package.py (pass; 206 tests).