### PR TITLE
Harden admin response headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ extracted from the matching version heading.
 
 ## Unreleased
 
+- Harden Admin UI browser responses with no-store caching, CSP, frame, referrer
+  and MIME protections across page, AJAX, download and redirect paths.
+
 - Add Tool Explorer time-range shortcuts, in-tab reference selection, action-specific
   control fields, and collapsible advanced parameters.
 

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -40,6 +40,10 @@ Configuration, encrypted sessions and plugin identity persist outside the packag
 
 Gen. 1 uses local HTTP/WS plus Loxone command encryption; Gen. 2 requires validated HTTPS/WSS and never falls back to cleartext. Logs and diagnostic exports are structured and sanitized: no credentials, tokens, private keys, full structures or arbitrary raw logs. Writes are audited without secrets and are never retried after an uncertain outcome.
 
+The authenticated Admin UI sends no-store cache directives, a same-origin Content
+Security Policy, frame denial, a no-referrer policy and MIME sniffing protection
+for page, AJAX, diagnostic-download and redirect responses.
+
 ## Related documents
 
 - [Implementation guidelines](implementation-guidelines.md)

--- a/tests/perl_stubs/LoxBerry/System.pm
+++ b/tests/perl_stubs/LoxBerry/System.pm
@@ -4,6 +4,15 @@ use warnings;
 use Exporter 'import';
 our @EXPORT = qw($lbhomedir $lbpplugindir $lbpconfigdir $lbpdatadir $lbpbindir $lbptemplatedir $lbplogdir);
 our ($lbhomedir, $lbpplugindir, $lbpconfigdir, $lbpdatadir, $lbpbindir, $lbptemplatedir, $lbplogdir);
+BEGIN {
+    $lbhomedir = $ENV{LB_TEST_HOME} // '';
+    $lbpplugindir = $ENV{LB_TEST_PLUGIN_DIR} // 'mcpserver';
+    $lbpconfigdir = $ENV{LB_TEST_CONFIG_DIR} // '';
+    $lbpdatadir = $ENV{LB_TEST_DATA_DIR} // '';
+    $lbpbindir = $ENV{LB_TEST_BIN_DIR} // '';
+    $lbptemplatedir = $ENV{LB_TEST_TEMPLATE_DIR} // '';
+    $lbplogdir = $ENV{LB_TEST_LOG_DIR} // '';
+}
 sub pluginversion { return 'test'; }
 sub pluginloglevel { return 3; }
 sub read_file { return ''; }

--- a/tests/perl_stubs/LoxBerry/System.pm
+++ b/tests/perl_stubs/LoxBerry/System.pm
@@ -15,6 +15,8 @@ BEGIN {
 }
 sub pluginversion { return 'test'; }
 sub pluginloglevel { return 3; }
+sub lbhostname { return 'localhost'; }
+sub get_localip { return '127.0.0.1'; }
 sub read_file { return ''; }
 sub readlanguage { return (); }
 1;

--- a/tests/test_admin_ui.py
+++ b/tests/test_admin_ui.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import re
 import shutil
 import subprocess
@@ -8,25 +9,69 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 
-def test_admin_responses_emit_no_store_and_frame_protection() -> None:
-    cgi = (ROOT / "webfrontend" / "htmlauth" / "index.cgi").read_text(encoding="utf-8")
+def _admin_cgi_environment(tmp_path: Path) -> dict[str, str]:
+    helper = tmp_path / "mcpserver-admin"
+    helper.write_text(
+        "#!/usr/bin/env perl\n"
+        "use strict; use warnings;\n"
+        'print qq({\\"ok\\":true,\\"data\\":{}});\n',
+        encoding="utf-8",
+    )
+    helper.chmod(0o755)
+    return {
+        **os.environ,
+        "LB_TEST_HOME": str(tmp_path),
+        "LB_TEST_CONFIG_DIR": str(tmp_path),
+        "LB_TEST_DATA_DIR": str(tmp_path),
+        "LB_TEST_BIN_DIR": str(tmp_path),
+        "LB_TEST_TEMPLATE_DIR": str(tmp_path),
+        "LB_TEST_LOG_DIR": str(tmp_path),
+    }
 
