### PR TITLE
Fix MQTT service transition reporting

### DIFF
--- a/src/mcpserver/admin.py
+++ b/src/mcpserver/admin.py
@@ -25,8 +25,10 @@ from mcpserver import __version__
 if TYPE_CHECKING:
     from mcpserver.auth.loxone_store import EncryptedLoxoneTokenStore
     from mcpserver.auth.store import AtomicJsonAuthStore
-    from mcpserver.config import AtomicConfigStore, PluginConfig
     from mcpserver.loxone.client import LoxoneClient, MiniserverEndpoint
+
+from mcpserver.config import AtomicConfigStore, PluginConfig
+from mcpserver.mqtt_health import clear_service_restart, request_service_restart
 
 _MAX_REQUEST_BYTES: Final = 32 * 1024
 _SERVICE: Final = "loxberry-mcpserver.service"
@@ -220,7 +222,17 @@ def _service_action(payload: object) -> dict[str, Any]:
     command = payload.get("command") if isinstance(payload, dict) else None
     if not isinstance(command, str) or command not in _SERVICE_ACTIONS:
         raise AdminError("service action is invalid")
-    _run_service_command(command)
+    if command == "restart":
+        # The service owns the MQTT connection.  Its graceful shutdown consumes
+        # this process-local marker and publishes retained ``restarting`` before
+        # systemd launches the replacement process.
+        request_service_restart()
+    try:
+        _run_service_command(command)
+    except AdminError:
+        if command == "restart":
+            clear_service_restart()
+        raise
     return _service_response()
 
 

--- a/src/mcpserver/admin.py
+++ b/src/mcpserver/admin.py
@@ -229,7 +229,11 @@ def _set_service_enabled(payload: object) -> dict[str, Any]:
     if not isinstance(enabled, bool):
         raise AdminError("service enabled state is invalid")
     previous = _service_status()
-    commands = ("enable", "start") if enabled else ("stop", "disable")
+    # This handler runs inside the service it controls.  Disabling first keeps
+    # the process alive long enough to persist the unit-file state and return
+    # an authoritative response to the Admin UI; stopping first can terminate
+    # the handler before it reaches ``disable``.
+    commands = ("enable", "start") if enabled else ("disable", "stop")
     try:
         for command in commands:
             _run_service_command(command)

--- a/src/mcpserver/mqtt_health.py
+++ b/src/mcpserver/mqtt_health.py
@@ -25,6 +25,27 @@ from mcpserver.config import PluginConfig
 LOXONE_EPOCH_OFFSET: Final = 1_230_768_000
 _LOGGER = logging.getLogger("mcpserver.mqtt_health")
 _CREDENTIALS_AAD: Final = b"mcpserver:mqtt-credentials:v1"
+_SERVICE_RESTART_REQUESTED = False
+
+
+def request_service_restart() -> None:
+    """Mark an Admin-initiated restart for the controlled shutdown publisher."""
+    global _SERVICE_RESTART_REQUESTED
+    _SERVICE_RESTART_REQUESTED = True
+
+
+def clear_service_restart() -> None:
+    """Clear a restart marker when systemd could not accept the request."""
+    global _SERVICE_RESTART_REQUESTED
+    _SERVICE_RESTART_REQUESTED = False
+
+
+def consume_service_restart() -> bool:
+    """Return and clear the process-local intentional restart marker."""
+    global _SERVICE_RESTART_REQUESTED
+    requested = _SERVICE_RESTART_REQUESTED
+    _SERVICE_RESTART_REQUESTED = False
+    return requested
 
 
 class MqttCredentialStoreError(RuntimeError):
@@ -358,19 +379,29 @@ class MqttHealthPublisher:
         self._close_clients()
 
     async def _publish_shutdown_state(self) -> None:
-        """Replace the Last-Will fallback before a controlled service stop."""
+        """Replace the Last-Will fallback before a controlled stop or restart."""
         if not self._clients:
             return
         topics = self.topics
