### PR TITLE
Publish generated MCP schema reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ extracted from the matching version heading.
 
 ## Unreleased
 
+- Generate a versioned HTML and JSON reference for the complete MCP tool
+  contract during package builds, link it from Help and the Tool Explorer, and
+  document `tools/list` as the authoritative installed tool surface.
+
 - Update the bundled `using-loxberry-mcp` agent workflow to revision 24 with
   task-specific read paths, complete cache-operation authorization and
   uncertainty guidance, and fail-closed schema and parameter-source rules.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -8,6 +8,7 @@
 
 - [Implementation guidelines](implementation-guidelines.md) — binding engineering and security rules.
 - [Architecture](architecture.md) — implemented system boundaries and data flows.
+- [Tool schema reference](tool-schema-reference.md) — live discovery and generated release-contract documentation.
 - [Historical plugin concept](plugin-concept.md) — compatibility entry point for the superseded planning document.
 - [Support matrix](support-matrix.md) — confirmed platforms, clients and limits.
 - [Evidence](../evidence/README.md) — current public evidence summary.

--- a/docs/development/tool-schema-reference.md
+++ b/docs/development/tool-schema-reference.md
@@ -1,0 +1,12 @@
+# Tool schema reference
+
+FastMCP derives each tool's input and output JSON Schemas from the registered Python function and Pydantic result model. MCP clients obtain the tool surface enabled for a concrete installation through `tools/list`; that response is authoritative for calls to that installation. The integrated Tool Explorer reads and visualizes the same response.
+
+The plugin package also contains a static reference for the complete tool contract supported by its release:
+
+- `tool-schema-reference.html` is the human-readable reference linked from **Help** and the Tool Explorer.
+- `tool-schema-reference.json` is the equivalent machine-readable catalog.
+
+`python tools/generate_schema_reference.py --output-root <directory>` generates both files from the FastMCP registry. The package builder invokes the same generator functions directly and passes the validated release version explicitly. Build-time verification with the project dependencies rejects stale output; the dependency-free publication job subsequently protects the downloaded package through its exact manifest and checksum. Do not maintain separate hand-written request or response schemas.
+
+The static catalog is version-specific and configuration-independent. Optional tools can therefore appear there even when an installation does not publish them. Use `tools/list` whenever the exact installed surface matters.

--- a/docs/user/operation.de.md
+++ b/docs/user/operation.de.md
@@ -12,7 +12,9 @@ Unter **Clients und Sitzungen** können Administratoren Sitzungen und lokale Dia
 
 ## Tool Explorer
 