-    assert "sub security_header_args" in cgi
-    assert "-Cache_Control => 'no-store'" in cgi
-    assert "-Pragma => 'no-cache'" in cgi
-    assert "-Content_Security_Policy =>" in cgi
-    assert "frame-ancestors 'none'" in cgi
-    assert "base-uri 'self'" in cgi
-    assert "object-src 'none'" in cgi
-    assert "form-action 'self'" in cgi
-    assert "connect-src 'self'" in cgi
-    assert "-Referrer_Policy => 'no-referrer'" in cgi
-    assert "-X_Content_Type_Options => 'nosniff'" in cgi
-    assert "-X_Frame_Options => 'DENY'" in cgi
-    assert "'unsafe-eval'" not in cgi
-    assert "sub redirect_reply" in cgi
-    assert "security_header_args()," in cgi
-    assert "print_html_security_headers();" in cgi
+
+def _assert_admin_security_headers(output: str) -> None:
+    headers = output.lower()
+    assert "cache-control: no-store" in headers
+    assert "pragma: no-cache" in headers
+    assert "content-security-policy:" in headers
+    assert "frame-ancestors 'none'" in headers
+    assert "base-uri 'self'" in headers
+    assert "object-src 'none'" in headers
+    assert "form-action 'self'" in headers
+    assert "connect-src 'self'" in headers
+    assert "referrer-policy: no-referrer" in headers
+    assert "x-content-type-options: nosniff" in headers
+    assert "x-frame-options: deny" in headers
+
+
+def test_admin_responses_emit_no_store_and_frame_protection(tmp_path: Path) -> None:
+    perl = shutil.which("perl")
+    if perl is None or os.name == "nt":
+        return
+    environment = _admin_cgi_environment(tmp_path)
+    cgi = ROOT / "webfrontend" / "htmlauth" / "index.cgi"
+    common = [perl, f"-I{ROOT / 'tests' / 'perl_stubs'}", str(cgi)]
+
+    page = subprocess.run(common, check=True, capture_output=True, text=True, env=environment)
+    _assert_admin_security_headers(page.stdout)
+
+    ajax_environment = {
+        **environment,
+        "REQUEST_METHOD": "POST",
+        "CONTENT_TYPE": "application/x-www-form-urlencoded",
+        "CONTENT_LENGTH": "20",
+        "HTTP_ORIGIN": "https://loxberry.example",
+        "HTTP_HOST": "loxberry.example",
+    }
+    ajax = subprocess.run(
+        common,
+        check=True,
+        capture_output=True,
+        text=True,
+        input="action=status&ajax=1",
+        env=ajax_environment,
+    )
+    _assert_admin_security_headers(ajax.stdout)
 
 
 def test_initial_page_renders_configuration_before_loading_dynamic_state() -> None:

--- a/tests/test_admin_ui.py
+++ b/tests/test_admin_ui.py
@@ -14,6 +14,7 @@ def _admin_cgi_environment(tmp_path: Path) -> dict[str, str]:
     helper.write_text(
         "#!/usr/bin/env perl\n"
         "use strict; use warnings;\n"
+        "my $request = <STDIN>;\n"
         'print qq({\\"ok\\":true,\\"data\\":{}});\n',
         encoding="utf-8",
     )

--- a/tests/test_admin_ui.py
+++ b/tests/test_admin_ui.py
@@ -8,6 +8,27 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 
+def test_admin_responses_emit_no_store_and_frame_protection() -> None:
+    cgi = (ROOT / "webfrontend" / "htmlauth" / "index.cgi").read_text(encoding="utf-8")
+
+    assert "sub security_header_args" in cgi
+    assert "-Cache_Control => 'no-store'" in cgi
+    assert "-Pragma => 'no-cache'" in cgi
+    assert "-Content_Security_Policy =>" in cgi
+    assert "frame-ancestors 'none'" in cgi
+    assert "base-uri 'self'" in cgi
+    assert "object-src 'none'" in cgi
+    assert "form-action 'self'" in cgi
+    assert "connect-src 'self'" in cgi
+    assert "-Referrer_Policy => 'no-referrer'" in cgi
+    assert "-X_Content_Type_Options => 'nosniff'" in cgi
+    assert "-X_Frame_Options => 'DENY'" in cgi
+    assert "'unsafe-eval'" not in cgi
+    assert "sub redirect_reply" in cgi
+    assert "security_header_args()," in cgi
+    assert "print_html_security_headers();" in cgi
+
+
 def test_initial_page_renders_configuration_before_loading_dynamic_state() -> None:
     cgi = (ROOT / "webfrontend/htmlauth/index.cgi").read_text(encoding="utf-8")
     template = (ROOT / "templates/index.html").read_text(encoding="utf-8")

