### PR TITLE
Restore Explorer date-time pickers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ extracted from the matching version heading.
   contract during package builds, link it from Help and the Tool Explorer, and
   document `tools/list` as the authoritative installed tool surface.
 
+- Restore date/time pickers for optional RFC-3339 tool parameters in the Tool Explorer.
+
 - Update the bundled `using-loxberry-mcp` agent workflow to revision 24 with
   task-specific read paths, complete cache-operation authorization and
   uncertainty guidance, and fail-closed schema and parameter-source rules.

--- a/tests/test_explorer_ui.py
+++ b/tests/test_explorer_ui.py
@@ -357,6 +357,18 @@ def test_explorer_converts_datetime_local_values_to_rfc3339() -> None:
     assert run_core(f"core.rfc3339ToDateTimeLocal({json.dumps(converted)})") == "2026-08-12T12:34"
 
 
+def test_explorer_preserves_datetime_format_for_optional_string_fields() -> None:
+    schema = {
+        "anyOf": [{"type": "string"}, {"type": "null"}],
+        "format": "date-time",
+        "default": None,
+    }
+    encoded = json.dumps(schema)
+
+    assert run_core(f"core.effectiveSchema({encoded},{encoded}).format") == "date-time"
+    assert run_core(f"core.schemaSupportedForReuse({encoded},{encoded})") is True
+
+
 def test_explorer_reuse_honours_full_nested_schema() -> None:
     tools = [
         {

--- a/webfrontend/htmlauth/explorer.js
+++ b/webfrontend/htmlauth/explorer.js
@@ -21,7 +21,7 @@
     '$ref', '$defs', 'type', 'enum', 'const', 'anyOf', 'oneOf', 'properties', 'required',
     'additionalProperties', 'items', 'minimum', 'maximum', 'minLength', 'maxLength',
     'pattern', 'minItems', 'maxItems', 'uniqueItems', 'title', 'description', 'default',
-    'examples', 'readOnly', 'writeOnly',
+    'examples', 'format', 'readOnly', 'writeOnly',
   ]);
   const TOOL_GROUPS = [
     {id: 'loxoneRead', names: [
@@ -198,7 +198,9 @@
     const useful = variants
       .map((item) => resolveRef(item, rootSchema))
       .filter((item) => item.type !== 'null');
-    return useful.length === 1 ? useful[0] : resolved;
+    if (useful.length !== 1) return resolved;
+    const {anyOf, oneOf, ...outer} = resolved;
+    return {...outer, ...useful[0]};
   }
 
   function schemaType(schema, rootSchema) {
@@ -408,6 +410,7 @@
     if (visited.has(schema)) return true;
     visited.add(schema);
     if (Object.keys(schema).some((key) => !REUSE_SCHEMA_KEYS.has(key))) return false;
+    if (schema.format !== undefined && schema.format !== 'date-time') return false;
     if (typeof schema.$ref === 'string') {
       if (!schema.$ref.startsWith('#/')) return false;
       const resolved = schema.$ref.slice(2).split('/').reduce((value, part) => {


### PR DESCRIPTION
## Summary

Restore native date/time pickers for optional RFC-3339 parameters in the Tool Explorer.

## Root cause

The Explorer resolved `string | null` schemas to their string variant and discarded parent metadata, including `format: date-time`. Optional history and diagnostic-event ranges therefore rendered as plain text fields.

## Impact

`loxone_get_control_history` and `loxberry_list_service_events` again render `start` and `end` as local date/time pickers and submit RFC-3339 UTC values. Other formats remain fail-closed for result reuse.

## Validation

- Python 3.13: `tests/test_explorer_ui.py` — 34 passed
- Python 3.13 Full gate — 601 passed; Ruff, MyPy, and diff check passed