+        restarting = consume_service_restart()
+        system_state = "restarting" if restarting else "inactive"
+        substate = "restarting" if restarting else "dead"
         publications: list[Any] = []
         try:
             if 0 in self._connected_clients:
                 publications.append(
-                    self._clients[0].publish(topics["system_state"], "inactive", qos=1, retain=True)
+                    self._clients[0].publish(
+                        topics["heartbeat"], str(loxone_epoch_seconds()), qos=1, retain=True
+                    )
+                )
+                publications.append(
+                    self._clients[0].publish(
+                        topics["system_state"], system_state, qos=1, retain=True
+                    )
                 )
             if 1 in self._connected_clients:
                 publications.append(
-                    self._clients[1].publish(topics["substate"], "dead", qos=1, retain=True)
+                    self._clients[1].publish(topics["substate"], substate, qos=1, retain=True)
                 )
             await asyncio.gather(
                 *(self._wait_for_publish(publication) for publication in publications)

--- a/src/mcpserver/mqtt_health.py
+++ b/src/mcpserver/mqtt_health.py
@@ -294,9 +294,31 @@ class MqttHealthPublisher:
         return clients
 
     def _on_connect(self, index: int) -> None:
-        """Publish each retained value only after its broker connection is ready."""
+        """Replace Last-Will values as soon as each broker connection is ready."""
         self._connected_clients.add(index)
-        self.publish()
+        self._publish_startup_state()
+
+    def _publish_startup_state(self) -> None:
+        """Publish the service's own ready state without a systemd start race.
+
+        systemd marks this Type=simple unit active when its process has started,
+        while querying it during the first MQTT callback can still expose the
+        previous retained state.  The publisher itself is only started by that
+        process, so ``active/running`` is the accurate immediate replacement
+        for the Last-Will fallback.  Later heartbeats continue to use systemd
+        for the current state.
+        """
+        topics = self.topics
+        try:
+            if 0 in self._connected_clients:
+                self._clients[0].publish(
+                    topics["heartbeat"], str(loxone_epoch_seconds()), qos=1, retain=True
+                )
+                self._clients[0].publish(topics["system_state"], "active", qos=1, retain=True)
+            if 1 in self._connected_clients:
+                self._clients[1].publish(topics["substate"], "running", qos=1, retain=True)
+        except Exception:
+            _LOGGER.warning("event=mqtt_startup_publish_failed")
 
     async def _publish_loop(self) -> None:
         retry_seconds = 1

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1042,7 +1042,7 @@ def test_concurrent_mqtt_saves_keep_broker_and_password_paired(
 
 @pytest.mark.parametrize(
     ("enabled", "commands"),
-    [(True, ["enable", "start"]), (False, ["stop", "disable"])],
+    [(True, ["enable", "start"]), (False, ["disable", "stop"])],
 )
 def test_master_service_state_uses_only_fixed_systemd_operations(
     enabled: bool, commands: list[str], monkeypatch: pytest.MonkeyPatch

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -667,6 +667,7 @@ def test_service_action_uses_only_the_fixed_unit(
 
     monkeypatch.setattr("mcpserver.admin.subprocess.run", run)
     monkeypatch.setattr("mcpserver.admin._service_status", lambda: service)
+    monkeypatch.setattr("mcpserver.admin.request_service_restart", lambda: None)
 
     result = dispatch({"action": "service_action", "payload": {"command": command}})
 

--- a/tests/test_mqtt_health.py
+++ b/tests/test_mqtt_health.py
@@ -11,6 +11,7 @@ from mcpserver.mqtt_health import (
     MqttGateway,
     MqttHealthPublisher,
     loxone_epoch_seconds,
+    request_service_restart,
 )
 
 
@@ -235,6 +236,51 @@ def test_health_replaces_last_will_immediately_with_the_service_ready_state(tmp_
         "publish",
         "mcpserver/health/substate",
         "running",
+        {"qos": 1, "retain": True},
+    ) in clients[1].calls
+
+
+def test_health_publishes_restarting_for_an_admin_initiated_restart(tmp_path: Path) -> None:
+    path = tmp_path / "config" / "system"
+    path.mkdir(parents=True)
+    (path / "general.json").write_text(
+        json.dumps(
+            {
+                "Mqtt": {
+                    "Brokerhost": "broker",
+                    "Brokerport": 1883,
+                    "Brokeruser": "user",
+                    "Brokerpass": "secret",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    clients: list[_Client] = []
+    publisher = MqttHealthPublisher(
+        PluginConfig(mqtt_enabled=True),
+        home=tmp_path,
+        client_factory=lambda **kwargs: clients.append(_Client(**kwargs)) or clients[-1],
+    )
+
+    async def exercise() -> None:
+        await publisher.start()
+        clients[0].on_connect(clients[0])
+        clients[1].on_connect(clients[1])
+        request_service_restart()
+        await publisher.close()
+
+    asyncio.run(exercise())
+    assert (
+        "publish",
+        "mcpserver/health/system_state",
+        "restarting",
+        {"qos": 1, "retain": True},
+    ) in clients[0].calls
+    assert (
+        "publish",
+        "mcpserver/health/substate",
+        "restarting",
         {"qos": 1, "retain": True},
     ) in clients[1].calls
 

--- a/tests/test_mqtt_health.py
+++ b/tests/test_mqtt_health.py
@@ -194,6 +194,51 @@ def test_health_waits_for_each_broker_connection_before_publishing(tmp_path: Pat
     asyncio.run(exercise())
 
 
+def test_health_replaces_last_will_immediately_with_the_service_ready_state(tmp_path: Path) -> None:
+    path = tmp_path / "config" / "system"
+    path.mkdir(parents=True)
+    (path / "general.json").write_text(
+        json.dumps(
+            {
+                "Mqtt": {
+                    "Brokerhost": "broker",
+                    "Brokerport": 1883,
+                    "Brokeruser": "user",
+                    "Brokerpass": "secret",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    clients: list[_Client] = []
+    publisher = MqttHealthPublisher(
+        PluginConfig(mqtt_enabled=True),
+        home=tmp_path,
+        client_factory=lambda **kwargs: clients.append(_Client(**kwargs)) or clients[-1],
+        state_reader=lambda: ("unknown", "unknown"),
+    )
+
+    async def exercise() -> None:
+        await publisher.start()
+        clients[0].on_connect(clients[0])
+        clients[1].on_connect(clients[1])
+        await publisher.close()
+
+    asyncio.run(exercise())
+    assert (
+        "publish",
+        "mcpserver/health/system_state",
+        "active",
+        {"qos": 1, "retain": True},
+    ) in clients[0].calls
+    assert (
+        "publish",
+        "mcpserver/health/substate",
+        "running",
+        {"qos": 1, "retain": True},
+    ) in clients[1].calls
+
+
 def test_missing_gateway_schedules_a_bounded_retry(tmp_path: Path) -> None:
     publisher = MqttHealthPublisher(
         PluginConfig(mqtt_enabled=True),


### PR DESCRIPTION
Publishes retained, intentional MQTT states for service transitions.\n\n- Disables before stopping so the master switch completes reliably.\n- Publishes active/running immediately after service start.\n- Publishes restarting during an Admin-initiated restart, and inactive/dead for controlled stops.\n- Keeps unknown exclusively for unplanned connection or process loss.