--- a/webfrontend/htmlauth/index.cgi
+++ b/webfrontend/htmlauth/index.cgi
@@ -99,9 +99,40 @@ sub same_origin_post {
     return $origin =~ m{^https?://\Q$host\E$}i ? 1 : 0;
 }
 
+sub security_header_args {
+    return (
+        -Cache_Control => 'no-store',
+        -Pragma => 'no-cache',
+        -Content_Security_Policy => "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; form-action 'self'; frame-ancestors 'none'; base-uri 'self'; object-src 'none'",
+        -Referrer_Policy => 'no-referrer',
+        -X_Content_Type_Options => 'nosniff',
+        -X_Frame_Options => 'DENY',
+    );
+}
+
+sub print_html_security_headers {
+    print "Cache-Control: no-store\n";
+    print "Pragma: no-cache\n";
+    print "Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; form-action 'self'; frame-ancestors 'none'; base-uri 'self'; object-src 'none'\n";
+    print "Referrer-Policy: no-referrer\n";
+    print "X-Content-Type-Options: nosniff\n";
+    print "X-Frame-Options: DENY\n";
+}
+
+sub redirect_reply {
+    my ($location) = @_;
+    print $cgi->header(-status => 302, -location => $location, security_header_args());
+    exit;
+}
+
 sub json_reply {
     my ($result, $status) = @_;
-    print $cgi->header(-type => 'application/json', -charset => 'utf-8', -status => ($status // 200));
+    print $cgi->header(
+        -type => 'application/json',
+        -charset => 'utf-8',
+        -status => ($status // 200),
+        security_header_args(),
+    );
     print encode_json($result);
     exit;
 }
@@ -303,8 +334,7 @@ if ($action ne '') {
     if (!same_origin_post()) {
         my $failure = {ok => JSON::PP::false, error => {code => 'forbidden', message => 'Same-origin POST required'}};
         json_reply($failure, 403) if $q->{ajax};
-        print $cgi->redirect('index.cgi?notice=forbidden');
-        exit;
+        redirect_reply('index.cgi?notice=forbidden');
     }
 
     my $result;
@@ -427,6 +457,7 @@ if ($action ne '') {
             -type => 'application/json',
             -charset => 'utf-8',
             -attachment => 'mcpserver-diagnostic.json',
+            security_header_args(),
         );
         print encode_json($result->{data});
         exit;
@@ -435,8 +466,7 @@ if ($action ne '') {
     my $notice = $result->{ok}
         ? ($action eq 'renew_certificate' ? 'certificate_scheduled' : 'success')
         : 'error';
-    print $cgi->redirect("index.cgi?notice=$notice");
-    exit;
+    redirect_reply("index.cgi?notice=$notice");
 }
 
 use constant MAX_EXPIRY_EPOCH => 4_102_444_799;
@@ -588,6 +618,7 @@ $navbar{45}{URL} = '#certificate';
 $navbar{50}{Name} = $L{'NAV.HELP'};
 $navbar{50}{URL} = '#help';
 
+print_html_security_headers();
 LoxBerry::Web::lbheader($L{'BASIC.TITLE'} . " V$version", '', '', 'nojqm');
 print LoxBerry::Log::get_notifications_html($lbpplugindir);
 print $template->output();


### PR DESCRIPTION
## Summary
- add no-store, CSP, frame, referrer, and MIME protections to Admin UI responses
- cover HTML, JSON, diagnostic downloads, and redirects consistently
- add a regression test for the header contract

## Validation
- Python 3.13 Full profile: 614 passed, 1 known Starlette deprecation warning