-Der MCP Tool Explorer ist ein lokaler administrativer Testclient. Er meldet sich mit einem Loxone-Benutzer an und erhält keine Rechte aus der LoxBerry-Admin-Sitzung. Ändernde Aufrufe verlangen vor dem Senden eine Bestätigung.
+Der [MCP Tool Explorer](https://loxberry/admin/plugins/mcpserver/explorer.cgi) ist ein lokaler administrativer Testclient. Er meldet sich mit einem Loxone-Benutzer an und erhält keine Rechte aus der LoxBerry-Admin-Sitzung. Ersetze `loxberry` im Link bei Bedarf durch den Hostnamen deiner Installation. Ändernde Aufrufe verlangen vor dem Senden eine Bestätigung.
 RFC-3339-Zeitfelder werden als lokale Datum-/Zeitfelder angezeigt und als UTC übermittelt.
+
+MCP-Clients erhalten die auf der konkreten Installation veröffentlichten Werkzeugbeschreibungen sowie deren Ein- und Ausgabeschemas über die MCP-Methode `tools/list`. Der Tool Explorer liest genau diese Antwort und visualisiert sie. Unter **Hilfe** stehen außerdem eine statische HTML-Referenz des vollständigen Werkzeugvertrags dieser Plugin-Version und dieselben Daten als JSON-Download bereit.
 
 Weiter: [Fehlerbehebung](troubleshooting.de.md).

--- a/docs/user/operation.en.md
+++ b/docs/user/operation.en.md
@@ -12,7 +12,9 @@ Under **Clients and sessions**, administrators can inspect and revoke sessions a
 
 ## Tool Explorer
 
-The MCP Tool Explorer is a local administrative test client. It signs in with a Loxone user and receives no rights from the LoxBerry admin session. Mutating calls require confirmation before sending.
+The [MCP Tool Explorer](https://loxberry/admin/plugins/mcpserver/explorer.cgi) is a local administrative test client. It signs in with a Loxone user and receives no rights from the LoxBerry admin session. Replace `loxberry` in the link with your installation's hostname when necessary. Mutating calls require confirmation before sending.
 RFC-3339 time fields are shown as local date/time fields and sent as UTC.
+
+MCP clients receive the tool descriptions published by the specific installation, including their input and output schemas, through the MCP method `tools/list`. The Tool Explorer reads and visualizes that exact response. **Help** also provides a static HTML reference for the complete tool contract of this plugin version and the same data as a JSON download.
 
 Next: [Troubleshooting](troubleshooting.en.md).

--- a/src/mcpserver/schema_reference.py
+++ b/src/mcpserver/schema_reference.py
@@ -1,0 +1,133 @@
+"""Generate the versioned static reference for the complete MCP tool surface."""
+
+from __future__ import annotations
+
+import html
+import json
+from pathlib import Path
+from typing import Any, Final, cast
+
+from mcp.server.fastmcp import FastMCP
+
+from mcpserver.loxone.runtime import LoxoneRuntime
+from mcpserver.tools import (
+    LoxBerryOperateRuntime,
+    LoxBerryReadRuntime,
+    register_tool_surface,
+)
+
+REFERENCE_HTML_PATH: Final = "webfrontend/htmlauth/tool-schema-reference.html"
+REFERENCE_JSON_PATH: Final = "webfrontend/htmlauth/tool-schema-reference.json"
+
+
+def tool_schema_catalog(version: str) -> dict[str, Any]:
+    """Return every supported release tool using FastMCP's canonical schemas."""
+    server = FastMCP("LoxBerry MCP Server schema reference")
+    placeholder = object()
+    register_tool_surface(
+        server,
+        runtime=cast(LoxoneRuntime, placeholder),
+        loxberry_runtime=cast(LoxBerryReadRuntime, placeholder),
+        loxberry_operate_runtime=cast(LoxBerryOperateRuntime, placeholder),
+        control_enabled=True,
+    )
+
+    tools = []
+    for tool in sorted(server._tool_manager.list_tools(), key=lambda item: item.name):
+        tools.append(
+            {
+                "name": tool.name,
+                "description": tool.description or "",
+                "annotations": (
+                    tool.annotations.model_dump(by_alias=True, exclude_none=True)
+                    if tool.annotations is not None
+                    else {}
+                ),
+                "inputSchema": tool.parameters,
+                "outputSchema": tool.output_schema,
+            }
+        )
+    return {
+        "title": "LoxBerry MCP Server tool schema reference",
+        "version": version,
+        "scope": "Complete tool contract supported by this plugin release",
+        "liveDiscovery": (
+            "MCP clients receive the tools enabled for an installation via tools/list."
+        ),
+        "tools": tools,
+    }
+
+
+def schema_reference_json(version: str) -> bytes:
+    """Render the canonical machine-readable catalog."""
+    return (json.dumps(tool_schema_catalog(version), indent=2, ensure_ascii=False) + "\n").encode(
+        "utf-8"
+    )
+
+
+def schema_reference_html(version: str) -> bytes:
+    """Render a standalone human-readable reference from the canonical catalog."""
+    catalog = tool_schema_catalog(version)
+    sections: list[str] = []
+    for tool in catalog["tools"]:
+        name = html.escape(tool["name"])
+        description = html.escape(tool["description"])
+        annotations = html.escape(json.dumps(tool["annotations"], indent=2, ensure_ascii=False))
+        input_schema = html.escape(json.dumps(tool["inputSchema"], indent=2, ensure_ascii=False))
+        output_schema = html.escape(json.dumps(tool["outputSchema"], indent=2, ensure_ascii=False))
+        sections.append(
+            f"""<article id="{name}" class="tool">
+  <h2><code>{name}</code></h2>
+  <p>{description}</p>
+  <details><summary>Annotations</summary><pre>{annotations}</pre></details>
+  <details><summary>Input schema</summary><pre>{input_schema}</pre></details>
+  <details><summary>Output schema</summary><pre>{output_schema}</pre></details>
+</article>"""
+        )
+    content = "\n".join(sections)
+    document = f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{html.escape(catalog["title"])} {html.escape(catalog["version"])}</title>
+  <style>
+    :root {{ color-scheme: light dark; font-family: system-ui, sans-serif; }}
+    body {{ max-width: 78rem; margin: 0 auto; padding: 1rem; line-height: 1.5; }}
+    nav {{ display: flex; flex-wrap: wrap; gap: .75rem; margin: 1rem 0; }}
+    .tool {{ margin: 1rem 0; padding: 1rem; border: 1px solid #8888; border-radius: .4rem; }}
+    summary {{ cursor: pointer; font-weight: 600; padding: .5rem 0; }}
+    pre {{ max-height: 32rem; overflow: auto; padding: .75rem; background: #7772;
+      white-space: pre-wrap; overflow-wrap: anywhere; }}
+    a {{ color: inherit; }}
+    :focus-visible {{ outline: 3px solid #1261a0; outline-offset: 2px; }}
+  </style>
+</head>
+<body>
+  <header>
+    <h1>{html.escape(catalog["title"])}</h1>
+    <p>Plugin version <strong>{html.escape(catalog["version"])}</strong>.
+      This static page documents the complete tool contract supported by this release.</p>
+    <p>MCP clients obtain the tools enabled for a specific installation, including their
+      input and output schemas, through <code>tools/list</code>. The Tool Explorer
+      visualizes that live response.</p>
+    <nav aria-label="Reference links">
+      <a href="explorer.cgi">Open Tool Explorer</a>
+      <a href="tool-schema-reference.json" download>Download JSON reference</a>
+    </nav>
+  </header>
+  <main>{content}</main>
+</body>
+</html>
+"""
+    return document.encode("utf-8")
+
+
+def write_schema_reference(output_root: Path, version: str) -> tuple[Path, Path]:
+    """Write both generated reference formats below an output root."""
+    html_path = output_root / REFERENCE_HTML_PATH
+    json_path = output_root / REFERENCE_JSON_PATH
+    html_path.parent.mkdir(parents=True, exist_ok=True)
+    html_path.write_bytes(schema_reference_html(version))
+    json_path.write_bytes(schema_reference_json(version))
+    return html_path, json_path

--- a/src/mcpserver/server.py
+++ b/src/mcpserver/server.py
@@ -48,12 +48,7 @@ from mcpserver.skill_delivery import SERVER_INSTRUCTIONS, register_skill_resourc
 from mcpserver.tools import (
     LoxBerryOperateRuntime,
     LoxBerryReadRuntime,
-    register_control_tool,
-    register_history_tools,
-    register_loxberry_operate_tool,
-    register_loxberry_read_tools,
-    register_read_tools,
-    register_skill_tool,
+    register_tool_surface,
 )
 
 SERVER_NAME: Final = "LoxBerry MCP Server"
@@ -497,16 +492,13 @@ def create_server(settings: ServerSettings) -> FastMCP:
         LOXBERRY_OPERATE_SCOPE,
     )
     register_skill_resource(server)
-    register_skill_tool(server)
-    register_read_tools(server, runtime, control_enabled=control_enabled)
-    if runtime is not None:
-        register_control_tool(server, runtime)
-    if loxberry_runtime is not None:
-        register_loxberry_read_tools(server, loxberry_runtime)
-    if runtime is not None:
-        register_history_tools(server, runtime)
-    if loxberry_operate_runtime is not None:
-        register_loxberry_operate_tool(server, loxberry_operate_runtime)
+    register_tool_surface(
+        server,
+        runtime=runtime,
+        loxberry_runtime=loxberry_runtime,
+        loxberry_operate_runtime=loxberry_operate_runtime,
+        control_enabled=control_enabled,
+    )
 
     if oauth_web is not None:
         server.custom_route("/authorize", methods=["GET", "POST"], include_in_schema=False)(

--- a/src/mcpserver/tools.py
+++ b/src/mcpserver/tools.py
@@ -3020,3 +3020,23 @@ def register_control_tool(server: FastMCP, runtime: LoxoneRuntime | None) -> Non
             )
         except ControlOperationError as exc:
             return _control_envelope(access, control_uuid, action, error=(exc.code, str(exc)))
+
+
+def register_tool_surface(
+    server: FastMCP,
+    *,
+    runtime: LoxoneRuntime | None,
+    loxberry_runtime: LoxBerryReadRuntime | None,
+    loxberry_operate_runtime: LoxBerryOperateRuntime | None,
+    control_enabled: bool,
+) -> None:
+    """Register one complete live or synthetic MCP tool surface."""
+    register_skill_tool(server)
+    register_read_tools(server, runtime, control_enabled=control_enabled)
+    if runtime is not None:
+        register_control_tool(server, runtime)
+        register_history_tools(server, runtime)
+    if loxberry_runtime is not None:
+        register_loxberry_read_tools(server, loxberry_runtime)
+    if loxberry_operate_runtime is not None:
+        register_loxberry_operate_tool(server, loxberry_operate_runtime)

--- a/templates/explorer.html
+++ b/templates/explorer.html
@@ -107,7 +107,10 @@
   data-origin-mismatch="<TMPL_VAR EXPLORER.ORIGIN_MISMATCH ESCAPE=HTML>">
 
   <section class="mcp-explorer-card" aria-labelledby="explorer-title">
-    <p><a class="lb-button" href="index.cgi"><TMPL_VAR EXPLORER.BACK></a></p>
+    <p class="mcp-explorer-actions">
+      <a class="lb-button" href="index.cgi"><TMPL_VAR EXPLORER.BACK></a>
+      <a class="lb-button" href="tool-schema-reference.html" target="_blank" rel="noopener"><TMPL_VAR ACTION.SCHEMA_REFERENCE></a>
+    </p>
     <h1 id="explorer-title"><TMPL_VAR EXPLORER.TITLE></h1>
     <p><TMPL_VAR EXPLORER.INTRO></p>
     <p class="mcp-explorer-muted"><TMPL_VAR EXPLORER.PERMISSIONS_AFTER_LOGIN></p>

--- a/templates/index.html
+++ b/templates/index.html
@@ -195,7 +195,10 @@
         <label class="mcp-field"><span><TMPL_VAR HELP.MCP_IP></span><span class="mcp-copy-row"><input id="mcp-url-ip" type="text" readonly value="<TMPL_VAR IP_MCP_URL ESCAPE=HTML>"><button class="lb-button" type="button" data-copy-target="mcp-url-ip"><TMPL_VAR ACTION.COPY></button></span></label>
       </div>
       <p class="mcp-help"><TMPL_VAR HELP.MCP_CERTIFICATE_HINT></p>
-      <p><a id="explorer-link" class="lb-button" href="<TMPL_VAR EXPLORER_URL ESCAPE=HTML>" target="_blank" rel="noopener"><TMPL_VAR ACTION.EXPLORER></a></p>
+      <p class="mcp-actions">
+        <a id="explorer-link" class="lb-button" href="<TMPL_VAR EXPLORER_URL ESCAPE=HTML>" target="_blank" rel="noopener"><TMPL_VAR ACTION.EXPLORER></a>
+        <a id="schema-reference-link" class="lb-button" href="<TMPL_VAR SCHEMA_REFERENCE_URL ESCAPE=HTML>" target="_blank" rel="noopener"><TMPL_VAR ACTION.SCHEMA_REFERENCE></a>
+      </p>
       <p><a href="https://github.com/Miraculix2050/LoxBerry-Plugin-MCP-Server" target="_blank" rel="noopener"><TMPL_VAR HELP.PROJECT></a></p>
     </div>
   </details>

--- a/templates/lang/language_de.ini
+++ b/templates/lang/language_de.ini
@@ -121,7 +121,7 @@ LOGMANAGER_HELP=Der nachfolgende LoxBerry-Log-Level steuert native Plugin-Logs i
 
 [HELP]
 TITLE=Hilfe
-TOOL_ACCESS=Sechs lesende Werkzeuge verwenden loxone:read. Das optionale Switch-Werkzeug benötigt zusätzlich loxone:control.
+TOOL_ACCESS=MCP-Clients erhalten die auf dieser Installation verfügbaren Werkzeuge sowie deren Ein- und Ausgabeschemas über tools/list. Der Tool Explorer liest und visualisiert diese Live-Antwort.
 MCP_HOSTNAME=MCP-Adresse mit Hostname (empfohlen)
 MCP_IP=MCP-Adresse mit IP-Adresse
 MCP_CERTIFICATE_HINT=Das Webserver-Zertifikat muss zu der verwendeten Adresse passen. Einige MCP-Clients akzeptieren keine private IP-Adresse für den OAuth-Server; verwende dann die Hostname-Adresse.
@@ -175,6 +175,7 @@ REVOKE_ALL=Alle widerrufen
 DIAGNOSTIC=Maskierte Diagnose exportieren
 SAVE_LOG_LEVEL=Log-Level speichern
 EXPLORER=MCP Tool Explorer öffnen
+SCHEMA_REFERENCE=Statische Schema-Referenz öffnen
 COPY=Kopieren
 COPIED=Kopiert
 RENEW_CERTIFICATE=Webserver-Zertifikat neu ausstellen

--- a/templates/lang/language_en.ini
+++ b/templates/lang/language_en.ini
@@ -121,7 +121,7 @@ LOGMANAGER_HELP=The LoxBerry log level below controls native plugin logs in the 
 
 [HELP]
 TITLE=Help
-TOOL_ACCESS=Six read-only tools use loxone:read. The optional Switch tool additionally requires loxone:control.
+TOOL_ACCESS=MCP clients receive the tools available on this installation and their input and output schemas through tools/list. The Tool Explorer reads and visualizes this live response.
 MCP_HOSTNAME=MCP address using the hostname (recommended)
 MCP_IP=MCP address using the IP address
 MCP_CERTIFICATE_HINT=The web server certificate must match the address in use. Some MCP clients reject a private IP address for the OAuth server; use the hostname address in that case.
@@ -175,6 +175,7 @@ REVOKE_ALL=Revoke all
 DIAGNOSTIC=Export masked diagnostics
 SAVE_LOG_LEVEL=Save log level
 EXPLORER=Open MCP Tool Explorer
+SCHEMA_REFERENCE=Open static schema reference
 COPY=Copy
 COPIED=Copied
 RENEW_CERTIFICATE=Reissue web server certificate

--- a/tests/test_explorer_ui.py
+++ b/tests/test_explorer_ui.py
@@ -11,6 +11,18 @@ ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "webfrontend" / "htmlauth" / "explorer.js"
 
 
+def test_help_and_explorer_link_to_static_schema_reference() -> None:
+    index = (ROOT / "templates" / "index.html").read_text(encoding="utf-8")
+    explorer = (ROOT / "templates" / "explorer.html").read_text(encoding="utf-8")
+    cgi = (ROOT / "webfrontend" / "htmlauth" / "index.cgi").read_text(encoding="utf-8")
+
+    assert "SCHEMA_REFERENCE_URL => 'tool-schema-reference.html'" in cgi
+    assert 'href="<TMPL_VAR SCHEMA_REFERENCE_URL ESCAPE=HTML>"' in index
+    assert 'href="tool-schema-reference.html"' in explorer
+    assert "ACTION.SCHEMA_REFERENCE" in index
+    assert "ACTION.SCHEMA_REFERENCE" in explorer
+
+
 def run_core(expression: str) -> object:
     node = shutil.which("node")
     if node is None:

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import pytest
 
+from mcpserver.schema_reference import REFERENCE_HTML_PATH, REFERENCE_JSON_PATH
 from mcpserver.skill_delivery import SKILL_REVISION
 from tools.build_plugin import (
     _EXECUTABLES,
@@ -24,6 +25,7 @@ from tools.build_plugin import (
 )
 from tools.build_release_candidate import _copy_runtime_wheels, _publish, _source_ignore
 from tools.build_release_candidate import main as build_release_candidate
+from tools.generate_schema_reference import main as generate_schema_reference
 from tools.prepare_wheelhouse import main as prepare_wheelhouse
 from tools.validate_release_metadata import validate as validate_release_metadata
 from tools.verify_plugin import (
@@ -74,6 +76,43 @@ def test_agent_skill_is_declared_as_wheel_package_data() -> None:
     assert (skill / "agents" / "openai.yaml").is_file()
     assert '"skills/using-loxberry-mcp/SKILL.md"' in pyproject
     assert '"skills/using-loxberry-mcp/agents/openai.yaml"' in pyproject
+
+
+def test_package_contract_includes_generated_schema_reference() -> None:
+    from tools.build_plugin import expected_source_entries
+
+    entries = expected_source_entries(ROOT)
+    assert REFERENCE_HTML_PATH in entries
+    assert REFERENCE_JSON_PATH in entries
+
+
+def test_verifier_help_does_not_import_mcp_runtime(tmp_path: Path) -> None:
+    (tmp_path / "mcp.py").write_text(
+        "raise RuntimeError('MCP runtime must not be imported')\n", encoding="utf-8"
+    )
+    environment = os.environ.copy()
+    environment["PYTHONPATH"] = str(tmp_path)
+
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "tools" / "verify_plugin.py"), "--help"],
+        cwd=ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Verify a built LoxBerry plugin archive" in result.stdout
+
+
+def test_schema_generator_requires_explicit_output_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "argv", ["generate_schema_reference.py"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        generate_schema_reference()
+
+    assert exc_info.value.code == 2
 
 
 def test_mcp_client_smoke_covers_skill_delivery_surfaces() -> None:

--- a/tests/test_schema_reference.py
+++ b/tests/test_schema_reference.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+import tomllib
+from pathlib import Path
+
+from mcpserver.schema_reference import (
+    REFERENCE_HTML_PATH,
+    REFERENCE_JSON_PATH,
+    schema_reference_html,
+    schema_reference_json,
+    tool_schema_catalog,
+    write_schema_reference,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+VERSION = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))["project"]["version"]
+
+EXPECTED_TOOLS = {
+    "loxberry_clear_statistics_cache",
+    "loxberry_get_plugin_status",
+    "loxberry_get_service_health",
+    "loxberry_get_system_status",
+    "loxberry_list_service_events",
+    "loxone_describe_control",
+    "loxone_find_controls",
+    "loxone_get_control_history",
+    "loxone_get_control_notes",
+    "loxone_get_room_snapshot",
+    "loxone_get_skill_guide",
+    "loxone_get_states",
+    "loxone_get_statistics",
+    "loxone_get_system_status",
+    "loxone_get_weather",
+    "loxone_list_categories",
+    "loxone_list_global_metadata",
+    "loxone_list_rooms",
+    "loxone_operate_control",
+}
+
+
+def test_schema_catalog_contains_complete_fastmcp_contract() -> None:
+    catalog = tool_schema_catalog(VERSION)
+    tools = catalog["tools"]
+
+    assert catalog["version"] == VERSION
+    assert [tool["name"] for tool in tools] == sorted(EXPECTED_TOOLS)
+    assert {tool["name"] for tool in tools} == EXPECTED_TOOLS
+    for tool in tools:
+        assert tool["description"]
+        assert tool["annotations"]["readOnlyHint"] in {True, False}
+        assert tool["inputSchema"]["type"] == "object"
+        assert tool["outputSchema"]["type"] == "object"
+        assert tool["outputSchema"]["properties"]["data"]["anyOf"]
+
+
+def test_schema_reference_formats_are_deterministic_and_equivalent() -> None:
+    first_json = schema_reference_json(VERSION)
+    first_html = schema_reference_html(VERSION)
+
+    assert schema_reference_json(VERSION) == first_json
+    assert schema_reference_html(VERSION) == first_html
+    catalog = json.loads(first_json)
+    rendered = first_html.decode("utf-8")
+    assert f"Plugin version <strong>{VERSION}</strong>" in rendered
+    assert "through <code>tools/list</code>" in rendered
+    assert 'href="tool-schema-reference.json"' in rendered
+    for tool in catalog["tools"]:
+        assert f'<article id="{tool["name"]}"' in rendered
+
+
+def test_schema_reference_writer_uses_installed_paths(tmp_path: Path) -> None:
+    html_path, json_path = write_schema_reference(tmp_path, VERSION)
+
+    assert html_path == tmp_path / REFERENCE_HTML_PATH
+    assert json_path == tmp_path / REFERENCE_JSON_PATH
+    assert html_path.read_bytes() == schema_reference_html(VERSION)
+    assert json_path.read_bytes() == schema_reference_json(VERSION)

--- a/tests/test_test_runner.py
+++ b/tests/test_test_runner.py
@@ -25,6 +25,7 @@ def test_changed_packaging_selects_package_contract_tests() -> None:
     assert _pytest_targets(plan) == {
         "tests/test_apache_config.py",
         "tests/test_plugin_package.py",
+        "tests/test_schema_reference.py",
     }
 
 

--- a/tools/build_plugin.py
+++ b/tools/build_plugin.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import re
+import sys
 import tomllib
 import zipfile
 from pathlib import Path
@@ -26,6 +27,9 @@ _ROOT_FILES: Final = (
     "postupgrade.sh",
 )
 _DIRECTORIES: Final = ("config", "icons", "templates", "uninstall", "webfrontend")
+REFERENCE_HTML_PATH: Final = "webfrontend/htmlauth/tool-schema-reference.html"
+REFERENCE_JSON_PATH: Final = "webfrontend/htmlauth/tool-schema-reference.json"
+_GENERATED_REFERENCE_PATHS: Final = {REFERENCE_HTML_PATH, REFERENCE_JSON_PATH}
 _EXECUTABLES: Final = {
     "preinstall.sh",
     "preupgrade.sh",
@@ -81,7 +85,7 @@ def expected_source_entries(root: Path) -> set[str]:
         item.relative_to(root).as_posix()
         for directory in _DIRECTORIES
         for item in (root / directory).rglob("*")
-        if item.is_file()
+        if item.is_file() and item.relative_to(root).as_posix() not in _GENERATED_REFERENCE_PATHS
     )
     entries.update(
         {
@@ -90,6 +94,8 @@ def expected_source_entries(root: Path) -> set[str]:
             "bin/renew-web-certificate",
             "bin/runtime-arm64.lock",
             "bin/runtime-arm64.sha256",
+            REFERENCE_HTML_PATH,
+            REFERENCE_JSON_PATH,
         }
     )
     return entries
@@ -105,12 +111,17 @@ def _locked_requirements(lock: Path) -> dict[str, str]:
     return requirements
 
 
-def _project_version(root: Path) -> str:
+def _release_version(root: Path) -> str:
     document = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
     version = document.get("project", {}).get("version")
     if not isinstance(version, str):
         raise SystemExit("project version is missing")
-    return project_version(version)
+    project_version(version)
+    return version
+
+
+def _project_version(root: Path) -> str:
+    return project_version(_release_version(root))
 
 
 def _wheel_names(wheelhouse: Path) -> set[str]:
@@ -168,17 +179,20 @@ def _verify_project_wheel(project_wheel: Path, source_root: Path) -> None:
                 raise SystemExit(f"project wheel contains stale source: {name}")
 
 
-def _add(archive: zipfile.ZipFile, source: Path, target: str) -> None:
+def _add_content(archive: zipfile.ZipFile, content: bytes, target: str) -> None:
     info = zipfile.ZipInfo(target.replace("\\", "/"), _TIMESTAMP)
     info.create_system = 3
     info.compress_type = zipfile.ZIP_STORED
     mode = 0o755 if target.replace("\\", "/") in _EXECUTABLES else 0o644
     info.external_attr = (mode | 0o100000) << 16
-    content = source.read_bytes()
     target_path = Path(target)
     if target_path.suffix.lower() in _TEXT_SUFFIXES or target.replace("\\", "/") in _TEXT_NAMES:
         content = content.replace(b"\r\n", b"\n")
     archive.writestr(info, content)
+
+
+def _add(archive: zipfile.ZipFile, source: Path, target: str) -> None:
+    _add_content(archive, source.read_bytes(), target)
 
 
 def main() -> int:
@@ -192,6 +206,9 @@ def main() -> int:
     )
     args = parser.parse_args()
     root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(root / "src"))
+    from mcpserver.schema_reference import schema_reference_html, schema_reference_json
+
     wheelhouse = args.wheelhouse.resolve()
     output = args.output.resolve()
     lock = root / "requirements" / "runtime-arm64.lock"
@@ -224,9 +241,10 @@ def main() -> int:
         for name, version in requirements.items()
         if (name, version.lower()) not in wheel_versions
     }
-    project_version = _project_version(root)
-    project_wheels = tuple(wheelhouse.glob(f"loxberry_mcpserver-{project_version}-*.whl"))
-    expected_project = [("loxberry-mcpserver", project_version.lower())]
+    release_version = _release_version(root)
+    project_wheel_version = _project_version(root)
+    project_wheels = tuple(wheelhouse.glob(f"loxberry_mcpserver-{project_wheel_version}-*.whl"))
+    expected_project = [("loxberry-mcpserver", project_wheel_version.lower())]
     unexpected = set(runtime_wheels) - expected_runtime
     duplicates = len(runtime_wheels) != len(set(runtime_wheels))
     invalid_wheel = len(wheel_files) != len(wheel_identities)
@@ -261,7 +279,7 @@ def main() -> int:
         (item, item.relative_to(root).as_posix())
         for directory in _DIRECTORIES
         for item in (root / directory).rglob("*")
-        if item.is_file()
+        if item.is_file() and item.relative_to(root).as_posix() not in _GENERATED_REFERENCE_PATHS
     )
     entries.extend(
         [
@@ -278,6 +296,8 @@ def main() -> int:
     with zipfile.ZipFile(output, "w") as archive:
         for source, target in sorted(entries, key=lambda item: item[1]):
             _add(archive, source, target)
+        _add_content(archive, schema_reference_html(release_version), REFERENCE_HTML_PATH)
+        _add_content(archive, schema_reference_json(release_version), REFERENCE_JSON_PATH)
     digest = hashlib.sha256(output.read_bytes()).hexdigest()
     output.with_suffix(output.suffix + ".sha256").write_text(
         f"{digest}  {output.name}\n", encoding="ascii", newline="\n"

--- a/tools/generate_schema_reference.py
+++ b/tools/generate_schema_reference.py
@@ -1,0 +1,30 @@
+"""Generate the static HTML and JSON MCP tool schema reference."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from mcpserver.schema_reference import write_schema_reference  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-root", type=Path, required=True)
+    args = parser.parse_args()
+    document = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    version = document.get("project", {}).get("version")
+    if not isinstance(version, str):
+        raise SystemExit("project version is missing")
+    for path in write_schema_reference(args.output_root.resolve(), version):
+        print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test.py
+++ b/tools/test.py
@@ -48,11 +48,17 @@ _TEST_GROUPS: Final = (
             "release.cfg",
             "tools/build_plugin.py",
             "tools/build_release_candidate.py",
+            "tools/generate_schema_reference.py",
             "tools/prepare_wheelhouse.py",
             "tools/verify_plugin.py",
+            "src/mcpserver/schema_reference.py",
             "uninstall/**",
         ),
-        ("tests/test_plugin_package.py", "tests/test_apache_config.py"),
+        (
+            "tests/test_plugin_package.py",
+            "tests/test_apache_config.py",
+            "tests/test_schema_reference.py",
+        ),
     ),
     (
         (

--- a/tools/verify_plugin.py
+++ b/tools/verify_plugin.py
@@ -8,15 +8,26 @@ import hashlib
 import io
 import re
 import stat
+import sys
 import zipfile
 from pathlib import Path, PurePosixPath
 from typing import Final
 
 try:
-    from tools.build_plugin import _TIMESTAMP, expected_source_entries
+    from tools.build_plugin import (
+        _TIMESTAMP,
+        REFERENCE_HTML_PATH,
+        REFERENCE_JSON_PATH,
+        expected_source_entries,
+    )
     from tools.versioning import project_version
 except ModuleNotFoundError:  # Direct documented CLI execution from repository root.
-    from build_plugin import _TIMESTAMP, expected_source_entries
+    from build_plugin import (
+        _TIMESTAMP,
+        REFERENCE_HTML_PATH,
+        REFERENCE_JSON_PATH,
+        expected_source_entries,
+    )
     from versioning import project_version
 
 _REQUIRED: Final = {
@@ -212,6 +223,22 @@ def verify_archive(archive: Path, *, require_checksum: bool = True) -> str:
             missing_exact = expected_names - set(names)
             detail = min(extra or missing_exact)
             raise PackageVerificationError(f"plugin archive violates exact manifest: {detail}")
+        try:
+            sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+            from mcpserver.schema_reference import schema_reference_html, schema_reference_json
+        except ModuleNotFoundError as exc:
+            if exc.name != "mcp":
+                raise
+        else:
+            generated_reference = {
+                REFERENCE_HTML_PATH: schema_reference_html(version),
+                REFERENCE_JSON_PATH: schema_reference_json(version),
+            }
+            for name, expected in generated_reference.items():
+                if package.read(name) != expected:
+                    raise PackageVerificationError(
+                        f"plugin archive contains stale schema reference: {name}"
+                    )
         if any(
             PurePosixPath(name).parent != PurePosixPath("bin/wheelhouse")
             or PurePosixPath(name).suffix != ".whl"

--- a/webfrontend/htmlauth/index.cgi
+++ b/webfrontend/htmlauth/index.cgi
@@ -512,6 +512,7 @@ $template->param(
     HOSTNAME_MCP_URL => $hostname_mcp_url,
     IP_MCP_URL => $ip_mcp_url,
     EXPLORER_URL => 'explorer.cgi',
+    SCHEMA_REFERENCE_URL => 'tool-schema-reference.html',
     ENDPOINT => $display_endpoint,
     MINISERVERS => $miniservers,
     MANUAL_ENDPOINT => $has_selected_miniserver ? 0 : 1,


### PR DESCRIPTION
## Summary

- generate a deterministic HTML and JSON reference from the shared FastMCP tool registration
- publish the versioned reference in plugin packages and link it from Help and the Tool Explorer
- document `tools/list` as the authoritative schema source for each installed configuration
- keep dependency-free release reverification and prevent generated source-tree files from entering packages twice

## Validation

- Python 3.13 Full profile: 604 passed
- Ruff format/check: passed
- strict mypy: passed
- package generation and stale-reference verification: covered
- dependency-free verifier import and explicit generator output target: covered
- independent subagent review: three findings reproduced and fixed (publish dependency boundary, ambient version drift, duplicate package members)

## Browser boundary

The local `file://` preview was blocked by the browser URL policy and was not bypassed. Help/Explorer links, synchronized DE/EN keys, DOM contracts, responsive CSS, and package paths are covered by automated tests.