### PR TITLE
Refresh MCP plugin icon

### DIFF
--- a/icons/icon.svg
+++ b/icons/icon.svg
@@ -1,8 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title">
   <title id="title">LoxBerry MCP Server</title>
-  <rect width="128" height="128" rx="24" fill="#2f7d32"/>
-  <path d="M37 30v19H25v30h12v19h18V79h18v19h18V79h12V49H91V30H73v19H55V30H37zm6 31h42v6H43v-6z" fill="#fff"/>
-  <circle cx="43" cy="64" r="4" fill="#2f7d32"/>
-  <circle cx="85" cy="64" r="4" fill="#2f7d32"/>
+  <defs>
+    <linearGradient id="background" x1="18" y1="12" x2="112" y2="118" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#125f4e"/>
+      <stop offset="1" stop-color="#07342d"/>
+    </linearGradient>
+    <linearGradient id="lettering" x1="31" y1="42" x2="98" y2="86" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#ffffff"/>
+      <stop offset="1" stop-color="#d9ffe9"/>
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="28" fill="url(#background)"/>
+  <g fill="none" opacity=".33" stroke="#a7f7bf" stroke-linecap="round" stroke-width="2">
+    <path d="M18 31 41 19l21 15 28-16 20 18M18 31l10 30 28 14 27-12 27 17M28 61l-10 34 29 15 22-20 33 8 8-18"/>
+    <path d="m41 19-13 42m34-27-6 41m34-57-7 45m19-27-19 27m-27 12 13 15m-41 5 19-19"/>
+  </g>
+  <g fill="#a7f7bf" opacity=".68">
+    <circle cx="18" cy="31" r="3"/><circle cx="41" cy="19" r="3"/><circle cx="62" cy="34" r="3"/><circle cx="90" cy="18" r="3"/><circle cx="110" cy="36" r="3"/>
+    <circle cx="28" cy="61" r="3"/><circle cx="56" cy="75" r="3"/><circle cx="83" cy="63" r="3"/><circle cx="110" cy="80" r="3"/>
+    <circle cx="18" cy="95" r="3"/><circle cx="47" cy="110" r="3"/><circle cx="69" cy="90" r="3"/><circle cx="102" cy="98" r="3"/>
+  </g>
+  <rect x="19" y="40" width="90" height="49" rx="15" fill="#07342d" opacity=".35"/>
+  <text x="64" y="76" fill="url(#lettering)" font-family="Arial, Helvetica, sans-serif" font-size="40" font-weight="800" letter-spacing="-2" text-anchor="middle">MCP</text>
 </svg>


### PR DESCRIPTION
## Summary
- replace the legacy plugin icon with a modern MCP wordmark
- keep connected nodes exclusively in the background

## Validation
- no local test run requested
- SVG XML and diff whitespace were checked during design