### PR TITLE
Harden dynamic client registration

### DIFF
--- a/docs/development/adr/0004-integrated-tool-explorer.md
+++ b/docs/development/adr/0004-integrated-tool-explorer.md
@@ -49,6 +49,12 @@ Origin, JSON content type and an explicitly parsed request body. The same-origin
 policy and a strict Content Security Policy remain important boundaries for the
 access token held in tab memory.
 
+Dynamic client registrations that have not entered an authorization flow expire
+after one hour. With the public rate limit of 16 registrations per five minutes,
+at most 192 unused clients can remain concurrently—below the persistent capacity
+of 256. Clients referenced by an authorization code or token family remain
+governed by their respective OAuth lifetime.
+
 Browsers cannot reliably distinguish reload from tab close or guarantee an
 unload request. The explorer therefore does not claim automatic revocation on
 page unload. Explicit disconnect performs RFC 7009 revocation and deletes the

--- a/src/mcpserver/auth/provider.py
+++ b/src/mcpserver/auth/provider.py
@@ -47,7 +47,11 @@ _EXPLORER_CALLBACK_PATH: Final = "/admin/plugins/mcpserver/explorer_callback.cgi
 _MAX_REGISTERED_CLIENTS: Final = 256
 _MAX_ACTIVE_FAMILIES: Final = 256
 _MAX_FAMILIES_PER_CLIENT: Final = 16
-_UNUSED_CLIENT_TTL: Final = 24 * 60 * 60
+# Public Dynamic Client Registration is deliberately rate-limited to 16 clients
+# per five minutes. Keep an unused client for at most one hour, so even a
+# sustained unauthenticated registration flood cannot consume all 256 slots.
+# A client becomes durable once it is referenced by an authorization flow.
+_UNUSED_CLIENT_TTL: Final = 60 * 60
 
 
 class StoredAuthorizationCode(AuthorizationCode):
@@ -234,7 +238,9 @@ class Phase0OAuthProvider(
 
         self.store.mutate(insert)
 
-    def _garbage_collect(self, document: dict[str, Any]) -> None:
+    def _garbage_collect(
+        self, document: dict[str, Any], *, preserve_client_ids: frozenset[str] = frozenset()
+    ) -> None:
         now = self.now()
         for family in document["families"].values():
             client = document["clients"].get(family.get("client_id"), {})
@@ -277,6 +283,7 @@ class Phase0OAuthProvider(
             client_id: record
             for client_id, record in document["clients"].items()
             if client_id in referenced_clients
+            or client_id in preserve_client_ids
             or int(record.get("client_id_issued_at", now)) + _UNUSED_CLIENT_TTL > now
         }
 
@@ -366,7 +373,10 @@ class Phase0OAuthProvider(
         }
 
         def insert(document: dict[str, Any]) -> None:
-            self._garbage_collect(document)
+            # The browser validated this client at authorization start. Preserve
+            # it through the short consent flow even if its unused-registration
+            # lifetime elapses before the authorization code is committed.
+            self._garbage_collect(document, preserve_client_ids=frozenset({client_id}))
             client_record = document["clients"].get(client_id)
             if client_record is None:
                 raise TokenError("invalid_client", "Client registration is unavailable")

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -19,6 +19,7 @@ from starlette.requests import Request
 from starlette.routing import Route
 from starlette.testclient import TestClient
 
+from mcpserver.auth import web as auth_web
 from mcpserver.auth.loxone_store import EncryptedLoxoneTokenStore
 from mcpserver.auth.provider import (
     CONTROL_SCOPE,
@@ -448,9 +449,40 @@ async def test_registration_capacity_returns_protocol_error_and_prunes_old_clien
     with pytest.raises(RegistrationError, match="capacity"):
         await provider.register_client(_client_info("overflow"))
 
-    clock.value += 24 * 60 * 60 + 1
+    clock.value += 60 * 60 + 1
     await provider.register_client(_client_info("replacement"))
     assert set(provider.store.snapshot()["clients"]) == {"replacement"}
+
+
+@pytest.mark.asyncio
+async def test_public_registration_rate_cannot_exhaust_unused_client_capacity(
+    tmp_path: Path,
+) -> None:
+    clock = Clock()
+    provider = _provider(tmp_path, clock)
+
+    # The public endpoint admits at most 16 clients per five-minute window.
+    # At the one-hour unused-client TTL, the oldest batch expires before a
+    # thirteenth batch can raise the live population above 192.
+    for window in range(13):
+        for index in range(16):
+            await provider.register_client(_client_info(f"client-{window}-{index}"))
+        assert len(provider.store.snapshot()["clients"]) <= 192
+        clock.value += 5 * 60
+
+
+def test_public_registration_rate_and_unused_client_ttl_preserve_capacity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    clock = Clock()
+    provider = _provider(tmp_path, clock)
+    monkeypatch.setattr(auth_web.time, "time", lambda: clock.value)
+    with TestClient(_web_app(provider)) as client:
+        for _window in range(13):
+            responses = [client.post("/register", json=_registration_payload()) for _ in range(17)]
+            assert [response.status_code for response in responses] == [201] * 16 + [429]
+            assert len(provider.store.snapshot()["clients"]) <= 192
+            clock.value += 5 * 60
 
 
 @pytest.mark.asyncio
@@ -467,7 +499,7 @@ async def test_stale_unused_client_is_removed_before_authorization_starts(tmp_pa
     client = _client_info("stale-client")
     await provider.register_client(client)
 
-    clock.value += 24 * 60 * 60 + 1
+    clock.value += 60 * 60 + 1
 
     assert await provider.get_client("stale-client") is None
     with pytest.raises(TokenError, match="registration"):
@@ -479,6 +511,29 @@ async def test_stale_unused_client_is_removed_before_authorization_starts(tmp_pa
             identity_id="identity",
             miniserver_id="miniserver",
         )
+
+
+@pytest.mark.asyncio
+async def test_started_authorization_can_finish_after_unused_client_ttl(tmp_path: Path) -> None:
+    clock = Clock()
+    provider = _provider(tmp_path, clock)
+    client = _client_info("consent-client")
+    await provider.register_client(client)
+
+    clock.value += 60 * 60 - 1
+    assert await provider.get_client("consent-client") is not None
+
+    clock.value += 2
+    code = provider.issue_authorization_code(
+        client_id="consent-client",
+        redirect_uri=REDIRECT,
+        code_challenge=CHALLENGE,
+        resource=RESOURCE,
+        identity_id="identity",
+        miniserver_id="miniserver",
+    )
+
+    assert await provider.load_authorization_code(client, code) is not None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- expire unused Dynamic Client Registration records after one hour
- prevent a sustained public registration flood from consuming the 256-client persistent capacity
- add a rate-to-capacity regression test and document the retained-client lifetime

## Root cause

Unauthenticated client registration is rate-limited to 16 registrations per five minutes, but unused registrations previously remained for 24 hours. At that rate, public requests could fill the global client capacity.

## Impact

Clients that do not start an authorization flow within one hour must register again. Clients referenced by an authorization code or token family retain their existing OAuth lifetime.

## Validation

- `python tools/test.py --profile changed` (Python 3.13): 113 passed; Ruff, mypy, and diff check passed
