### PR TITLE
Add MCP tool filters and time ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ extracted from the matching version heading.
 - Update the bundled `using-loxberry-mcp` agent workflow to revision 18 for room
   snapshots, weather, and the new read-only controller interpretations.
 
+- Add bounded, paginated filtering for service events by trace ID, component,
+  severity and RFC-3339 time range; diagnostic records now use UTC timestamps.
+
+- Add optional time-range filters to control history and discovery filters for
+  visibility, notes, favorites, room groups and bounded name searches.
+
 - Add an explicit, fail-closed `room_group` reference to each visible room from
   `loxone_list_rooms`, and resolve visible room and control references in
   StatusMonitor and WindowMonitor descriptions.

--- a/docs/user/operation.de.md
+++ b/docs/user/operation.de.md
@@ -13,5 +13,6 @@ Unter **Clients und Sitzungen** können Administratoren Sitzungen und lokale Dia
 ## Tool Explorer
 
 Der MCP Tool Explorer ist ein lokaler administrativer Testclient. Er meldet sich mit einem Loxone-Benutzer an und erhält keine Rechte aus der LoxBerry-Admin-Sitzung. Ändernde Aufrufe verlangen vor dem Senden eine Bestätigung.
+RFC-3339-Zeitfelder werden als lokale Datum-/Zeitfelder angezeigt und als UTC übermittelt.
 
 Weiter: [Fehlerbehebung](troubleshooting.de.md).

--- a/docs/user/operation.en.md
+++ b/docs/user/operation.en.md
@@ -13,5 +13,6 @@ Under **Clients and sessions**, administrators can inspect and revoke sessions a
 ## Tool Explorer
 
 The MCP Tool Explorer is a local administrative test client. It signs in with a Loxone user and receives no rights from the LoxBerry admin session. Mutating calls require confirmation before sending.
+RFC-3339 time fields are shown as local date/time fields and sent as UTC.
 
 Next: [Troubleshooting](troubleshooting.en.md).

--- a/src/mcpserver/loxberry/diagnostics.py
+++ b/src/mcpserver/loxberry/diagnostics.py
@@ -7,6 +7,7 @@ import os
 import re
 import stat
 import subprocess
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Final
 
@@ -39,6 +40,16 @@ _EVENT_COMPONENTS: Final = frozenset(
         "mcpserver.loxone.runtime",
     }
 )
+
+
+def _event_timestamp(value: str) -> datetime | None:
+    """Parse current UTC log records and legacy records retained during upgrade."""
+    try:
+        if value.endswith("Z"):
+            return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+        return datetime.strptime(value, "%Y-%m-%d %H:%M:%S,%f").replace(tzinfo=UTC)
+    except ValueError:
+        return None
 
 
 class LoxBerryDiagnostics:
@@ -179,10 +190,28 @@ class LoxBerryDiagnostics:
             "healthy": installed and active_state == "active",
         }
 
-    def service_events(self, *, limit: int) -> list[dict[str, str]]:
+    def service_events(
+        self,
+        *,
+        trace_id: str | None = None,
+        component: str | None = None,
+        severity: str | None = None,
+        start: datetime | None = None,
+        end: datetime | None = None,
+    ) -> list[dict[str, str]]:
         """Return only allowlisted fields from this plugin's bounded service log."""
-        if not 1 <= limit <= _MAX_SERVICE_EVENTS:
-            raise ValueError("event limit is invalid")
+        if component is not None and component not in _EVENT_COMPONENTS:
+            raise ValueError("event component is invalid")
+        if severity is not None and severity not in {
+            "debug",
+            "info",
+            "warning",
+            "error",
+            "critical",
+        }:
+            raise ValueError("event severity is invalid")
+        if start is not None and end is not None and start > end:
+            raise ValueError("event interval is invalid")
         # This is a fixed plugin-owned path, deliberately not an MCP argument.
         raw = self._read_limited(
             self._home / "log/plugins/mcpserver/service.log", _SERVICE_LOG_MAX_BYTES
@@ -203,5 +232,16 @@ class LoxBerryDiagnostics:
             }
             for field in _EVENT_FIELD.finditer(match["fields"]):
                 event[field["name"]] = field["value"]
+            observed_at = _event_timestamp(event["timestamp"])
+            if trace_id is not None and event.get("trace_id") != trace_id:
+                continue
+            if component is not None and event["component"] != component:
+                continue
+            if severity is not None and event["severity"] != severity:
+                continue
+            if start is not None and (observed_at is None or observed_at < start):
+                continue
+            if end is not None and (observed_at is None or observed_at > end):
+                continue
             events.append(event)
-        return events[-limit:]
+        return events

--- a/src/mcpserver/server.py
+++ b/src/mcpserver/server.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import time
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager, suppress
 from logging.handlers import RotatingFileHandler
