### PR TITLE
Harden root lifecycle paths

### DIFF
--- a/bin/root-lifecycle-paths.py
+++ b/bin/root-lifecycle-paths.py
@@ -1,0 +1,202 @@
+#!/usr/bin/python3
+"""Prepare plugin-owned paths without following attacker-controlled links."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import grp
+import os
+import pwd
+import re
+import stat
+from collections.abc import Sequence
+
+DIRECTORY_FLAGS = os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC | os.O_NOFOLLOW
+PLUGIN_FOLDER_PATTERN = re.compile(r"[A-Za-z0-9_-]+\Z")
+
+
+def _open_directory_chain(
+    home: str, parts: Sequence[str]
+) -> tuple[int, list[tuple[str, os.stat_result]]]:
+    fd = os.open(home, DIRECTORY_FLAGS)
+    paths = [(home, os.fstat(fd))]
+    current = home
+    try:
+        for part in parts:
+            next_fd = os.open(part, DIRECTORY_FLAGS, dir_fd=fd)
+            os.close(fd)
+            fd = next_fd
+            current = os.path.join(current, part)
+            paths.append((current, os.fstat(fd)))
+        return fd, paths
+    except BaseException:
+        os.close(fd)
+        raise
+
+
+def _verify_directories(paths: Sequence[tuple[str, os.stat_result]]) -> None:
+    for path, opened in paths:
+        current = os.lstat(path)
+        if not stat.S_ISDIR(current.st_mode) or (current.st_dev, current.st_ino) != (
+            opened.st_dev,
+            opened.st_ino,
+        ):
+            raise RuntimeError("plugin directory path changed during root operation")
+
+
+def _identity() -> tuple[int, int]:
+    return pwd.getpwnam("loxberry").pw_uid, grp.getgrnam("loxberry").gr_gid
+
+
+def _validate_inputs(home: str, folder: str) -> None:
+    if not os.path.isabs(home) or not PLUGIN_FOLDER_PATTERN.fullmatch(folder):
+        raise RuntimeError("invalid lifecycle path input")
+
+
+def prepare_private_directory(
+    home: str,
+    folder: str,
+    name: str,
+    *,
+    owner_uid: int | None = None,
+    owner_gid: int | None = None,
+) -> None:
+    """Create a private directory below data/plugins/<folder>."""
+    _validate_inputs(home, folder)
+    if name != "statistics-cache":
+        raise RuntimeError("unsupported private directory")
+    if owner_uid is None or owner_gid is None:
+        owner_uid, owner_gid = _identity()
+    plugin_fd, plugin_paths = _open_directory_chain(home, ("data", "plugins", folder))
+    child_fd: int | None = None
+    try:
+        with contextlib.suppress(FileExistsError):
+            os.mkdir(name, 0o700, dir_fd=plugin_fd)
+        child_fd = os.open(name, DIRECTORY_FLAGS, dir_fd=plugin_fd)
+        opened = os.fstat(child_fd)
+        if not stat.S_ISDIR(opened.st_mode):
+            raise RuntimeError("private path is not a directory")
+        os.fchown(child_fd, owner_uid, owner_gid)
+        os.fchmod(child_fd, 0o700)
+        child_path = os.path.join(home, "data", "plugins", folder, name)
+        _verify_directories((*plugin_paths, (child_path, opened)))
+    finally:
+        if child_fd is not None:
+            os.close(child_fd)
+        os.close(plugin_fd)
+
+
+def prepare_install_key(
+    home: str,
+    folder: str,
+    *,
+    owner_uid: int | None = None,
+    owner_gid: int | None = None,
+    root_uid: int = 0,
+) -> None:
+    """Create or validate the shared installation key and restore root ownership."""
+    _validate_inputs(home, folder)
+    if owner_uid is None or owner_gid is None:
+        owner_uid, owner_gid = _identity()
+    plugin_fd, plugin_paths = _open_directory_chain(home, ("data", "plugins", folder))
+    auth_fd: int | None = None
+    key_fd: int | None = None
+    created = False
+    try:
+        with contextlib.suppress(FileExistsError):
+            os.mkdir("auth", 0o700, dir_fd=plugin_fd)
+        auth_fd = os.open("auth", DIRECTORY_FLAGS, dir_fd=plugin_fd)
+        auth_opened = os.fstat(auth_fd)
+        os.fchown(auth_fd, owner_uid, owner_gid)
+        os.fchmod(auth_fd, 0o700)
+        try:
+            key_fd = os.open(
+                "install.key",
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC | os.O_NOFOLLOW,
+                0o640,
+                dir_fd=auth_fd,
+            )
+            created = True
+            if os.write(key_fd, os.urandom(32)) != 32:
+                raise RuntimeError("could not write the installation key")
+            os.fsync(key_fd)
+        except FileExistsError:
+            key_fd = os.open(
+                "install.key", os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW, dir_fd=auth_fd
+            )
+            existing = os.fstat(key_fd)
+            if (
+                not stat.S_ISREG(existing.st_mode)
+                or existing.st_nlink != 1
+                or existing.st_uid not in {0, owner_uid}
+                or existing.st_gid != owner_gid
+                or stat.S_IMODE(existing.st_mode) not in {0o600, 0o640}
+                or len(os.read(key_fd, 33)) != 32
+            ):
+                raise RuntimeError("existing installation key is unsafe") from None
+        os.fchown(key_fd, root_uid, owner_gid)
+        os.fchmod(key_fd, 0o640)
+        auth_path = os.path.join(home, "data", "plugins", folder, "auth")
+        _verify_directories((*plugin_paths, (auth_path, auth_opened)))
+    except BaseException:
+        if created and auth_fd is not None:
+            os.unlink("install.key", dir_fd=auth_fd)
+        raise
+    finally:
+        if key_fd is not None:
+            os.close(key_fd)
+        if auth_fd is not None:
+            os.close(auth_fd)
+        os.close(plugin_fd)
+
+
+def prepare_service_log(
+    home: str,
+    folder: str,
+    *,
+    owner_uid: int | None = None,
+    owner_gid: int | None = None,
+) -> None:
+    """Create the service log below log/plugins/<folder> without following links."""
+    _validate_inputs(home, folder)
+    if owner_uid is None or owner_gid is None:
+        owner_uid, owner_gid = _identity()
+    log_fd, log_paths = _open_directory_chain(home, ("log", "plugins", folder))
+    file_fd: int | None = None
+    try:
+        file_fd = os.open(
+            "service.log",
+            os.O_WRONLY | os.O_APPEND | os.O_CREAT | os.O_CLOEXEC | os.O_NOFOLLOW,
+            0o640,
+            dir_fd=log_fd,
+        )
+        opened = os.fstat(file_fd)
+        if not stat.S_ISREG(opened.st_mode) or opened.st_nlink != 1:
+            raise RuntimeError("service log is not a safe regular file")
+        os.fchown(file_fd, owner_uid, owner_gid)
+        os.fchmod(file_fd, 0o640)
+        _verify_directories(log_paths)
+    finally:
+        if file_fd is not None:
+            os.close(file_fd)
+        os.close(log_fd)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("operation", choices=("statistics-cache", "install-key", "service-log"))
+    parser.add_argument("--home", required=True)
+    parser.add_argument("--folder", required=True)
+    args = parser.parse_args()
+    if args.operation == "statistics-cache":
+        prepare_private_directory(args.home, args.folder, "statistics-cache")
+    elif args.operation == "install-key":
+        prepare_install_key(args.home, args.folder)
+    else:
+        prepare_service_log(args.home, args.folder)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -34,7 +34,7 @@ The server loads the user-filtered structure at connection start and refreshes i
 
 ## Persistence and lifecycle
 
-Configuration, encrypted sessions and plugin identity persist outside the package. Secrets are separated from ordinary configuration. Install, upgrade and removal follow the native LoxBerry layout; upgrade preserves supported configuration and authentication state through idempotent migration. The service starts unprivileged, validates configuration and listens only on loopback.
+Configuration, encrypted sessions and plugin identity persist outside the package. Secrets are separated from ordinary configuration. Root lifecycle hooks consume service templates only from the current installer staging area, never from the installed plugin configuration or binary directories. The staging area's integrity remains a LoxBerry Core trust boundary because Core runs unprivileged lifecycle hooks before `postroot`; plugin code cannot make that shared staging area root-owned. Within the persistent LoxBerry tree, sensitive root operations use descriptor-relative traversal and reject symbolic links, non-regular files and path replacement. Install, upgrade and removal follow the native LoxBerry layout; upgrade preserves supported configuration and authentication state through idempotent migration. The service starts unprivileged, validates configuration and listens only on loopback.
 
 ## Security and observability
 

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -7,6 +7,18 @@ if [ -z "$actual_folder" ] || [ -z "$installer_root" ] || [ -z "${LBPBIN:-}" ] |
     echo "<ERROR> LoxBerry did not provide the plugin paths or actual folder."
     exit 2
 fi
+case "$actual_folder" in
+    *[!A-Za-z0-9_-]*|'') echo "<ERROR> Invalid plugin folder."; exit 2 ;;
+esac
+case "$installer_root" in
+    /*) ;;
+    *) echo "<ERROR> Invalid installer root."; exit 2 ;;
+esac
+installer_root=$(realpath -e -- "$installer_root") || { echo "<ERROR> Invalid installer root."; exit 2; }
+if [ ! -d "$installer_root" ]; then
+    echo "<ERROR> Invalid installer root."
+    exit 2
+fi
 
 plugin_bin="$LBPBIN/$actual_folder"
 plugin_config="$LBPCONFIG/$actual_folder"

--- a/postroot.sh
+++ b/postroot.sh
@@ -8,7 +8,8 @@ sudoers=/etc/sudoers.d/loxberry-mcpserver
 certificate_helper=/usr/local/sbin/loxberry-mcpserver-renew-web-certificate
 
 actual_folder=$3
-if [ -z "$actual_folder" ] || [ -z "${LBHOMEDIR:-}" ] || [ -z "${LBPBIN:-}" ] || [ -z "${LBPCONFIG:-}" ] || [ -z "${LBPDATA:-}" ] || [ -z "${LBPLOG:-}" ]; then
+installer_root=${6:-}
+if [ -z "$actual_folder" ] || [ -z "$installer_root" ] || [ -z "${LBHOMEDIR:-}" ] || [ -z "${LBPCONFIG:-}" ] || [ -z "${LBPDATA:-}" ] || [ -z "${LBPLOG:-}" ]; then
     echo "<ERROR> LoxBerry plugin paths are unavailable."
     exit 2
 fi
@@ -27,44 +28,26 @@ if [ ! -d "$loxberry_home/libs/perllib" ]; then
     echo "<ERROR> LoxBerry Perl libraries are unavailable."
     exit 2
 fi
+case "$actual_folder" in
+    *[!A-Za-z0-9_-]*|'') echo "<ERROR> Invalid plugin folder."; exit 2 ;;
+esac
+case "$installer_root" in
+    /*) ;;
+    *) echo "<ERROR> Invalid installer root."; exit 2 ;;
+esac
+installer_root=$(realpath -e -- "$installer_root") || { echo "<ERROR> Invalid installer root."; exit 2; }
+if [ ! -d "$installer_root" ] || [ ! -f "$installer_root/config/systemd/loxberry-mcpserver.service.in" ] \
+    || [ ! -f "$installer_root/config/apache/mcpserver.conf" ] \
+    || [ ! -f "$installer_root/bin/renew-web-certificate" ] \
+    || [ ! -f "$installer_root/bin/root-lifecycle-paths.py" ]; then
+    echo "<ERROR> Required package templates are unavailable."
+    exit 2
+fi
 plugin_config="$LBPCONFIG/$actual_folder"
 plugin_data="$LBPDATA/$actual_folder"
 plugin_log="$LBPLOG/$actual_folder"
 service_log="$plugin_log/service.log"
-
-prepare_private_directory() {
-    python3 - "$1" <<'PY'
-import grp
-import os
-import pwd
-import stat
-import sys
-
-path = sys.argv[1]
-parent, name = os.path.split(path)
-parent_fd = os.open(parent, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC)
-try:
-    try:
-        os.mkdir(name, 0o700, dir_fd=parent_fd)
-    except FileExistsError:
-        pass
-    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC | os.O_NOFOLLOW
-    fd = os.open(name, flags, dir_fd=parent_fd)
-    try:
-        opened = os.fstat(fd)
-        if not stat.S_ISDIR(opened.st_mode):
-            raise RuntimeError("private path is not a directory")
-        os.fchown(fd, pwd.getpwnam("loxberry").pw_uid, grp.getgrnam("loxberry").gr_gid)
-        os.fchmod(fd, 0o700)
-        current = os.lstat(path)
-        if not stat.S_ISDIR(current.st_mode) or (current.st_dev, current.st_ino) != (opened.st_dev, opened.st_ino):
-            raise RuntimeError("private directory path changed during preparation")
-    finally:
-        os.close(fd)
-finally:
-    os.close(parent_fd)
-PY
-}
+root_path_helper="$installer_root/bin/root-lifecycle-paths.py"
 
 for target in "$unit" "$apache" "$sudoers" "$certificate_helper"; do
     if [ -e "$target" ] && ! grep -Fqx "$marker" "$target"; then
@@ -72,10 +55,6 @@ for target in "$unit" "$apache" "$sudoers" "$certificate_helper"; do
         exit 2
     fi
 done
-
-case "$actual_folder" in
-    *[!A-Za-z0-9_-]*|'') echo "<ERROR> Invalid plugin folder."; exit 2 ;;
-esac
 
 if ss -H -ltn 'sport = :8765' | grep -q . && ! systemctl is-active --quiet loxberry-mcpserver.service; then
     echo "<ERROR> TCP port 8765 is already owned by another service."
@@ -87,13 +66,8 @@ if grep -RIl --exclude='loxberry-mcpserver.conf' '/plugins/mcpserver/mcp' /etc/a
 fi
 
 key="$plugin_data/auth/install.key"
-mkdir -p "$plugin_data/auth"
-prepare_private_directory "$plugin_data/statistics-cache" || exit 2
-if [ ! -f "$key" ]; then
-    (umask 0137 && openssl rand 32 > "$key") || exit 2
-fi
-chown root:loxberry "$key"
-chmod 640 "$key"
+python3 "$root_path_helper" statistics-cache --home "$loxberry_home" --folder "$actual_folder" || exit 2
+python3 "$root_path_helper" install-key --home "$loxberry_home" --folder "$actual_folder" || exit 2
 
 host=$(hostname -f 2>/dev/null || hostname)
 case "$host" in
@@ -121,14 +95,14 @@ sed \
     -e "s|@CONFIG_DIR@|$plugin_config|g" \
     -e "s|@DATA_DIR@|$plugin_data|g" \
     -e "s|@LOG_DIR@|$plugin_log|g" \
-    "$plugin_config/systemd/loxberry-mcpserver.service.in" > "$unit" || exit 2
+    "$installer_root/config/systemd/loxberry-mcpserver.service.in" > "$unit" || exit 2
 
-cp "$plugin_config/apache/mcpserver.conf" "$apache" || exit 2
+cp "$installer_root/config/apache/mcpserver.conf" "$apache" || exit 2
 chown root:root "$unit" "$apache"
 chmod 644 "$unit" "$apache"
 certificate_helper_tmp=$(mktemp "${certificate_helper}.tmp.XXXXXX") || exit 2
 if ! sed "s|@LBHOMEDIR@|$loxberry_home|g" \
-    "$LBPBIN/$actual_folder/renew-web-certificate" > "$certificate_helper_tmp" \
+    "$installer_root/bin/renew-web-certificate" > "$certificate_helper_tmp" \
     || ! chown root:root "$certificate_helper_tmp" \
     || ! chmod 755 "$certificate_helper_tmp" \
     || ! mv -f "$certificate_helper_tmp" "$certificate_helper"; then
@@ -153,28 +127,7 @@ apache2ctl configtest >/dev/null || { a2disconf loxberry-mcpserver >/dev/null; e
 if systemctl is-active --quiet loxberry-mcpserver.service; then
     systemctl stop loxberry-mcpserver.service || exit 2
 fi
-python3 - "$service_log" <<'PY' || exit 2
-import grp
-import os
-import pwd
-import stat
-import sys
-
-path = sys.argv[1]
-flags = os.O_WRONLY | os.O_APPEND | os.O_CREAT | os.O_CLOEXEC | os.O_NOFOLLOW
-fd = os.open(path, flags, 0o640)
-try:
-    opened = os.fstat(fd)
-    if not stat.S_ISREG(opened.st_mode):
-        raise RuntimeError("service log is not a regular file")
-    os.fchown(fd, pwd.getpwnam("loxberry").pw_uid, grp.getgrnam("loxberry").gr_gid)
-    os.fchmod(fd, 0o640)
-    current = os.lstat(path)
-    if not stat.S_ISREG(current.st_mode) or (current.st_dev, current.st_ino) != (opened.st_dev, opened.st_ino):
-        raise RuntimeError("service log path changed during preparation")
-finally:
-    os.close(fd)
-PY
+python3 "$root_path_helper" service-log --home "$loxberry_home" --folder "$actual_folder" || exit 2
 
 systemctl daemon-reload
 systemctl enable loxberry-mcpserver.service >/dev/null

--- a/postupgrade.sh
+++ b/postupgrade.sh
@@ -6,6 +6,9 @@ if [ -z "$actual_folder" ] || [ -z "${LBPCONFIG:-}" ] || [ -z "${LBPDATA:-}" ]; 
     echo "<ERROR> LoxBerry plugin paths are unavailable."
     exit 2
 fi
+case "$actual_folder" in
+    *[!A-Za-z0-9_-]*|'') echo "<ERROR> Invalid plugin folder."; exit 2 ;;
+esac
 
 # Schema migrations are idempotent and never replace an existing session store.
 plugin_config="$LBPCONFIG/$actual_folder"

--- a/preupgrade.sh
+++ b/preupgrade.sh
@@ -7,6 +7,18 @@ if [ -z "$actual_folder" ] || [ -z "$installer_root" ] || [ -z "${LBPCONFIG:-}" 
     echo "<ERROR> LoxBerry plugin paths are unavailable."
     exit 2
 fi
+case "$actual_folder" in
+    *[!A-Za-z0-9_-]*|'') echo "<ERROR> Invalid plugin folder."; exit 2 ;;
+esac
+case "$installer_root" in
+    /*) ;;
+    *) echo "<ERROR> Invalid installer root."; exit 2 ;;
+esac
+installer_root=$(realpath -e -- "$installer_root") || { echo "<ERROR> Invalid installer root."; exit 2; }
+if [ ! -d "$installer_root" ]; then
+    echo "<ERROR> Invalid installer root."
+    exit 2
+fi
 
 if systemctl is-active --quiet loxberry-mcpserver.service; then
     if ! sudo -n /bin/systemctl stop loxberry-mcpserver.service; then

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -206,6 +206,7 @@ def test_v4_package_manifest_is_present() -> None:
         "uninstall/uninstall.sh",
         "bin/healthcheck",
         "bin/renew-web-certificate",
+        "bin/root-lifecycle-paths.py",
         "icons/icon.svg",
         "webfrontend/htmlauth/index.cgi",
         "webfrontend/htmlauth/explorer.cgi",
@@ -276,6 +277,14 @@ def test_postupgrade_removes_legacy_per_request_admin_logs() -> None:
     assert "-name '*_admin-ui.log' -delete" in postupgrade
 
 
+def test_lifecycle_hooks_reject_an_unsafe_plugin_folder() -> None:
+    for name in ("postinstall.sh", "preupgrade.sh", "postroot.sh", "postupgrade.sh"):
+        hook = (ROOT / name).read_text(encoding="utf-8")
+
+        assert 'case "$actual_folder" in' in hook
+        assert "*[!A-Za-z0-9_-]*|'')" in hook
+
+
 def test_shell_hooks_have_valid_syntax() -> None:
     bash = shutil.which("bash")
     if bash is None:
@@ -305,15 +314,16 @@ def test_upgrade_removes_the_obsolete_debug_window_atomically() -> None:
 def test_phase_four_upgrade_migrates_configuration_and_private_cache() -> None:
     hook = (ROOT / "postupgrade.sh").read_text(encoding="utf-8")
     postroot = (ROOT / "postroot.sh").read_text(encoding="utf-8")
+    helper = (ROOT / "bin/root-lifecycle-paths.py").read_text(encoding="utf-8")
 
     assert 'document.get("schema_version") == 1' in hook
     assert 'document["schema_version"] = 2' in hook
-    for script in (hook, postroot):
-        assert 'prepare_private_directory "$plugin_data/statistics-cache" || exit 2' in script
-        assert "os.O_NOFOLLOW" in script
-        assert "os.fchown(fd" in script
-        assert "os.fchmod(fd, 0o700)" in script
-        assert "os.lstat(path)" in script
+    assert 'prepare_private_directory "$plugin_data/statistics-cache" || exit 2' in hook
+    assert 'python3 "$root_path_helper" statistics-cache' in postroot
+    assert "os.O_NOFOLLOW" in helper
+    assert "os.fchown(child_fd" in helper
+    assert "os.fchmod(child_fd, 0o700)" in helper
+    assert "os.lstat(path)" in helper
 
 
 def test_postroot_keeps_installer_alive_during_apache_activation() -> None:
@@ -328,7 +338,14 @@ def test_postroot_keeps_installer_alive_during_apache_activation() -> None:
     assert "for _ in {1..30}" in hook
     assert "curl --fail --silent --max-time 2 http://127.0.0.1:8765/healthz" in hook
     assert 'if [ "$service_ready" -ne 1 ]' in hook
-    assert '(umask 0137 && openssl rand 32 > "$key")' in hook
+    assert "installer_root=${6:-}" in hook
+    assert 'installer_root=$(realpath -e -- "$installer_root")' in hook
+    assert '"$installer_root/config/systemd/loxberry-mcpserver.service.in" > "$unit"' in hook
+    assert 'cp "$installer_root/config/apache/mcpserver.conf" "$apache"' in hook
+    assert '"$installer_root/bin/renew-web-certificate" > "$certificate_helper_tmp"' in hook
+    assert '"$plugin_config/systemd/loxberry-mcpserver.service.in"' not in hook
+    assert '"$plugin_config/apache/mcpserver.conf"' not in hook
+    assert '"$LBPBIN/$actual_folder/renew-web-certificate"' not in hook
     assert 'chmod 644 "$unit" "$apache"' in hook
     assert 'loxberry_home=$(realpath -e -- "$LBHOMEDIR")' in hook
     assert 'sed "s|@LBHOMEDIR@|$loxberry_home|g"' in hook
@@ -344,13 +361,13 @@ def test_postroot_keeps_installer_alive_during_apache_activation() -> None:
     assert "NOPASSWD: /bin/systemctl stop *" not in hook
     assert 'service_log="$plugin_log/service.log"' in hook
     assert "systemctl stop loxberry-mcpserver.service || exit 2" in hook
-    assert hook.index("systemctl stop loxberry-mcpserver.service || exit 2") < hook.index(
-        'python3 - "$service_log"'
+    assert hook.index("systemctl stop loxberry-mcpserver.service || exit 2") < hook.rindex(
+        'python3 "$root_path_helper" service-log'
     )
-    assert "os.O_NOFOLLOW" in hook
-    assert "os.fchown(fd" in hook
-    assert "os.fchmod(fd, 0o640)" in hook
-    assert "os.lstat(path)" in hook
+    assert 'root_path_helper="$installer_root/bin/root-lifecycle-paths.py"' in hook
+    assert 'python3 "$root_path_helper" install-key' in hook
+    assert 'python3 "$root_path_helper" service-log' in hook
+    assert "openssl rand 32" not in hook
     assert 'chown loxberry:loxberry "$service_log"' not in hook
     assert 'chmod 640 "$service_log"' not in hook
     assert "LoxBerry::System::get_localip()" in hook

--- a/tests/test_root_lifecycle_paths.py
+++ b/tests/test_root_lifecycle_paths.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import os
+import runpy
+import stat
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.skipif(os.name != "posix", reason="requires POSIX dir_fd semantics")
+
+
+def _helpers() -> dict[str, Any]:
+    return runpy.run_path(
+        str(ROOT / "bin" / "root-lifecycle-paths.py"), run_name="root_lifecycle_paths"
+    )
+
+
+def _plugin_tree(tmp_path: Path) -> tuple[Path, Path, Path]:
+    home = tmp_path / "loxberry"
+    data = home / "data" / "plugins" / "mcpserver"
+    log = home / "log" / "plugins" / "mcpserver"
+    data.mkdir(parents=True)
+    log.mkdir(parents=True)
+    return home, data, log
+
+
+def _call(helper: Callable[..., None], home: Path, *args: str) -> None:
+    helper(
+        str(home),
+        "mcpserver",
+        *args,
+        owner_uid=os.getuid(),
+        owner_gid=os.getgid(),
+        **({"root_uid": os.getuid()} if helper.__name__ == "prepare_install_key" else {}),
+    )
+
+
+def test_lifecycle_helper_preserves_upgrade_key_and_sets_modes(tmp_path: Path) -> None:
+    helpers = _helpers()
+    home, data, log = _plugin_tree(tmp_path)
+    auth = data / "auth"
+    auth.mkdir()
+    key = auth / "install.key"
+    original = os.urandom(32)
+    key.write_bytes(original)
+    key.chmod(0o600)
+
+    _call(helpers["prepare_private_directory"], home, "statistics-cache")
+    _call(helpers["prepare_install_key"], home)
+    _call(helpers["prepare_service_log"], home)
+
+    assert key.read_bytes() == original
+    assert stat.S_IMODE(key.stat().st_mode) == 0o640
+    assert stat.S_IMODE((data / "statistics-cache").stat().st_mode) == 0o700
+    assert stat.S_IMODE((log / "service.log").stat().st_mode) == 0o640
+
+
+@pytest.mark.parametrize("target_name", ["statistics-cache", "auth"])
+def test_lifecycle_helper_rejects_symlinked_private_paths(tmp_path: Path, target_name: str) -> None:
+    helpers = _helpers()
+    home, data, _ = _plugin_tree(tmp_path)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (data / target_name).symlink_to(outside, target_is_directory=True)
+
+    helper = (
+        helpers["prepare_private_directory"]
+        if target_name == "statistics-cache"
+        else helpers["prepare_install_key"]
+    )
+    args = ("statistics-cache",) if target_name == "statistics-cache" else ()
+    with pytest.raises(OSError):
+        _call(helper, home, *args)
+
+    assert list(outside.iterdir()) == []
+
+
+def test_lifecycle_helper_rejects_symlinked_key(tmp_path: Path) -> None:
+    helpers = _helpers()
+    home, data, _ = _plugin_tree(tmp_path)
+    auth = data / "auth"
+    auth.mkdir()
+    outside = tmp_path / "outside-key"
+    outside.write_bytes(os.urandom(32))
+    (auth / "install.key").symlink_to(outside)
+
+    with pytest.raises(OSError):
+        _call(helpers["prepare_install_key"], home)
+
+    assert outside.stat().st_nlink == 1
+
+
+def test_lifecycle_helper_rejects_non_regular_service_log(tmp_path: Path) -> None:
+    helpers = _helpers()
+    home, _, log = _plugin_tree(tmp_path)
+    (log / "service.log").mkdir()
+
+    with pytest.raises(OSError):
+        _call(helpers["prepare_service_log"], home)
+
+
+def test_lifecycle_helper_rejects_symlinked_plugin_prefix(tmp_path: Path) -> None:
+    helpers = _helpers()
+    home, data, _ = _plugin_tree(tmp_path)
+    outside = tmp_path / "outside-plugin"
+    outside.mkdir()
+    data.rmdir()
+    data.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(OSError):
+        _call(helpers["prepare_private_directory"], home, "statistics-cache")
+
+    assert list(outside.iterdir()) == []

--- a/tools/build_plugin.py
+++ b/tools/build_plugin.py
@@ -40,6 +40,7 @@ _EXECUTABLES: Final = {
     "bin/healthcheck",
     "bin/mcpserver-admin",
     "bin/renew-web-certificate",
+    "bin/root-lifecycle-paths.py",
     "webfrontend/htmlauth/index.cgi",
     "webfrontend/htmlauth/explorer.cgi",
     "webfrontend/htmlauth/explorer_callback.cgi",
@@ -64,6 +65,7 @@ _TEXT_NAMES: Final = {
     "bin/healthcheck",
     "bin/mcpserver-admin",
     "bin/renew-web-certificate",
+    "bin/root-lifecycle-paths.py",
 }
 
 
@@ -93,6 +95,7 @@ def expected_source_entries(root: Path) -> set[str]:
             "bin/healthcheck",
             "bin/mcpserver-admin",
             "bin/renew-web-certificate",
+            "bin/root-lifecycle-paths.py",
             "bin/runtime-arm64.lock",
             "bin/runtime-arm64.sha256",
             REFERENCE_HTML_PATH,
@@ -287,6 +290,7 @@ def main() -> int:
             (root / "bin" / "healthcheck", "bin/healthcheck"),
             (root / "bin" / "mcpserver-admin", "bin/mcpserver-admin"),
             (root / "bin" / "renew-web-certificate", "bin/renew-web-certificate"),
+            (root / "bin" / "root-lifecycle-paths.py", "bin/root-lifecycle-paths.py"),
             (lock, "bin/runtime-arm64.lock"),
             (hash_lock, "bin/runtime-arm64.sha256"),
         ]

--- a/tools/test.py
+++ b/tools/test.py
@@ -99,6 +99,10 @@ _TEST_GROUPS: Final = (
         ("tests/test_admin.py", "tests/test_certificates.py"),
     ),
     (
+        ("bin/root-lifecycle-paths.py", "postroot.sh"),
+        ("tests/test_plugin_package.py", "tests/test_root_lifecycle_paths.py"),
+    ),
+    (
         ("src/mcpserver/auth/**",),
         (
             "tests/test_auth_store.py",

--- a/tools/verify_plugin.py
+++ b/tools/verify_plugin.py
@@ -41,6 +41,7 @@ _REQUIRED: Final = {
     "bin/healthcheck",
     "bin/mcpserver-admin",
     "bin/renew-web-certificate",
+    "bin/root-lifecycle-paths.py",
     "bin/runtime-arm64.lock",
     "config/default-config.json",
     "config/apache/mcpserver.conf",
@@ -65,6 +66,7 @@ _EXECUTABLES: Final = {
     "bin/healthcheck",
     "bin/mcpserver-admin",
     "bin/renew-web-certificate",
+    "bin/root-lifecycle-paths.py",
     "webfrontend/htmlauth/index.cgi",
     "webfrontend/htmlauth/explorer.cgi",
     "webfrontend/htmlauth/explorer_callback.cgi",
@@ -82,7 +84,12 @@ _TEXT_SUFFIXES: Final = {
     ".sh",
     ".svg",
 }
-_TEXT_NAMES: Final = {"bin/healthcheck", "bin/mcpserver-admin", "bin/renew-web-certificate"}
+_TEXT_NAMES: Final = {
+    "bin/healthcheck",
+    "bin/mcpserver-admin",
+    "bin/renew-web-certificate",
+    "bin/root-lifecycle-paths.py",
+}
 _REQUIRED_PROJECT_WHEEL_ENTRIES: Final = {
     "mcpserver/skills/using-loxberry-mcp/SKILL.md",
     "mcpserver/skills/using-loxberry-mcp/agents/openai.yaml",


### PR DESCRIPTION
## What changed

- validate lifecycle folder and staging inputs consistently
- move root-owned key, statistics-cache, and service-log preparation into a descriptor-relative helper that rejects symlinks, path replacement, non-regular files, and hard links
- accept the legitimate LoxBerry upgrade key state (`loxberry:loxberry 0600`), preserve its 32-byte value, and normalize it to `root:loxberry 0640`
- package and verify the helper, add POSIX behavioral regression tests, and document the remaining LoxBerry Core staging trust boundary

## Root cause

During an upgrade, LoxBerry Core recursively assigns the plugin data tree to `loxberry`, while `preupgrade`/`postinstall` restore `install.key` as `loxberry:loxberry 0600`. The initial hardening accepted only a root-owned key and therefore caused `postroot` to return exit code 2 even though the earlier hooks succeeded.

## Validation

- Python 3.13 full gate: 615 passed, 6 POSIX-only tests skipped on Windows, 1 existing warning
- independent security subagent re-review: no remaining repo-level High/Medium finding
- verified local plugin ZIP: SHA-256 `467dd79c81b6cb1226f8edc05806df0332c2efdf58a7e70fd212012a04b09f42`
- native LoxBerry-Test upgrade: `INSTALL_STATUS=0`, 72.1 seconds, health passed
- target metadata: key `root:loxberry 0640`, statistics cache `loxberry:loxberry 0700`, service log `loxberry:loxberry 0640`

The remaining writable installer-staging boundary is a LoxBerry Core issue and is explicitly not claimed as fixed by this plugin.