@@ -132,8 +133,13 @@ def configure_service_logging(
         handler = logging.StreamHandler()
     handler.addFilter(ServiceLevelFilter(level))
     handler.setFormatter(
-        BoundedLogFormatter("%(asctime)s component=%(name)s severity=%(levelname)s %(message)s")
+        BoundedLogFormatter(
+            "%(asctime)s component=%(name)s severity=%(levelname)s %(message)s",
+            datefmt="%Y-%m-%dT%H:%M:%SZ",
+        )
     )
+    assert handler.formatter is not None
+    handler.formatter.converter = time.gmtime
     logging.basicConfig(
         level=logging.DEBUG,
         handlers=[handler],

--- a/src/mcpserver/skill_delivery.py
+++ b/src/mcpserver/skill_delivery.py
@@ -8,7 +8,7 @@ from typing import Final
 from mcp.server.fastmcp import FastMCP
 
 SKILL_NAME: Final = "using-loxberry-mcp"
-SKILL_REVISION: Final = 24
+SKILL_REVISION: Final = 25
 SKILL_MIME_TYPE: Final = "text/markdown"
 SKILL_RESOURCE_URI: Final = f"skill://{SKILL_NAME}/SKILL.md"
 SERVER_INSTRUCTIONS: Final = (

--- a/src/mcpserver/skills/using-loxberry-mcp/SKILL.md
+++ b/src/mcpserver/skills/using-loxberry-mcp/SKILL.md
@@ -39,8 +39,11 @@ Call `loxone_get_system_status` when connectivity or data freshness matters.
    statistic series, `has_history=true` to require control history, or both to
    require both capabilities.
 2. For an explicit read-only diagnosis of controls that are neither visible nor
-   linked in Loxone, set `include_hidden=true`. Treat results with
-   `visibility: "hidden"` as non-operable.
+    linked in Loxone, set `include_hidden=true`. Treat results with
+    `visibility: "hidden"` as non-operable.
+   `visibility`, `has_notes`, `is_favorite`, and `room_group_uuid` are additional
+   exact discovery filters. Rooms, categories, and global metadata also support
+   bounded case-insensitive name queries.
 3. Follow every non-null `next_cursor` until the relevant result is found or all
    pages are checked. If more than one control remains plausible, present the
    candidates and ask the user to choose. Never guess a UUID.
@@ -100,7 +103,10 @@ The MCP service can report its own health only while it is reachable. A fully
 stopped MCP service cannot diagnose itself through MCP.
 
 `loxberry_list_service_events` is a read-only, bounded aid for correlating a
-tool response's `trace_id` with recent server-authored diagnostic events. It
+tool response's `trace_id` with server-authored diagnostic events. Use its exact
+`trace_id`, component, severity, and optional RFC-3339 `start`/`end` filters;
+without them it returns the most recent `limit` events. Keep all filters unchanged
+when following `next_cursor`. It
 does not expose raw logs, arbitrary files, journal output, credentials, or
 foreign services. If the service is stopped, use the local LoxBerry log viewer
 or an explicitly authorized host diagnosis instead.
@@ -121,6 +127,9 @@ the same query arguments. History and statistic cursors use signed continuation
 anchors, so a changed live result does not duplicate prior entries. Do not invent
 a series ID or interpret a cache hit as newer than its response metadata. A hidden
 control is readable only with the same explicit `include_hidden=true` mode.
+`loxone_get_control_history` accepts optional inclusive RFC-3339 `start` and `end`
+filters; they narrow its returned bounded result but do not expand the Miniserver
+history fetch.
 
 ## Operate a supported control
 

--- a/src/mcpserver/tools.py
+++ b/src/mcpserver/tools.py
@@ -618,6 +618,7 @@ class LoxBerryServiceEventData(BaseModel):
 class LoxBerryServiceEventsData(BaseModel):
     model_config = ConfigDict(extra="forbid")
     events: list[LoxBerryServiceEventData]
+    next_cursor: str | None = None
 
 
 class LoxBerryErrorData(ErrorData):
@@ -890,11 +891,27 @@ class LoxBerryReadRuntime:
 
         return await asyncio.to_thread(self._diagnostics.service_health)
 
-    async def service_events(self, access: StoredAccessToken, limit: int) -> dict[str, Any]:
+    async def service_events(
+        self,
+        access: StoredAccessToken,
+        *,
+        trace_id: str | None = None,
+        component: str | None = None,
+        severity: str | None = None,
+        start: datetime | None = None,
+        end: datetime | None = None,
+    ) -> list[dict[str, str]]:
         self._allowed(access)
         import asyncio
 
-        return {"events": await asyncio.to_thread(self._diagnostics.service_events, limit=limit)}
+        return await asyncio.to_thread(
+            self._diagnostics.service_events,
+            trace_id=trace_id,
+            component=component,
+            severity=severity,
+            start=start,
+            end=end,
+        )
 
 
 class LoxBerryOperateRuntime:
@@ -958,6 +975,12 @@ def _page(
         "items": selected,
         "next_cursor": codec.encode(scope, next_offset) if next_offset < len(items) else None,
     }
+
+
+def _normalized_query(value: str | None) -> str | None:
+    if value is not None and len(value) > 200:
+        raise ValueError("query is too long")
+    return value.casefold().strip() if value else None
 
 
 async def _snapshot(runtime: LoxoneRuntime | None) -> tuple[StoredAccessToken, RuntimeSnapshot]:
@@ -1349,11 +1372,24 @@ def register_read_tools(
         structured_output=True,
     )
     async def list_rooms(
-        cursor: CursorArgument = None, limit: LimitArgument = DEFAULT_PAGE_SIZE
+        query: Annotated[
+            str | None,
+            Field(
+                description="Case-insensitive text contained in the visible room name.",
+                max_length=200,
+            ),
+        ] = None,
+        room_group_uuid: Annotated[
+            str | None,
+            Field(description="Exact room-group UUID returned by loxone_list_global_metadata."),
+        ] = None,
+        cursor: CursorArgument = None,
+        limit: LimitArgument = DEFAULT_PAGE_SIZE,
     ) -> RoomPageEnvelope:
         try:
             _access_token, snapshot = await _snapshot(runtime)
             room_groups = {item.uuid: item.name for item in snapshot.structure.room_groups}
+            normalized = _normalized_query(query)
             values = [
                 {
                     "uuid": item.uuid,
@@ -1365,10 +1401,18 @@ def register_read_tools(
                     ),
                 }
                 for item in snapshot.structure.rooms
+                if (normalized is None or normalized in item.name.casefold())
+                and (room_group_uuid is None or item.room_group_uuid == room_group_uuid)
             ]
             return _result(
                 RoomPageEnvelope,
-                _page(cursors, "rooms", values, cursor, limit),
+                _page(
+                    cursors,
+                    f"rooms:{normalized or ''}:{room_group_uuid or ''}",
+                    values,
+                    cursor,
+                    limit,
+                ),
             )
         except ValueError as exc:
             return _error(RoomPageEnvelope, "invalid_input", str(exc))
@@ -1453,13 +1497,27 @@ def register_read_tools(
         structured_output=True,
     )
     async def list_categories(
-        cursor: CursorArgument = None, limit: LimitArgument = DEFAULT_PAGE_SIZE
+        query: Annotated[
+            str | None,
+            Field(
+                description="Case-insensitive text contained in the visible category name.",
+                max_length=200,
+            ),
+        ] = None,
+        cursor: CursorArgument = None,
+        limit: LimitArgument = DEFAULT_PAGE_SIZE,
     ) -> NamedGroupPageEnvelope:
         try:
             _access_token, snapshot = await _snapshot(runtime)
+            normalized = _normalized_query(query)
+            values = [
+                item
+                for item in _groups(snapshot.structure.categories)
+                if normalized is None or normalized in item["name"].casefold()
+            ]
             return _result(
                 NamedGroupPageEnvelope,
-                _page(cursors, "categories", _groups(snapshot.structure.categories), cursor, limit),
+                _page(cursors, f"categories:{normalized or ''}", values, cursor, limit),
             )
         except ValueError as exc:
             return _error(NamedGroupPageEnvelope, "invalid_input", str(exc))
@@ -1487,11 +1545,19 @@ def register_read_tools(
             | None,
             Field(description="Optional exact metadata kind."),
         ] = None,
+        query: Annotated[
+            str | None,
+            Field(
+                description="Case-insensitive text contained in the visible metadata name.",
+                max_length=200,
+            ),
+        ] = None,
         cursor: CursorArgument = None,
         limit: LimitArgument = DEFAULT_PAGE_SIZE,
     ) -> GlobalMetadataPageEnvelope:
         try:
             _access_token, snapshot = await _snapshot(runtime)
+            normalized = _normalized_query(query)
             values = [
                 {
                     "kind": item.kind,
@@ -1502,11 +1568,18 @@ def register_read_tools(
                     "state_uuid": item.state_uuid,
                 }
                 for item in snapshot.structure.global_metadata
-                if kind is None or item.kind == kind
+                if (kind is None or item.kind == kind)
+                and (normalized is None or normalized in item.name.casefold())
             ]
             return _result(
                 GlobalMetadataPageEnvelope,
-                _page(cursors, f"global-metadata:{kind or 'all'}", values, cursor, limit),
+                _page(
+                    cursors,
+                    f"global-metadata:{kind or 'all'}:{normalized or ''}",
+                    values,
+                    cursor,
+                    limit,
+                ),
             )
         except ValueError as exc:
             return _error(GlobalMetadataPageEnvelope, "invalid_input", str(exc))
@@ -1657,6 +1730,22 @@ def register_read_tools(
             bool,
             Field(description="Only return controls that advertise control history."),
         ] = False,
+        visibility: Annotated[
+            Literal["direct", "linked", "hidden"] | None,
+            Field(description="Optional exact discovery visibility."),
+        ] = None,
+        has_notes: Annotated[
+            bool,
+            Field(description="Only return controls that advertise bounded control notes."),
+        ] = False,
+        is_favorite: Annotated[
+            bool,
+            Field(description="Only return controls marked as a Loxone favorite."),
+        ] = False,
+        room_group_uuid: Annotated[
+            str | None,
+            Field(description="Exact room-group UUID returned by loxone_list_global_metadata."),
+        ] = None,
         include_hidden: Annotated[
             bool,
             Field(
@@ -1669,12 +1758,11 @@ def register_read_tools(
         cursor: CursorArgument = None,
         limit: LimitArgument = DEFAULT_PAGE_SIZE,
     ) -> ControlPageEnvelope:
-        if query is not None and len(query) > 200:
-            return _error(ControlPageEnvelope, "invalid_input", "query is too long")
         try:
+            normalized = _normalized_query(query)
             _access_token, snapshot = await _snapshot(runtime)
             controls = _controls_for_diagnosis(snapshot.structure, include_hidden=include_hidden)
-            normalized = query.casefold().strip() if query else None
+            room_groups = {item.uuid: item.room_group_uuid for item in snapshot.structure.rooms}
             normalized_control_type = control_type.casefold().strip() if control_type else None
             matches = [
                 item
@@ -1688,6 +1776,19 @@ def register_read_tools(
                 )
                 and (not has_statistics or bool(item.statistic_series))
                 and (not has_history or item.has_history)
+                and (
+                    visibility is None
+                    or _control_summary(item, snapshot)["visibility"] == visibility
+                )
+                and (not has_notes or item.has_notes)
+                and (not is_favorite or item.is_favorite)
+                and (
+                    room_group_uuid is None
+                    or (
+                        item.room_uuid is not None
+                        and room_groups.get(item.room_uuid) == room_group_uuid
+                    )
+                )
             ]
             scope = hashlib.sha256(
                 json.dumps(
@@ -1698,6 +1799,10 @@ def register_read_tools(
                         normalized_control_type,
                         has_statistics,
                         has_history,
+                        visibility,
+                        has_notes,
+                        is_favorite,
+                        room_group_uuid,
                         include_hidden,
                     ]
                 ).encode()
@@ -2115,6 +2220,7 @@ def register_skill_tool(server: FastMCP) -> None:
 def register_loxberry_read_tools(server: FastMCP, runtime: LoxBerryReadRuntime) -> None:
     """Publish the optional, fixed Phase 3 LoxBerry diagnostics surface."""
     annotations = ToolAnnotations(readOnlyHint=True, destructiveHint=False, openWorldHint=False)
+    cursors = _CursorCodec()
 
     @server.tool(
         name="loxberry_get_system_status",
@@ -2253,50 +2359,111 @@ def register_loxberry_read_tools(server: FastMCP, runtime: LoxBerryReadRuntime) 
         structured_output=True,
     )
     async def list_loxberry_service_events(
+        trace_id: Annotated[
+            str | None,
+            Field(
+                description="Optional exact trace ID returned by a prior MCP tool call.",
+                max_length=64,
+            ),
+        ] = None,
+        component: Annotated[
+            Literal[
+                "mcpserver.tools",
+                "mcpserver.service",
+                "mcpserver.auth.provider",
+                "mcpserver.auth.remote_revocation",
+                "mcpserver.loxone.client",
+                "mcpserver.loxone.runtime",
+            ]
+            | None,
+            Field(description="Optional exact server component."),
+        ] = None,
+        severity: Annotated[
+            Literal["debug", "info", "warning", "error", "critical"] | None,
+            Field(description="Optional exact event severity."),
+        ] = None,
+        start: Annotated[
+            str | None,
+            Field(
+                description="Inclusive RFC 3339 start timestamp with timezone.",
+                json_schema_extra={"format": "date-time"},
+            ),
+        ] = None,
+        end: Annotated[
+            str | None,
+            Field(
+                description="Inclusive RFC 3339 end timestamp with timezone.",
+                json_schema_extra={"format": "date-time"},
+            ),
+        ] = None,
+        cursor: CursorArgument = None,
         limit: Annotated[
             int, Field(description="Recent events to return, from 1 to 100.", ge=1, le=100)
         ] = 50,
     ) -> LoxBerryServiceEventsEnvelope:
-        trace_id = str(uuid4())
+        call_trace_id = str(uuid4())
         try:
+            start_time = _rfc3339(start) if start is not None else None
+            end_time = _rfc3339(end) if end is not None else None
+            if start_time is not None and end_time is not None and start_time > end_time:
+                raise ValueError("event interval is invalid")
+            events = await runtime.service_events(
+                _access(),
+                trace_id=trace_id,
+                component=component,
+                severity=severity,
+                start=start_time,
+                end=end_time,
+            )
+            scope = (
+                "service-events:"
+                + hashlib.sha256(
+                    json.dumps(
+                        [trace_id, component, severity, start, end], separators=(",", ":")
+                    ).encode()
+                ).hexdigest()
+            )
+            # Page from newest to oldest, while keeping each returned page chronological
+            # like the pre-pagination "last limit" response.
+            page = _page(cursors, scope, list(reversed(events)), cursor, limit)
             return _result(
                 LoxBerryServiceEventsEnvelope,
-                await runtime.service_events(_access(), limit),
-                trace_id=trace_id,
+                {"events": list(reversed(page["items"])), "next_cursor": page["next_cursor"]},
+                trace_id=call_trace_id,
             )
         except ValueError as exc:
             return _error(
                 LoxBerryServiceEventsEnvelope,
                 "invalid_input",
                 str(exc),
-                trace_id=trace_id,
+                trace_id=call_trace_id,
             )
         except PermissionError:
             return _error(
                 LoxBerryServiceEventsEnvelope,
                 "permission_denied",
                 "LoxBerry diagnostics require loxberry:read and local approval",
-                trace_id=trace_id,
+                trace_id=call_trace_id,
             )
         except DiagnosticsUnavailable:
             return _error(
                 LoxBerryServiceEventsEnvelope,
                 "temporarily_unavailable",
                 "LoxBerry diagnostic events are temporarily unavailable",
-                trace_id=trace_id,
+                trace_id=call_trace_id,
             )
         except Exception as exc:
             _LOGGER.error(
                 "component=tools trace_id=%s outcome=internal_error "
                 "tool=loxberry_list_service_events error_type=%s",
-                trace_id,
+                call_trace_id,
                 type(exc).__name__,
             )
             return _error(
                 LoxBerryServiceEventsEnvelope,
                 "internal_error",
                 "Internal error",
-                trace_id=trace_id,
+                trace_id=call_trace_id,
             )
 
 
@@ -2483,6 +2650,20 @@ def register_history_tools(server: FastMCP, runtime: LoxoneRuntime | None) -> No
     )
     async def get_control_history(
         control_uuid: Annotated[str, Field(description="Exact control UUID.")],
+        start: Annotated[
+            str | None,
+            Field(
+                description="Inclusive RFC 3339 start timestamp with timezone.",
+                json_schema_extra={"format": "date-time"},
+            ),
+        ] = None,
+        end: Annotated[
+            str | None,
+            Field(
+                description="Inclusive RFC 3339 end timestamp with timezone.",
+                json_schema_extra={"format": "date-time"},
+            ),
+        ] = None,
         include_hidden: Annotated[
             bool,
             Field(description="Allow a hidden control returned by include_hidden search."),
@@ -2496,9 +2677,15 @@ def register_history_tools(server: FastMCP, runtime: LoxoneRuntime | None) -> No
                     "temporarily_unavailable", "the service is not configured"
                 )
             access = _access()
+            start_time = _rfc3339(start) if start is not None else None
+            end_time = _rfc3339(end) if end is not None else None
+            if start_time is not None and end_time is not None and start_time > end_time:
+                raise ValueError("history interval is invalid")
             scope = (
                 "history:"
-                + hashlib.sha256(f"{access.family_id}\0{control_uuid}".encode()).hexdigest()
+                + hashlib.sha256(
+                    f"{access.family_id}\0{control_uuid}\0{include_hidden}\0{start}\0{end}".encode()
+                ).hexdigest()
             )
             if include_hidden:
                 _control, entries = await runtime.get_control_history(
@@ -2507,6 +2694,12 @@ def register_history_tools(server: FastMCP, runtime: LoxoneRuntime | None) -> No
             else:
                 _control, entries = await runtime.get_control_history(access, control_uuid)
             keyed_entries = history_keyed_entries(entries)
+            keyed_entries = tuple(
+                item
+                for item in keyed_entries
+                if (start_time is None or item[0].timestamp >= ceil(start_time.timestamp()))
+                and (end_time is None or item[0].timestamp <= floor(end_time.timestamp()))
+            )
             if cursor is not None:
                 anchor = cursors.decode_anchor(scope, cursor)
                 if anchor[0] != "history":

--- a/tests/test_loxberry_diagnostics.py
+++ b/tests/test_loxberry_diagnostics.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import subprocess
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -67,7 +68,7 @@ def test_service_events_return_only_allowlisted_fields_from_fixed_log(tmp_path: 
         encoding="utf-8",
     )
 
-    assert LoxBerryDiagnostics(tmp_path.resolve()).service_events(limit=100) == [
+    assert LoxBerryDiagnostics(tmp_path.resolve()).service_events() == [
         {
             "timestamp": "2026-08-14 10:00:00,000",
             "component": "mcpserver.tools",
@@ -78,17 +79,51 @@ def test_service_events_return_only_allowlisted_fields_from_fixed_log(tmp_path: 
     ]
 
 
-def test_service_events_reject_invalid_limit_and_oversized_log(tmp_path: Path) -> None:
+def test_service_events_filter_and_reject_invalid_input_or_oversized_log(tmp_path: Path) -> None:
     log = tmp_path / "log" / "plugins" / "mcpserver"
     log.mkdir(parents=True)
     target = log / "service.log"
-    target.write_text("", encoding="utf-8")
+    target.write_text(
+        (
+            "2026-08-14T10:00:00Z component=mcpserver.tools severity=ERROR "
+            "trace_id=trace-1 outcome=failed\n"
+            "2026-08-14T11:00:00Z component=mcpserver.service severity=INFO "
+            "trace_id=trace-2 outcome=ok\n"
+        ),
+        encoding="utf-8",
+    )
     diagnostics = LoxBerryDiagnostics(tmp_path.resolve())
     with pytest.raises(ValueError):
-        diagnostics.service_events(limit=0)
+        diagnostics.service_events(component="not-allowed")
+    assert diagnostics.service_events(trace_id="trace-1", severity="error") == [
+        {
+            "timestamp": "2026-08-14T10:00:00Z",
+            "component": "mcpserver.tools",
+            "severity": "error",
+            "trace_id": "trace-1",
+            "outcome": "failed",
+        }
+    ]
+    assert diagnostics.service_events(
+        start=datetime(2026, 8, 14, 10, 0, tzinfo=UTC),
+        end=datetime(2026, 8, 14, 10, 0, tzinfo=UTC),
+    ) == [
+        {
+            "timestamp": "2026-08-14T10:00:00Z",
+            "component": "mcpserver.tools",
+            "severity": "error",
+            "trace_id": "trace-1",
+            "outcome": "failed",
+        }
+    ]
+    with pytest.raises(ValueError, match="event interval"):
+        diagnostics.service_events(
+            start=datetime(2026, 8, 14, 11, 0, tzinfo=UTC),
+            end=datetime(2026, 8, 14, 10, 0, tzinfo=UTC),
+        )
     target.write_bytes(b"x" * (512 * 1024 + 1))
     with pytest.raises(DiagnosticsUnavailable):
-        diagnostics.service_events(limit=1)
+        diagnostics.service_events()
 
 
 def test_diagnostic_source_rejects_a_symlink(tmp_path: Path) -> None:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -130,7 +130,9 @@ def test_loxberry_tool_contracts_have_closed_output_schemas() -> None:
     }
     for name, tool in published.items():
         assert set(tool.parameters["properties"]) == (
-            {"limit"} if name == "loxberry_list_service_events" else set()
+            {"trace_id", "component", "severity", "start", "end", "cursor", "limit"}
+            if name == "loxberry_list_service_events"
+            else set()
         )
         assert tool.annotations is not None
         assert tool.annotations.readOnlyHint is True
@@ -145,6 +147,73 @@ def test_loxberry_tool_contracts_have_closed_output_schemas() -> None:
             tool.output_schema["$defs"][name]["additionalProperties"] is False
             for name in data_names
         )
+
+
+@pytest.mark.asyncio
+async def test_service_events_filters_time_range_and_binds_cursor_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    received: dict[str, object] = {}
+
+    class Runtime:
+        async def service_events(self, _access: object, **kwargs: object) -> list[dict[str, str]]:
+            received.update(kwargs)
+            return [
+                {
+                    "timestamp": "2026-08-14T10:00:00Z",
+                    "component": "mcpserver.tools",
+                    "severity": "error",
+                    "trace_id": "trace-1",
+                    "outcome": "first",
+                },
+                {
+                    "timestamp": "2026-08-14T10:01:00Z",
+                    "component": "mcpserver.tools",
+                    "severity": "error",
+                    "trace_id": "trace-1",
+                    "outcome": "second",
+                },
+            ]
+
+    server = FastMCP("service-event-filters")
+    register_loxberry_read_tools(server, Runtime())  # type: ignore[arg-type]
+    monkeypatch.setattr(
+        tools_module, "_access", lambda: _loxberry_access(READ_SCOPE, LOXBERRY_READ_SCOPE)
+    )
+    arguments = {
+        "trace_id": "trace-1",
+        "component": "mcpserver.tools",
+        "severity": "error",
+        "start": "2026-08-14T10:00:00Z",
+        "end": "2026-08-14T10:01:00Z",
+        "limit": 1,
+    }
+    first = await server._tool_manager.call_tool("loxberry_list_service_events", arguments)
+
+    assert first.ok is True
+    assert [event.outcome for event in first.data.events] == ["second"]
+    assert received == {
+        "trace_id": "trace-1",
+        "component": "mcpserver.tools",
+        "severity": "error",
+        "start": datetime(2026, 8, 14, 10, 0, tzinfo=UTC),
+        "end": datetime(2026, 8, 14, 10, 1, tzinfo=UTC),
+    }
+    assert first.data.next_cursor is not None
+
+    second = await server._tool_manager.call_tool(
+        "loxberry_list_service_events",
+        {**arguments, "cursor": first.data.next_cursor},
+    )
+    assert [event.outcome for event in second.data.events] == ["first"]
+    assert second.data.next_cursor is None
+
+    changed_range = await server._tool_manager.call_tool(
+        "loxberry_list_service_events",
+        {**arguments, "start": "2026-08-14T09:59:00Z", "cursor": first.data.next_cursor},
+    )
+    assert changed_range.ok is False
+    assert changed_range.data.error == "invalid_input"
 
 
 def test_read_results_and_expected_errors_are_debug_only(
@@ -325,6 +394,59 @@ async def test_history_cursor_preserves_identical_entries_across_pages(
 
 
 @pytest.mark.asyncio
+async def test_history_time_range_is_inclusive_and_binds_cursor_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    entries = tuple(ControlHistoryEntry(index, str(index), "", "", ()) for index in range(100, 103))
+
+    class Runtime:
+        async def get_control_history(
+            self, _access: object, _control: str
+        ) -> tuple[object, tuple[ControlHistoryEntry, ...]]:
+            return object(), entries
+
+    server = FastMCP("history-time-range")
+    register_history_tools(server, Runtime())  # type: ignore[arg-type]
+    monkeypatch.setattr(
+        tools_module, "_access", lambda: _loxberry_access(READ_SCOPE, HISTORY_SCOPE)
+    )
+    arguments = {
+        "control_uuid": "control",
+        "start": "1970-01-01T00:01:41Z",
+        "end": "1970-01-01T00:01:42Z",
+        "limit": 1,
+    }
+    first = await server._tool_manager.call_tool("loxone_get_control_history", arguments)
+
+    assert first.ok is True
+    assert [entry.what for entry in first.data.entries] == ["102"]
+    assert first.data.next_cursor is not None
+
+    second = await server._tool_manager.call_tool(
+        "loxone_get_control_history", {**arguments, "cursor": first.data.next_cursor}
+    )
+    assert [entry.what for entry in second.data.entries] == ["101"]
+
+    changed_range = await server._tool_manager.call_tool(
+        "loxone_get_control_history",
+        {**arguments, "start": "1970-01-01T00:01:40Z", "cursor": first.data.next_cursor},
+    )
+    assert changed_range.ok is False
+    assert changed_range.data.error == "invalid_input"
+
+    invalid = await server._tool_manager.call_tool(
+        "loxone_get_control_history",
+        {
+            "control_uuid": "control",
+            "start": "1970-01-01T00:01:42Z",
+            "end": "1970-01-01T00:01:41Z",
+        },
+    )
+    assert invalid.ok is False
+    assert invalid.data.error == "invalid_input"
+
+
+@pytest.mark.asyncio
 async def test_statistics_cursor_uses_a_timestamp_anchor(monkeypatch: pytest.MonkeyPatch) -> None:
     points = tuple(StatisticPoint(index, float(index)) for index in range(1, 4))
     calls = 0
@@ -481,7 +603,7 @@ def test_skill_guide_tool_is_read_only_and_matches_resource_content() -> None:
     assert tool.annotations.destructiveHint is False
     assert tool.annotations.openWorldHint is False
     assert result.data.name == "using-loxberry-mcp"  # type: ignore[union-attr]
-    assert result.data.revision == 24  # type: ignore[union-attr]
+    assert result.data.revision == 25  # type: ignore[union-attr]
     assert result.data.media_type == "text/markdown"  # type: ignore[union-attr]
     assert result.data.content == read_skill_markdown()  # type: ignore[union-attr]
     assert "For a `StatusMonitor`, use its `inputStates` state UUID." in result.data.content  # type: ignore[union-attr]
@@ -497,9 +619,10 @@ def test_tool_input_schemas_explain_every_argument() -> None:
     published = {tool.name: tool for tool in server._tool_manager.list_tools()}
 
     expected_fields = {
-        "loxone_list_rooms": {"cursor", "limit"},
+        "loxone_list_rooms": {"query", "room_group_uuid", "cursor", "limit"},
         "loxone_get_room_snapshot": {"room_uuid", "cursor", "limit"},
-        "loxone_list_categories": {"cursor", "limit"},
+        "loxone_list_categories": {"query", "cursor", "limit"},
+        "loxone_list_global_metadata": {"kind", "query", "cursor", "limit"},
         "loxone_get_weather": {"mode", "cursor", "limit"},
         "loxone_find_controls": {
             "query",
@@ -508,6 +631,10 @@ def test_tool_input_schemas_explain_every_argument() -> None:
             "control_type",
             "has_statistics",
             "has_history",
+            "visibility",
+            "has_notes",
+            "is_favorite",
+            "room_group_uuid",
             "include_hidden",
             "cursor",
             "limit",
@@ -589,6 +716,8 @@ def test_phase_four_tool_contracts_are_narrow_and_correctly_annotated() -> None:
     assert history.annotations is not None
     assert history.annotations.readOnlyHint is True
     assert history.parameters["properties"]["include_hidden"]["default"] is False
+    assert history.parameters["properties"]["start"]["format"] == "date-time"
+    assert history.parameters["properties"]["end"]["format"] == "date-time"
     cache = published["loxberry_clear_statistics_cache"]
     assert cache.annotations is not None
     assert cache.annotations.readOnlyHint is False
@@ -1620,3 +1749,53 @@ async def test_find_controls_combines_history_and_statistics_filters(
     assert [item.uuid for item in history.data.items] == ["both", "history"]  # type: ignore[union-attr]
     assert [item.uuid for item in statistics.data.items] == ["both", "statistics"]  # type: ignore[union-attr]
     assert [item.uuid for item in both.data.items] == ["both"]  # type: ignore[union-attr]
+
+
+@pytest.mark.asyncio
+async def test_find_controls_filters_visibility_notes_favorite_and_room_group(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    access = _loxberry_access(READ_SCOPE)
+    structure = LoxoneStructure(
+        identity=LoxoneIdentity("user", "serial"),
+        last_modified="1",
+        rooms=(Room("room-1", "Office", "group-1"),),
+        categories=(),
+        controls=(
+            Control(
+                "matching",
+                "Matching",
+                "Switch",
+                "room-1",
+                None,
+                "action-1",
+                (),
+                has_notes=True,
+                is_favorite=True,
+            ),
+            Control(
+                "not-favorite",
+                "Not favorite",
+                "Switch",
+                "room-1",
+                None,
+                "action-2",
+                (),
+                has_notes=True,
+            ),
+        ),
+    )
+
+    async def snapshot(_runtime: object) -> tuple[StoredAccessToken, RuntimeSnapshot]:
+        return access, RuntimeSnapshot("family", structure, True)
+
+    monkeypatch.setattr(tools_module, "_snapshot", snapshot)
+    server = FastMCP("discovery-filters")
+    register_read_tools(server, None)
+    tool = server._tool_manager.get_tool("loxone_find_controls")
+    assert tool is not None
+
+    result = await tool.fn(
+        visibility="direct", has_notes=True, is_favorite=True, room_group_uuid="group-1"
+    )
+    assert [item.uuid for item in result.data.items] == ["matching"]  # type: ignore[union-attr]

--- a/tools/test_mcp_client.ps1
+++ b/tools/test_mcp_client.ps1
@@ -272,7 +272,7 @@ try {
     $script:nextId = 4
     $skillGuide = Invoke-ReadTool (Get-NextId) 'loxone_get_skill_guide' @{}
     if ($skillGuide.data.name -ne 'using-loxberry-mcp' -or
-        $skillGuide.data.revision -ne 24 -or
+        $skillGuide.data.revision -ne 25 -or
         $skillGuide.data.media_type -ne 'text/markdown' -or
         $skillGuide.data.content -ne $skillMarkdown) {
         throw 'MCP skill guide tool differs from the canonical resource.'

--- a/webfrontend/htmlauth/explorer.js
+++ b/webfrontend/htmlauth/explorer.js
@@ -33,6 +33,7 @@
     {id: 'loxoneControl', names: ['loxone_operate_control']},
     {id: 'loxberryRead', names: [
       'loxberry_get_system_status', 'loxberry_get_plugin_status', 'loxberry_get_service_health',
+      'loxberry_list_service_events',
     ]},
     {id: 'loxberryOperate', names: ['loxberry_clear_statistics_cache']},
   ];


### PR DESCRIPTION
## Summary
- add bounded discovery, history, and service-event filters with filter-bound pagination
- expose RFC-3339 time ranges through the Tool Explorer's existing native date-time fields
- synchronize DE/EN guidance, delivered skill revision, smoke contract, and changelog

## Validation
- Python 3.13 Full: 583 passed, 1 existing deprecation warning
- Ruff format/lint, MyPy, and git diff --check
- independent subagent review; all findings addressed